### PR TITLE
Fix Aimi-branded messaging in all commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-02-16
+
+### Fixed
+
+- **Aimi-Branded Messaging**: All commands now show only Aimi commands in next steps
+  - Commands still execute compound-engineering workflows under the hood
+  - Post-completion options are intercepted and replaced with Aimi equivalents
+  - Command mapping: `/workflows:plan` → `/aimi:plan`, `/deepen-plan` → `/aimi:deepen`, etc.
+
+### Changed
+
+- `/aimi:brainstorm` - Added Step 2 with Aimi-branded next steps override
+- `/aimi:plan` - Added Step 6 with Aimi-branded report override
+- `/aimi:deepen` - Added Step 6 with Aimi-branded report override
+- `/aimi:review` - Added Step 2 with Aimi-branded summary override
+- All commands include "NEVER mention" guidance to prevent compound-engineering leakage
+
 ## [0.7.0] - 2026-02-16
 
 ### Added

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Autonomous task execution with Ralph-style JSON tasks. Wraps compound-engineering for brainstorm, plan, review workflows.",
   "author": {
     "name": "Stanley Takamatsu"

--- a/plugins/aimi-engineering/commands/brainstorm.md
+++ b/plugins/aimi-engineering/commands/brainstorm.md
@@ -6,12 +6,39 @@ argument-hint: "[feature description]"
 
 # Aimi Brainstorm
 
-Run the compound-engineering brainstorm workflow to explore ideas and requirements.
+Run compound-engineering's brainstorm workflow, then present Aimi-branded next steps.
+
+## Step 1: Execute Compound Brainstorm
 
 /workflows:brainstorm $ARGUMENTS
 
-After brainstorming completes, suggest next steps:
+## Step 2: Aimi-Branded Next Steps (OVERRIDE)
 
-"Brainstorming complete! Next steps:
-- Run `/aimi:plan` to create an implementation plan and generate tasks.json
-- Or continue exploring with another `/aimi:brainstorm` session"
+**CRITICAL:** After the brainstorm workflow completes, IGNORE any compound-engineering options it presents. Instead, display ONLY these Aimi-specific next steps:
+
+```
+Brainstorm complete!
+
+Document: docs/brainstorms/[filename].md
+
+Next steps:
+1. **Run `/aimi:plan`** - Create implementation plan and tasks.json
+2. **Continue brainstorming** - Run `/aimi:brainstorm` to explore further
+3. **Review document** - Open the brainstorm file to refine manually
+```
+
+**Command Mapping (what to say vs what NOT to say):**
+
+| If compound says... | Aimi says instead... |
+|---------------------|----------------------|
+| `/workflows:plan` | `/aimi:plan` |
+| `/workflows:brainstorm` | `/aimi:brainstorm` |
+| `/workflows:work` | `/aimi:execute` |
+| `/deepen-plan` | `/aimi:deepen` |
+| `/plan_review` | `/aimi:review` |
+| `/technical_review` | `/aimi:review` |
+
+**NEVER mention:**
+- compound-engineering
+- workflows:*
+- Any command without the `aimi:` prefix

--- a/plugins/aimi-engineering/commands/deepen.md
+++ b/plugins/aimi-engineering/commands/deepen.md
@@ -2,19 +2,17 @@
 name: aimi:deepen
 description: Enhance plan with research and update tasks.json
 argument-hint: "[path to plan file]"
-disable-model-invocation: true
-allowed-tools: Read, Write, Edit, Skill(plan-to-tasks)
 ---
 
 # Aimi Deepen
 
-Enhance an existing plan with research insights, then update tasks.json while preserving completion state.
+Run compound-engineering's deepen workflow, then update tasks.json while preserving state.
 
-## Step 1: Enhance Plan
-
-Run compound-engineering's deepen workflow:
+## Step 1: Execute Compound Deepen
 
 /deepen-plan $ARGUMENTS
+
+**IMPORTANT:** When compound-engineering presents post-enhancement options, DO NOT show them to the user. Proceed directly to Step 2.
 
 ## Step 2: Read Current State
 
@@ -27,8 +25,7 @@ After deepening completes, read `docs/tasks/tasks.json` to capture current state
 
 ## Step 3: Re-Convert to Tasks
 
-Re-read the enhanced plan file.
-Re-invoke the plan-to-tasks skill to generate updated stories.
+Re-read the enhanced plan file and invoke the plan-to-tasks skill to generate updated stories.
 
 ## Step 4: Preserve State
 
@@ -49,20 +46,35 @@ Write the merged result to `docs/tasks/tasks.json`.
 
 Add or update `deepenedAt` field with current ISO 8601 timestamp.
 
-## Step 6: Report Changes
+## Step 6: Aimi-Branded Report (OVERRIDE)
 
-Tell the user what was enhanced:
+**CRITICAL:** Display ONLY Aimi-specific output. NEVER show compound-engineering options.
 
 ```
 Plan deepened successfully!
 
-Updated stories:
-- US-001: Added [X] new acceptance criteria
-- US-003: Enhanced description with research insights
+📋 Enhanced: docs/plans/[filename].md
+📝 Updated: docs/tasks/tasks.json
 
-Preserved state:
-- [Y] completed stories kept their status
-- [Z] stories with notes preserved
+Changes:
+- [X] stories updated with research insights
+- [Y] completed stories preserved their status
 
-Run `/aimi:status` to view updated task list.
+Next steps:
+1. **Run `/aimi:review`** - Get feedback from code reviewers
+2. **Run `/aimi:status`** - View updated task list
+3. **Run `/aimi:execute`** - Begin autonomous execution
 ```
+
+**Command Mapping (what to say vs what NOT to say):**
+
+| If compound says... | Aimi says instead... |
+|---------------------|----------------------|
+| `/workflows:work` | `/aimi:execute` |
+| `/technical_review` | `/aimi:review` |
+| `/plan_review` | `/aimi:review` |
+
+**NEVER mention:**
+- compound-engineering
+- workflows:*
+- Any command without the `aimi:` prefix

--- a/plugins/aimi-engineering/commands/plan.md
+++ b/plugins/aimi-engineering/commands/plan.md
@@ -2,48 +2,19 @@
 name: aimi:plan
 description: Create implementation plan and convert to tasks.json
 argument-hint: "[feature description]"
-disable-model-invocation: true
-allowed-tools: Read, Write, Bash(mkdir:*), Bash(ls:*), Skill(compound-engineering:workflows:plan), Skill(plan-to-tasks)
 ---
 
 # Aimi Plan
 
-Create an implementation plan using compound-engineering, then convert it to tasks.json for autonomous execution.
+Run compound-engineering's plan workflow, then convert to tasks.json for autonomous execution.
 
-## Execution Flow
+## Step 1: Execute Compound Plan
 
-**IMPORTANT:** This command has two phases that MUST run sequentially:
-
-1. **Phase 1:** Run `/workflows:plan` to generate the implementation plan
-2. **Phase 2:** After Phase 1 completes, automatically run Steps 2-6 to convert to tasks.json
-
-Do NOT wait for user input between phases. The entire flow runs as one operation.
-
----
-
-## Phase 1: Generate Plan
-
-**CRITICAL:** Invoke the compound-engineering plan workflow FIRST:
-
-```
 /workflows:plan $ARGUMENTS
-```
 
-Wait for this skill to complete fully. It will:
-- Research the codebase
-- Ask clarifying questions if needed
-- Generate a plan file at `docs/plans/YYYY-MM-DD-*-plan.md`
-- Present post-generation options to the user
+**IMPORTANT:** When compound-engineering presents post-generation options, DO NOT show them to the user. Proceed directly to Step 2.
 
-**After the user selects an option OR the plan is complete**, proceed immediately to Phase 2.
-
----
-
-## Phase 2: Convert to Tasks (Automatic)
-
-Once the plan file exists, execute these steps automatically WITHOUT user prompts:
-
-### Step 2: Locate Generated Plan
+## Step 2: Locate Generated Plan
 
 Find the most recent plan file:
 
@@ -51,17 +22,13 @@ Find the most recent plan file:
 ls -t docs/plans/*-plan.md | head -1
 ```
 
-Store the path for the next step.
-
-### Step 3: Initialize Output Directory
-
-Create the tasks directory if it doesn't exist:
+## Step 3: Initialize Output Directory
 
 ```bash
 mkdir -p docs/tasks
 ```
 
-### Step 4: Convert to Tasks
+## Step 4: Convert to Tasks
 
 Read the plan file and invoke the plan-to-tasks skill:
 
@@ -70,43 +37,51 @@ Skill: plan-to-tasks
 Args: [plan-file-path]
 ```
 
-This generates the structured tasks.json with:
-- Task-specific steps for each story
-- Pattern library matching
-- AGENTS.md discovery
-- qualityChecks for verification
-
-### Step 5: Write Output Files
+## Step 5: Write tasks.json
 
 Write the converted tasks to `docs/tasks/tasks.json`.
 
-### Step 6: Report Output
+## Step 6: Aimi-Branded Report (OVERRIDE)
 
-Tell the user:
+**CRITICAL:** Display ONLY Aimi-specific output. NEVER show compound-engineering options.
 
 ```
 Plan and tasks created successfully!
 
-- Plan: docs/plans/[filename].md
-- Tasks: docs/tasks/tasks.json
+📋 Plan: docs/plans/[filename].md
+📝 Tasks: docs/tasks/tasks.json
 
 Stories: [X] total
 Schema version: 2.0
 
 Next steps:
-- Run `/aimi:deepen [plan-path]` to enhance with research (optional)
-- Run `/aimi:status` to view task list
-- Run `/aimi:execute` to begin autonomous execution
+1. **Run `/aimi:deepen`** - Enhance plan with parallel research (optional)
+2. **Run `/aimi:review`** - Get feedback from code reviewers
+3. **Run `/aimi:status`** - View task list
+4. **Run `/aimi:execute`** - Begin autonomous execution
 ```
 
----
+**Command Mapping (what to say vs what NOT to say):**
+
+| If compound says... | Aimi says instead... |
+|---------------------|----------------------|
+| `/workflows:plan` | `/aimi:plan` |
+| `/workflows:work` | `/aimi:execute` |
+| `/deepen-plan` | `/aimi:deepen` |
+| `/plan_review` | `/aimi:review` |
+| `/technical_review` | `/aimi:review` |
+
+**NEVER mention:**
+- compound-engineering
+- workflows:*
+- Any command without the `aimi:` prefix
 
 ## Error Handling
 
-If Phase 1 fails or is cancelled:
-- Do NOT proceed to Phase 2
+If Step 1 fails or is cancelled:
+- Do NOT proceed to Step 2-6
 - Report the error to the user
 
-If Phase 2 fails:
+If Step 4-5 fails:
 - Report which step failed
-- The plan file still exists and can be converted manually with `/plan-to-tasks [path]`
+- Plan file still exists - user can run `/aimi:plan-to-tasks [path]` manually

--- a/plugins/aimi-engineering/commands/review.md
+++ b/plugins/aimi-engineering/commands/review.md
@@ -6,6 +6,33 @@ argument-hint: "[files or PR to review]"
 
 # Aimi Review
 
-Run the compound-engineering review workflow for thorough code review.
+Run compound-engineering's review workflow, then present Aimi-branded summary.
+
+## Step 1: Execute Compound Review
 
 /workflows:review $ARGUMENTS
+
+## Step 2: Aimi-Branded Summary (OVERRIDE)
+
+**CRITICAL:** After the review completes, present ONLY Aimi-specific next steps.
+
+```
+Review complete!
+
+Next steps:
+1. **Address findings** - Fix issues identified in the review
+2. **Run `/aimi:execute`** - Continue autonomous execution
+3. **Run `/aimi:status`** - Check current task progress
+```
+
+**Command Mapping (what to say vs what NOT to say):**
+
+| If compound says... | Aimi says instead... |
+|---------------------|----------------------|
+| `/workflows:work` | `/aimi:execute` |
+| `/workflows:plan` | `/aimi:plan` |
+
+**NEVER mention:**
+- compound-engineering
+- workflows:*
+- Any command without the `aimi:` prefix


### PR DESCRIPTION
## Summary

All commands now show only Aimi commands in next steps, never compound-engineering references.

## Problem

When running `/aimi:brainstorm` or `/aimi:plan`, the post-completion menu showed compound-engineering commands like `/workflows:plan`, `/deepen-plan`, etc. This broke the Aimi branding experience.

## Solution

All Aimi wrapper commands now:
1. **Execute compound-engineering workflows** under the hood (unchanged)
2. **Override the post-completion messaging** with Aimi-branded options

Each command includes:
- **Command Mapping Table** - Shows what compound says vs what Aimi should say
- **"NEVER mention" guidance** - Explicit list of things to avoid

| Compound Command | Aimi Equivalent |
|------------------|-----------------|
| `/workflows:plan` | `/aimi:plan` |
| `/workflows:work` | `/aimi:execute` |
| `/workflows:brainstorm` | `/aimi:brainstorm` |
| `/deepen-plan` | `/aimi:deepen` |
| `/plan_review` | `/aimi:review` |
| `/technical_review` | `/aimi:review` |

## Changes

- `/aimi:brainstorm` - Added Step 2 with Aimi-branded next steps override
- `/aimi:plan` - Added Step 6 with Aimi-branded report override  
- `/aimi:deepen` - Added Step 6 with Aimi-branded report override
- `/aimi:review` - Added Step 2 with Aimi-branded summary override

## Version

Bumped to **0.8.0**