### PR TITLE
refactor: rename 'completed' field to 'passes' in task schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-02-15
+
+### Changed
+
+- **BREAKING:** Rename `completed` field to `passes` in tasks.json schema
+  - Better reflects acceptance criteria validation semantics (pass/fail)
+  - Aligns with testing vocabulary
+  - Updated all commands: deepen, execute, next, status
+  - Updated all skills: plan-to-tasks, story-executor
+  - Existing tasks.json files need field renamed from `completed` to `passes`
+
 ## [0.2.1] - 2026-02-15
 
 ### Added
@@ -29,7 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Rename `passes` field to `completed` in tasks.json schema for clarity
+- **BREAKING:** Introduced `completed` field in tasks.json schema (now renamed to `passes` in v0.3.0)
 - Inline story data in Task prompts (reduces file I/O by ~33%)
 - Extract only Codebase Patterns from progress.md (reduces context usage)
 - Add structured error format with type classification for programmatic handling

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ docs/tasks/
       "title": "Add database schema",
       "acceptanceCriteria": ["...", "Typecheck passes"],
       "priority": 1,
-      "completed": false
+      "passes": false
     }
   ]
 }

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Autonomous task execution with Ralph-style JSON tasks. Wraps compound-engineering for brainstorm, plan, review workflows.",
   "author": {
     "name": "Stanley Takamatsu"

--- a/plugins/aimi-engineering/CLAUDE.md
+++ b/plugins/aimi-engineering/CLAUDE.md
@@ -93,7 +93,7 @@ All task execution files go in `docs/tasks/`:
     "description": "string (max 500)",
     "acceptanceCriteria": ["string"],
     "priority": 1,
-    "completed": false,
+    "passes": false,
     "notes": "",
     "attempts": 0,
     "error": null

--- a/plugins/aimi-engineering/commands/deepen.md
+++ b/plugins/aimi-engineering/commands/deepen.md
@@ -20,7 +20,7 @@ Run compound-engineering's deepen workflow:
 
 After deepening completes, read `docs/tasks/tasks.json` to capture current state:
 
-- Which stories have `completed: true`
+- Which stories have `passes: true`
 - Current `notes` field contents
 - Current `attempts` counts
 - Current `lastAttempt` timestamps
@@ -36,7 +36,7 @@ Re-invoke the plan-to-tasks skill to generate updated stories.
 
 For each story in the new conversion:
 - If a matching story (by ID or title) exists in old state:
-  - Keep `completed` value from old state
+  - Keep `passes` value from old state
   - Keep `notes` value from old state
   - Keep `attempts` value from old state
   - Keep `lastAttempt` value from old state

--- a/plugins/aimi-engineering/commands/execute.md
+++ b/plugins/aimi-engineering/commands/execute.md
@@ -62,7 +62,7 @@ Switched to branch: [branchName]
 
 ## Step 3: Check for Pending Stories
 
-Count pending stories (where `completed === false`).
+Count pending stories (where `passes === false`).
 
 If none pending:
 ```

--- a/plugins/aimi-engineering/commands/next.md
+++ b/plugins/aimi-engineering/commands/next.md
@@ -15,7 +15,7 @@ Read `docs/tasks/tasks.json`.
 
 Find the story with:
 - Lowest priority value
-- Where `completed === false`
+- Where `passes === false`
 
 If no pending stories found:
 ```
@@ -62,14 +62,14 @@ Acceptance Criteria:
 3. Run quality checks (typecheck, lint, tests as appropriate)
 4. If checks FAIL: Update tasks.json with error details, return failure
 5. If checks PASS: Commit with message 'feat: [STORY_ID] - [STORY_TITLE]'
-6. Update tasks.json: Set completed: true for story [STORY_ID]
+6. Update tasks.json: Set passes: true for story [STORY_ID]
 7. Append progress entry to docs/tasks/progress.md
 8. If you discovered important patterns, add to Codebase Patterns section
 
 ## ON FAILURE
 
-Do NOT mark completed: true. Update tasks.json with:
-- completed: false
+Do NOT mark passes: true. Update tasks.json with:
+- passes: false
 - notes: 'Failed: [detailed error]'
 - attempts: [increment]
 - lastAttempt: [timestamp]
@@ -83,7 +83,7 @@ Return with clear failure report.
 ### If Task succeeds:
 
 Verify:
-1. `docs/tasks/tasks.json` was updated (story has `completed: true`)
+1. `docs/tasks/tasks.json` was updated (story has `passes: true`)
 2. `docs/tasks/progress.md` was appended with progress entry
 
 Report:

--- a/plugins/aimi-engineering/commands/status.md
+++ b/plugins/aimi-engineering/commands/status.md
@@ -21,8 +21,8 @@ No tasks.json found. Run /aimi:plan to create a task list.
 
 Count stories:
 - Total: length of userStories array
-- Completed: count where completed === true
-- Pending: count where completed === false
+- Completed: count where passes === true
+- Pending: count where passes === false
 
 ## Step 3: Display Status
 
@@ -42,9 +42,9 @@ Next: [next story info or completion message]
 
 For each story, show status indicator:
 
-- `✓` for completed (completed: true)
-- `→` for next pending (first story where completed: false)
-- `○` for pending (completed: false)
+- `✓` for completed (passes: true)
+- `→` for next pending (first story where passes: false)
+- `○` for pending (passes: false)
 
 Example:
 ```

--- a/plugins/aimi-engineering/skills/plan-to-tasks/SKILL.md
+++ b/plugins/aimi-engineering/skills/plan-to-tasks/SKILL.md
@@ -8,7 +8,7 @@ description: >
 
 # Plan to Tasks Conversion
 
-Convert a markdown implementation plan into a structured `tasks.json` file for autonomous execution.
+Convert a markdown implementation plan into a structured `docs/tasks/tasks.json` file for autonomous execution.
 
 ## Input
 
@@ -16,7 +16,7 @@ A markdown plan file path containing Implementation Phases sections.
 
 ## Output
 
-A `tasks.json` file following the schema in [task-format.md](./references/task-format.md).
+A `docs/tasks/tasks.json` file following the schema in [task-format.md](./references/task-format.md).
 
 ## Conversion Steps
 
@@ -84,7 +84,7 @@ Create the users table with authentication fields.
     "Typecheck passes"
   ],
   "priority": 1,
-  "completed": false,
+  "passes": false,
   "notes": "",
   "attempts": 0,
   "lastAttempt": null

--- a/plugins/aimi-engineering/skills/plan-to-tasks/references/task-format.md
+++ b/plugins/aimi-engineering/skills/plan-to-tasks/references/task-format.md
@@ -20,7 +20,7 @@ The `tasks.json` file is the structured task list that drives autonomous executi
 - `description` (string, non-empty, max 500 chars)
 - `acceptanceCriteria` (array of strings, at least one item)
 - `priority` (number, positive integer)
-- `completed` (boolean)
+- `passes` (boolean)
 
 ### Validation Errors
 
@@ -69,7 +69,7 @@ Do NOT proceed with invalid tasks.json.
 | `description` | string | Yes | User story format: "As a [role], I need [feature]" |
 | `acceptanceCriteria` | array | Yes | List of verifiable criteria |
 | `priority` | number | Yes | Execution order (1 = first) |
-| `completed` | boolean | Yes | Whether story is complete |
+| `passes` | boolean | Yes | Whether story passes (complete) |
 | `notes` | string | Yes | Execution notes or learnings |
 | `attempts` | number | Yes | Number of execution attempts |
 | `lastAttempt` | string | No | ISO 8601 timestamp of last attempt |
@@ -126,7 +126,7 @@ This structured format enables:
         "Typecheck passes"
       ],
       "priority": 1,
-      "completed": false,
+      "passes": false,
       "notes": "",
       "attempts": 0,
       "lastAttempt": null
@@ -142,7 +142,7 @@ This structured format enables:
         "Unit tests pass"
       ],
       "priority": 2,
-      "completed": false,
+      "passes": false,
       "notes": "",
       "attempts": 0,
       "lastAttempt": null
@@ -159,7 +159,7 @@ This structured format enables:
         "Verify changes work in browser"
       ],
       "priority": 3,
-      "completed": false,
+      "passes": false,
       "notes": "",
       "attempts": 0,
       "lastAttempt": null

--- a/plugins/aimi-engineering/skills/story-executor/SKILL.md
+++ b/plugins/aimi-engineering/skills/story-executor/SKILL.md
@@ -82,7 +82,7 @@ Follow the execution rules in order:
 4. **Fail fast**: If quality checks fail, STOP and report the failure
 5. **Update AGENTS.md**: If you discovered reusable patterns, update nearby AGENTS.md files (see below)
 6. **Commit**: If all checks pass, commit with message "feat: [STORY_ID] - [STORY_TITLE]"
-7. **Update tasks.json**: Set completed: true for this story
+7. **Update tasks.json**: Set passes: true for this story
 8. **Append progress**: Add your progress entry to progress.md
 9. **Update patterns**: If you discovered important patterns, add to Codebase Patterns section
 
@@ -129,11 +129,11 @@ Append this to docs/tasks/progress.md:
 
 If you cannot complete the story:
 
-1. Do NOT mark completed: true
+1. Do NOT mark passes: true
 2. Update tasks.json with structured error:
    ```json
    {
-     "completed": false,
+     "passes": false,
      "notes": "Failed: [brief summary]",
      "attempts": [increment],
      "lastAttempt": "[timestamp]",
@@ -194,8 +194,8 @@ STORY: [STORY_DESCRIPTION]
 CRITERIA: [acceptance criteria as comma-separated list]
 PATTERNS: [extracted codebase patterns or "none yet"]
 
-FLOW: implement → check (tsc/lint/test) → update AGENTS.md (if reusable patterns) → commit "feat: [ID] - [title]" → update tasks.json (completed:true) → append progress.md
-FAIL: Set completed:false, add error object with type/message/file/suggestion, return failure report.
+FLOW: implement → check (tsc/lint/test) → update AGENTS.md (if reusable patterns) → commit "feat: [ID] - [title]" → update tasks.json (passes:true) → append progress.md
+FAIL: Set passes:false, add error object with type/message/file/suggestion, return failure report.
 AGENTS.md: Add reusable patterns to nearby AGENTS.md files (conventions, gotchas, dependencies). Skip story-specific details.
 ```
 

--- a/plugins/aimi-engineering/skills/story-executor/references/execution-rules.md
+++ b/plugins/aimi-engineering/skills/story-executor/references/execution-rules.md
@@ -81,7 +81,7 @@ Read `docs/tasks/tasks.json`, update your story:
 ```json
 {
   "id": "US-XXX",
-  "completed": true,
+  "passes": true,
   "notes": "Completed successfully. [brief notes]",
   "attempts": 1,
   "lastAttempt": "2026-02-15T10:45:00Z"
@@ -218,11 +218,11 @@ _Consolidated learnings from all stories (read this first)_
 
 If you fail to complete a story:
 
-1. **Do NOT** mark `completed: true`
+1. **Do NOT** mark `passes: true`
 2. **Update** tasks.json with structured error:
    ```json
    {
-     "completed": false,
+     "passes": false,
      "notes": "Failed: [brief summary]",
      "attempts": [increment],
      "lastAttempt": "[timestamp]",


### PR DESCRIPTION
## Summary

Renames the `completed` boolean field to `passes` across the entire task schema and all related documentation.

## Motivation

The new `passes` terminology better reflects the semantics of task validation:
- A story "passes" when all acceptance criteria are verified
- Aligns with testing vocabulary (pass/fail)
- More descriptive than generic "completed"

## Changes

- **Task Schema**: `completed` → `passes` in all JSON examples
- **Commands Updated**:
  - `deepen.md`: State preservation logic
  - `execute.md`: Pending story detection
  - `next.md`: Story selection and completion
  - `status.md`: Progress counting and display
- **Skills Updated**:
  - `plan-to-tasks`: Output format and examples
  - `story-executor`: Execution flow and failure handling
- **Documentation**: README.md and CLAUDE.md examples

## Migration

Existing `tasks.json` files will need to rename `completed` to `passes`.