### PR TITLE
Harden parallel execution with Docker sandbox support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and swarm orchestration.",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "author": {
         "name": "Stanley Takamatsu",
         "url": "https://github.com/aimi-so"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and swarm orchestration.",
-      "version": "1.15.0",
+      "version": "1.16.0",
       "author": {
         "name": "Stanley Takamatsu",
         "url": "https://github.com/aimi-so"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and swarm orchestration.",
-      "version": "1.16.1",
+      "version": "1.17.0",
       "author": {
         "name": "Stanley Takamatsu",
         "url": "https://github.com/aimi-so"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and swarm orchestration.",
-      "version": "1.10.0",
+      "version": "1.11.1",
       "author": {
         "name": "Stanley Takamatsu",
         "url": "https://github.com/aimi-so"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and swarm orchestration.",
-      "version": "1.11.1",
+      "version": "1.12.0",
       "author": {
         "name": "Stanley Takamatsu",
         "url": "https://github.com/aimi-so"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and swarm orchestration.",
-      "version": "1.14.1",
+      "version": "1.15.0",
       "author": {
         "name": "Stanley Takamatsu",
         "url": "https://github.com/aimi-so"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and swarm orchestration.",
-      "version": "1.14.0",
+      "version": "1.14.1",
       "author": {
         "name": "Stanley Takamatsu",
         "url": "https://github.com/aimi-so"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and swarm orchestration.",
-      "version": "1.13.0",
+      "version": "1.14.0",
       "author": {
         "name": "Stanley Takamatsu",
         "url": "https://github.com/aimi-so"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and swarm orchestration.",
-      "version": "1.16.0",
+      "version": "1.16.1",
       "author": {
         "name": "Stanley Takamatsu",
         "url": "https://github.com/aimi-so"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and swarm orchestration.",
-      "version": "1.16.0",
+      "version": "1.17.0",
       "author": {
         "name": "Stanley Takamatsu",
         "url": "https://github.com/aimi-so"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.worktrees

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.14.1] - 2026-03-01
+## [1.15.0] - 2026-03-01
+
+### Changed
+
+- **execute.md parallel execution rewrite**: Replaced Team/SendMessage swarm orchestration with foreground fan-out using `run_in_background` Task agents — eliminates Team lifecycle complexity, reduces token overhead, and runs parallel workers directly from the orchestrator's context
+- **execute.md Team/SendMessage dependency removed**: Parallel story execution no longer requires TeamCreate, SendMessage, or teammate coordination — workers are spawned as background tasks and polled for completion
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.1] - 2026-03-01
+
+### Changed
+
+- **`/aimi:swarm` status subcommand**: Now runs automatic state reconciliation before displaying status table — detects zombie entries (containers in state but missing from Docker), silent completions, silent failures, unexpected stops, and already-started containers
+- **`/aimi:swarm` resume subcommand**: Enhanced with full crash recovery — reconciles state first, identifies resumable containers, recreates failed containers for retry, skips running/completed containers, fans out only pending containers
+- **`/aimi:swarm` cleanup subcommand**: Enhanced with per-container removal reporting (removed vs already gone), proper state entry cleanup count, and graceful handling of missing swarms
+
+### Added
+
+- **State reconciliation subroutine** in swarm.md: Shared procedure that runs before `status` display and `resume` operations, comparing `swarm-state.json` entries against actual Docker daemon state via `sandbox-manager.sh status`
+- **Zombie detection documentation**: New "State Reconciliation" reference section documenting detection scenarios (zombie, silent completion/failure, unexpected stop, already started), zombie causes, and idempotency guarantees
+
 ## [1.16.0] - 2026-03-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.14.0] - 2026-02-28
+
+### Changed
+
+- **aimi-cli.sh portable `_lock()` function**: Replaces direct `flock` calls with cross-platform locking — Linux uses `flock`, macOS uses atomic `mkdir` spinlock with 10s stale-lock timeout and `trap EXIT` cleanup
+- **aimi-cli.sh platform detection at startup**: Caches `_HAS_FLOCK` and `_HAS_REALPATH` to avoid per-call `command -v` overhead
+- **aimi-cli.sh `cmd_clear_state`**: Also removes `*.lock.d` directories (mkdir-based lock cleanup)
+- **execute.md CLI resolution**: Glob first (always finds latest version), cli-path as fallback only — prevents stale cached path from using old plugin version
+- **status.md + next.md CLI resolution**: Consistent with execute.md — glob first, cli-path fallback (was glob-only, no fallback)
+
 ## [1.13.0] - 2026-02-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.1] - 2026-02-27
+
+### Security
+
+- **auto-approve-cli.sh**: Hardened with subcommand whitelist and shell metacharacter rejection
+  - Pattern 1 (AIMI_CLI= assignment): Now validates path matches `~/.claude/plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh` — rejects arbitrary assignments
+  - Pattern 2 ($AIMI_CLI invocation): Replaced permissive regex with explicit subcommand whitelist (19 commands: init-session, find-tasks, status, metadata, next-story, current-story, list-ready, mark-in-progress, mark-complete, mark-failed, mark-skipped, count-pending, validate-deps, validate-stories, cascade-skip, get-branch, get-state, clear-state, help)
+  - Shell chaining rejection: Commands containing `;`, `&&`, `||`, `|`, `$()`, or backticks after `$AIMI_CLI` or `$WORKTREE_MGR` are rejected
+  - Pattern 3 (NEW): WORKTREE_MGR= assignment validated against expected plugin path
+  - Pattern 4 (NEW): $WORKTREE_MGR invocation with subcommand whitelist (create, remove, merge, list, help)
+
 ## [1.11.0] - 2026-02-27
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.0] - 2026-02-27
+
+### Added
+
+- **aimi-cli.sh `resolve_path()` helper**: POSIX-compatible path resolution (uses `realpath` when available, falls back to `cd`+`pwd`+`basename` for macOS)
+- **aimi-cli.sh `reset-orphaned` subcommand**: Atomically marks all `in_progress` stories as `failed`, returns `{count, reset: [ids]}` — replaces fragile `status | jq` pipeline
+- **aimi-cli.sh `validate_story_exists()` function**: Verifies story ID exists in tasks file before mutation; all `mark-*` and `cascade-skip` commands now exit 1 with clear error for non-existent IDs
+- **aimi-cli.sh `cli-path` state file**: `init-session` writes CLI's absolute path to `.aimi/cli-path` for reliable resolution across shell sessions
+- **aimi-cli.sh stale state warning**: `get_tasks_file()` prints stderr warning when `current-tasks` points to a deleted file, auto-updates state with discovered alternative
+- **test-aimi-cli.sh**: 16 new tests (65 total) covering: resolve_path, cli-path, userStories key, story ID existence validation, reset-orphaned (empty + with orphans), stale state warning
+- **test-aimi-cli.sh `assert_stderr_contains` helper**: New test helper for validating stderr output
+
+### Changed
+
+- **aimi-cli.sh `cmd_status` output**: Renamed `.stories` key to `.userStories` for consistency with schema v3.0 source field name
+- **aimi-cli.sh state files**: `init-session` and `get_tasks_file()` now store absolute paths in `.aimi/current-tasks` (resolves cwd-dependency bugs)
+- **aimi-cli.sh `write_state()` and `clear_state_file()`**: Now use `flock` with `$AIMI_DIR/.state.lock` for parallel execution safety
+- **aimi-cli.sh `cmd_clear_state`**: Also removes `.state.lock`, `cli-path`, and all `.lock` files under `.aimi/`
+- **execute.md Step 0**: CLI resolution now tries `cat .aimi/cli-path` first, falls back to `ls` glob if missing or invalid
+- **execute.md orphaned recovery**: Replaced `status | jq` pipeline with `$AIMI_CLI reset-orphaned` subcommand
+- **status.md**: Updated example output to use `userStories` key
+- **auto-approve-cli.sh**: Added `reset-orphaned` to subcommand whitelist
+
 ## [1.12.0] - 2026-02-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.16.1] - 2026-03-01
+## [1.17.0] - 2026-03-01
 
 ### Changed
 
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **State reconciliation subroutine** in swarm.md: Shared procedure that runs before `status` display and `resume` operations, comparing `swarm-state.json` entries against actual Docker daemon state via `sandbox-manager.sh status`
 - **Zombie detection documentation**: New "State Reconciliation" reference section documenting detection scenarios (zombie, silent completion/failure, unexpected stop, already started), zombie causes, and idempotency guarantees
+
+### Security
+
+- **auto-approve-cli.sh**: Added `SANDBOX_MGR` patterns with path validation and subcommand whitelist (create, remove, list, status, cleanup, check-runtime)
+- **auto-approve-cli.sh**: Added `BUILD_IMG` patterns with path validation for build-project-image.sh invocation
+- **auto-approve-cli.sh**: Added swarm subcommands to `$AIMI_CLI` whitelist (swarm-init, swarm-add, swarm-update, swarm-remove, swarm-status, swarm-list, swarm-cleanup)
+- **auto-approve-cli.sh**: Added `docker exec -i aimi-*` pattern for ACP adapter communication — restricted to `aimi-` prefixed containers running `python3 /opt/aimi/acp-adapter.py` only (no wildcard Docker approvals)
 
 ## [1.16.0] - 2026-03-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.14.1] - 2026-03-01
+
+### Fixed
+
+- **worktree-manager.sh merge stderr suppression**: Removed `2>/dev/null` from `git checkout` and `git merge` commands in `merge_worktree()` and `merge_all_worktrees()` functions — merge conflicts and failures are now visible in stderr for proper diagnosis
+
 ## [1.14.0] - 2026-02-28
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.0] - 2026-03-01
+
+### Added
+
+- **`/aimi:swarm` command**: Multi-task Docker sandbox orchestration for parallel feature execution
+  - Discovers `.aimi/tasks/*-tasks.json` files, presents multi-select list to user
+  - Supports `--file <path>` flag for single-file execution
+  - Provisions Sysbox-isolated Docker containers via `sandbox-manager.sh` for each task file
+  - Builds per-project images via `build-project-image.sh` with checksum-based rebuild skipping
+  - Fans out parallel Task agents, each communicating with its container via ACP adapter (`docker exec -i`)
+  - Tracks execution via `swarm-state.json` using CLI swarm-* subcommands
+  - Configurable `maxContainers` limit (default 4, override with `--max <N>`)
+  - Subcommands: `status` (view swarm state), `resume` (restart pending containers), `cleanup` (remove containers and state)
+  - Handles partial failure: failed containers marked in state, successful ones continue independently
+  - Reports summary with per-container status, branch names, and PR URLs
+
 ## [1.15.0] - 2026-03-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Pattern 3 (NEW): WORKTREE_MGR= assignment validated against expected plugin path
   - Pattern 4 (NEW): $WORKTREE_MGR invocation with subcommand whitelist (create, remove, merge, list, help)
 
+### Changed
+
+- **execute.md**: Hardened orchestration with recovery, validation, and story notes
+  - Step 1: Orphaned `in_progress` story recovery — detects stories stuck from interrupted runs, resets them to `failed` for retry
+  - Step 1: Content validation via `$AIMI_CLI validate-stories` before any execution begins (prompt injection defense)
+  - Step 3.1: Moved `validate-deps` from parallel-only path (4b.1) to shared path before mode detection — both sequential and parallel now validate dependency graph
+  - Worker prompt: Added `## PREVIOUS NOTES` section with `story.notes` content (omitted when empty) for context on retried/failed stories
+  - Renumbered 4b subsections (4b.1-4b.6) after removing duplicate validate-deps
+  - Fixed stale reference to Step 4b.7 in Error Recovery section
+
 ## [1.11.0] - 2026-02-27
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.17.0] - 2026-03-01
+
+### Security
+
+- **auto-approve-cli.sh**: Added `SANDBOX_MGR` patterns with path validation and subcommand whitelist (create, remove, list, status, cleanup, check-runtime)
+- **auto-approve-cli.sh**: Added `BUILD_IMG` patterns with path validation for build-project-image.sh invocation
+- **auto-approve-cli.sh**: Added swarm subcommands to `$AIMI_CLI` whitelist (swarm-init, swarm-add, swarm-update, swarm-remove, swarm-status, swarm-list, swarm-cleanup)
+- **auto-approve-cli.sh**: Added `docker exec -i aimi-*` pattern for ACP adapter communication — restricted to `aimi-` prefixed containers running `python3 /opt/aimi/acp-adapter.py` only (no wildcard Docker approvals)
+
 ## [1.16.0] - 2026-03-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -437,15 +437,18 @@ Invalid characters (spaces, semicolons, quotes) trigger validation errors.
 
 ## Version History
 
-**Current Version:** 1.16.1
+**Current Version:** 1.17.0
 
 ### Recent Changes
 
-**v1.16.1** - Swarm State Reconciliation
+**v1.17.0** - Swarm State Reconciliation & Auto-Approve Hooks
 - Automatic state reconciliation before `status` display and `resume` operations
 - Zombie detection: identifies containers in state but missing from Docker daemon
 - Enhanced `resume` with crash recovery: recreates failed containers, retries pending
 - Enhanced `cleanup` with per-container removal reporting
+- auto-approve-cli.sh: SANDBOX_MGR, BUILD_IMG path validation + subcommand whitelists
+- auto-approve-cli.sh: swarm-* subcommands added to AIMI_CLI whitelist
+- auto-approve-cli.sh: docker exec -i aimi-* pattern for ACP adapter (no wildcard Docker)
 
 **v1.16.0** - Docker Swarm Orchestration
 - `/aimi:swarm` command for multi-task parallel Docker sandbox execution

--- a/README.md
+++ b/README.md
@@ -437,9 +437,15 @@ Invalid characters (spaces, semicolons, quotes) trigger validation errors.
 
 ## Version History
 
-**Current Version:** 1.16.0
+**Current Version:** 1.17.0
 
 ### Recent Changes
+
+**v1.17.0** - Sandbox & Swarm Auto-Approve Hooks
+- auto-approve-cli.sh: SANDBOX_MGR path validation + subcommand whitelist
+- auto-approve-cli.sh: BUILD_IMG path validation + invocation approval
+- auto-approve-cli.sh: swarm-* subcommands added to AIMI_CLI whitelist
+- auto-approve-cli.sh: docker exec -i aimi-* pattern for ACP adapter (no wildcard Docker)
 
 **v1.16.0** - Docker Swarm Orchestration
 - `/aimi:swarm` command for multi-task parallel Docker sandbox execution

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ All execution state lives in `.aimi/tasks/YYYY-MM-DD-[feature-name]-tasks.json`.
 | `dependsOn` | array | Story IDs that must complete before this story can start |
 | `notes` | string | Error details or learnings |
 
-> **Backward compatibility:** v2.2 tasks files (with `passes` boolean) are auto-detected and fully supported. All CLI commands work with both v2.2 and v3 schemas.
+> **Note:** As of v1.11.0, only schema v3.0 is supported. v2.2 backward compatibility was removed.
 
 ### Story Sizing
 
@@ -418,9 +418,16 @@ Invalid characters (spaces, semicolons, quotes) trigger validation errors.
 
 ## Version History
 
-**Current Version:** 1.9.0
+**Current Version:** 1.12.0
 
 ### Recent Changes
+
+**v1.12.0** - Parallel Execution Hardening
+- worktree-manager: `remove` command, `--from` flag, input validation, non-interactive
+- aimi-cli: flock-based locking, story ID validation, `validate-stories` command, maxConcurrency guard
+- execute.md: orphaned recovery, content validation, agent-driven merge conflict resolution, worker timeout, single-sourced worker prompt
+- auto-approve-cli.sh: subcommand whitelist, metacharacter rejection, WORKTREE_MGR support
+- story-executor SKILL.md: canonical prompt template, contradiction fixes
 
 **v1.9.0** - Schema v3, Parallel Execution, Worktree Merge
 - Schema v3 with `dependsOn` dependency graph and `status` enum replacing `passes` boolean

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ claude /plugin list
 | `/aimi:next` | Execute the next pending story | `/aimi:next` |
 | `/aimi:execute` | Run all stories autonomously (parallel for v3, sequential for v2.2) | `/aimi:execute` |
 | `/aimi:review` | Multi-agent code review with findings synthesis | `/aimi:review [PR or branch]` |
+| `/aimi:swarm` | Execute multiple tasks.json files in parallel Docker sandboxes | `/aimi:swarm [--file path] [--max N]` |
 
 ### Command Details
 
@@ -156,6 +157,24 @@ Multi-agent code review using aimi-native review agents. Runs parallel agents (a
 /aimi:review 42        # Review PR #42
 /aimi:review feat/auth # Review specific branch
 ```
+
+#### `/aimi:swarm`
+
+Executes multiple tasks.json files in parallel Docker sandboxes. Each task file gets its own Sysbox-isolated container with a full Claude Code agent running the story-executor flow inside it.
+
+```bash
+/aimi:swarm                          # Discover and select task files
+/aimi:swarm --file .aimi/tasks/f.json  # Execute a single task file
+/aimi:swarm --max 2                  # Limit to 2 concurrent containers
+/aimi:swarm status                   # View swarm state
+/aimi:swarm resume                   # Resume pending containers
+/aimi:swarm cleanup                  # Remove containers and state
+```
+
+Requirements:
+- Docker with Sysbox runtime installed
+- Git remote `origin` configured (containers clone via URL)
+- `ANTHROPIC_API_KEY` set in environment (injected into containers)
 
 ## Workflow
 
@@ -418,9 +437,15 @@ Invalid characters (spaces, semicolons, quotes) trigger validation errors.
 
 ## Version History
 
-**Current Version:** 1.12.0
+**Current Version:** 1.16.0
 
 ### Recent Changes
+
+**v1.16.0** - Docker Swarm Orchestration
+- `/aimi:swarm` command for multi-task parallel Docker sandbox execution
+- Multi-select task file discovery, container provisioning, parallel ACP fan-out
+- Subcommands: status, resume, cleanup
+- Configurable maxContainers limit with partial failure handling
 
 **v1.12.0** - Parallel Execution Hardening
 - worktree-manager: `remove` command, `--from` flag, input validation, non-interactive
@@ -473,7 +498,7 @@ See [CHANGELOG.md](CHANGELOG.md) for complete version history.
 
 | Type | Count | Description |
 |------|-------|-------------|
-| Commands | 7 | Slash commands for workflow stages |
+| Commands | 8 | Slash commands for workflow stages |
 | Skills | 3 | `brainstorm`, `task-planner`, `story-executor` |
 | Agents | 28 | 4 research, 15 review, 3 design, 1 docs, 5 workflow |
 

--- a/README.md
+++ b/README.md
@@ -437,9 +437,15 @@ Invalid characters (spaces, semicolons, quotes) trigger validation errors.
 
 ## Version History
 
-**Current Version:** 1.16.0
+**Current Version:** 1.16.1
 
 ### Recent Changes
+
+**v1.16.1** - Swarm State Reconciliation
+- Automatic state reconciliation before `status` display and `resume` operations
+- Zombie detection: identifies containers in state but missing from Docker daemon
+- Enhanced `resume` with crash recovery: recreates failed containers, retries pending
+- Enhanced `cleanup` with per-container removal reporting
 
 **v1.16.0** - Docker Swarm Orchestration
 - `/aimi:swarm` command for multi-task parallel Docker sandbox execution

--- a/README.md
+++ b/README.md
@@ -508,7 +508,7 @@ See [CHANGELOG.md](CHANGELOG.md) for complete version history.
 | Type | Count | Description |
 |------|-------|-------------|
 | Commands | 8 | Slash commands for workflow stages |
-| Skills | 3 | `brainstorm`, `task-planner`, `story-executor` |
+| Skills | 4 | `brainstorm`, `task-planner`, `story-executor`, `docker-sandbox` |
 | Agents | 28 | 4 research, 15 review, 3 design, 1 docs, 5 workflow |
 
 ## License

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi"

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi"

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi"

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi"

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.14.1",
+  "version": "1.15.0",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi"

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi"

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi"

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.16.1",
+  "version": "1.17.0",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi"

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi"

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi"

--- a/plugins/aimi-engineering/commands/execute.md
+++ b/plugins/aimi-engineering/commands/execute.md
@@ -17,11 +17,11 @@ Execute all pending stories autonomously with smart execution mode detection.
 **CRITICAL:** The CLI script lives in the plugin install directory, NOT the project directory. Resolve it first:
 
 ```bash
-# Try cached cli-path first (set by init-session), fall back to glob discovery
-if [ -f .aimi/cli-path ] && [ -x "$(cat .aimi/cli-path)" ]; then
+# Glob always finds the latest installed version
+AIMI_CLI=$(ls ~/.claude/plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh 2>/dev/null | tail -1)
+# Fallback to cached cli-path if glob found nothing (edge case)
+if [ -z "$AIMI_CLI" ] && [ -f .aimi/cli-path ] && [ -x "$(cat .aimi/cli-path)" ]; then
   AIMI_CLI=$(cat .aimi/cli-path)
-else
-  AIMI_CLI=$(ls ~/.claude/plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh 2>/dev/null | tail -1)
 fi
 ```
 

--- a/plugins/aimi-engineering/commands/next.md
+++ b/plugins/aimi-engineering/commands/next.md
@@ -14,7 +14,12 @@ Execute the next pending story using a Task-spawned agent.
 **CRITICAL:** The CLI script lives in the plugin install directory, NOT the project directory. Resolve it first:
 
 ```bash
+# Glob always finds the latest installed version
 AIMI_CLI=$(ls ~/.claude/plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh 2>/dev/null | tail -1)
+# Fallback to cached cli-path if glob found nothing (edge case)
+if [ -z "$AIMI_CLI" ] && [ -f .aimi/cli-path ] && [ -x "$(cat .aimi/cli-path)" ]; then
+  AIMI_CLI=$(cat .aimi/cli-path)
+fi
 ```
 
 If empty, report: "aimi-cli.sh not found. Reinstall plugin: `/plugin install aimi-engineering`" and STOP.

--- a/plugins/aimi-engineering/commands/next.md
+++ b/plugins/aimi-engineering/commands/next.md
@@ -55,40 +55,13 @@ The CLI also saves the story ID to `.aimi/current-story` for tracking.
 
 ## Step 2: Load Project Guidelines
 
-**BEFORE building the prompt, load project guidelines to inject into the Task agent.**
-
-### Discovery Order:
+Load project guidelines following the discovery order defined in `story-executor/SKILL.md` → "PROJECT GUIDELINES" section:
 
 1. **CLAUDE.md** (project root) - Primary project instructions
 2. **AGENTS.md** (any directory) - Module-specific patterns
-3. **Aimi defaults** - Fallback if neither exists
+3. **Aimi defaults** from story-executor - Fallback if neither exists
 
-### Load Guidelines:
-
-Check for CLAUDE.md and AGENTS.md files. Read them if they exist.
-
-### Aimi Default Rules (fallback):
-
-If no CLAUDE.md or AGENTS.md found, use these defaults:
-
-```markdown
-## Aimi Default Rules
-
-### Commit Format
-- Format: `<type>(<scope>): <description>`
-- Types: feat, fix, refactor, docs, test, chore
-- Max 72 chars, imperative mood, no trailing period
-
-### Quality Checks
-- Run typecheck before committing
-- Run lint if available
-- Run tests if relevant to changes
-
-### On Failure
-- Do NOT commit if checks fail
-- Update story notes with error details
-- Report the failure clearly
-```
+Read these files and store the content as `PROJECT_GUIDELINES`.
 
 ## Step 3: Display Current Story
 
@@ -104,47 +77,23 @@ Acceptance Criteria:
 ...
 ```
 
-## Step 4: Build Inline Prompt
+## Step 4: Build Worker Prompt
 
-**CRITICAL:** Pass story data AND project guidelines INLINE to the Task agent.
+**CRITICAL:** Construct the worker prompt following the canonical template in `story-executor/SKILL.md`.
+
+Interpolate the following into the template:
+- `PROJECT_GUIDELINES` = guidelines loaded in Step 2
+- `STORY_ID` = story.id
+- `STORY_TITLE` = story.title
+- `STORY_DESCRIPTION` = story.description
+- `ACCEPTANCE_CRITERIA` = story.acceptanceCriteria (bulleted)
+- `story.notes` = story.notes (include PREVIOUS NOTES section only if non-empty)
+- No WORKTREE_PATH (sequential mode — worker operates in current directory)
 
 ```
 Task general-purpose: "Execute [STORY_ID]: [STORY_TITLE]
 
-## PROJECT GUIDELINES (MUST FOLLOW)
-
-[GUIDELINES from CLAUDE.md/AGENTS.md or Aimi defaults]
-
-## STORY
-
-ID: [STORY_ID]
-Title: [STORY_TITLE]
-Description: [STORY_DESCRIPTION]
-
-## ACCEPTANCE CRITERIA
-
-- [criterion 1]
-- [criterion 2]
-- [criterion N]
-
-## INSTRUCTIONS
-
-1. **FIRST**: Read CLAUDE.md and/or AGENTS.md if they exist for project conventions
-2. Read relevant files to understand current state
-3. Implement the changes to satisfy ALL acceptance criteria
-4. Verify each criterion is met
-5. Run quality checks (typecheck, lint, tests as appropriate)
-6. Commit with message: 'feat(scope): [STORY_TITLE]'
-7. Report success when done
-
-## ON FAILURE
-
-Do NOT claim success. Instead:
-1. Report the failure clearly with:
-   - What failed
-   - Error messages
-   - Suggested fix
-
+[story-executor/SKILL.md prompt template with interpolated values]
 "
 ```
 

--- a/plugins/aimi-engineering/commands/status.md
+++ b/plugins/aimi-engineering/commands/status.md
@@ -13,7 +13,12 @@ Display the current execution progress using the CLI script.
 **CRITICAL:** The CLI script lives in the plugin install directory, NOT the project directory. Resolve it first:
 
 ```bash
+# Glob always finds the latest installed version
 AIMI_CLI=$(ls ~/.claude/plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh 2>/dev/null | tail -1)
+# Fallback to cached cli-path if glob found nothing (edge case)
+if [ -z "$AIMI_CLI" ] && [ -f .aimi/cli-path ] && [ -x "$(cat .aimi/cli-path)" ]; then
+  AIMI_CLI=$(cat .aimi/cli-path)
+fi
 ```
 
 If empty, report: "aimi-cli.sh not found. Reinstall plugin: `/plugin install aimi-engineering`" and STOP.

--- a/plugins/aimi-engineering/commands/status.md
+++ b/plugins/aimi-engineering/commands/status.md
@@ -42,7 +42,7 @@ This returns JSON:
   "failed": 0,
   "skipped": 0,
   "total": 6,
-  "stories": [
+  "userStories": [
     {"id": "US-001", "title": "Story title", "status": "completed", "dependsOn": [], "priority": 1, "notes": ""},
     {"id": "US-002", "title": "Story title", "status": "in_progress", "dependsOn": ["US-001"], "priority": 2, "notes": ""}
   ]

--- a/plugins/aimi-engineering/commands/swarm.md
+++ b/plugins/aimi-engineering/commands/swarm.md
@@ -1,0 +1,430 @@
+---
+name: aimi:swarm
+description: "Execute multiple tasks.json files in parallel Docker sandboxes"
+disable-model-invocation: true
+allowed-tools: Read, Bash(SANDBOX_MGR=*), Bash($SANDBOX_MGR:*), Bash(BUILD_IMG=*), Bash($BUILD_IMG:*), Bash(AIMI_CLI=*), Bash($AIMI_CLI:*), Bash(docker:*), Bash(git:*), Task, Glob, AskUserQuestion
+---
+
+# Aimi Swarm
+
+Execute multiple tasks.json files in parallel Docker sandboxes. Each task file runs inside its own Sysbox-isolated container with a full Claude Code agent executing the story-executor flow.
+
+## Step 0: Resolve Tool Paths
+
+**CRITICAL:** Resolve all tool paths from the plugin install directory first.
+
+```bash
+# CLI script
+AIMI_CLI=$(ls ~/.claude/plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh 2>/dev/null | tail -1)
+if [ -z "$AIMI_CLI" ] && [ -f .aimi/cli-path ] && [ -x "$(cat .aimi/cli-path)" ]; then
+  AIMI_CLI=$(cat .aimi/cli-path)
+fi
+```
+
+If empty, report: "aimi-cli.sh not found. Reinstall plugin: `/plugin install aimi-engineering`" and STOP.
+
+```bash
+# Sandbox manager
+SANDBOX_MGR=$(ls ~/.claude/plugins/cache/*/aimi-engineering/*/skills/docker-sandbox/scripts/sandbox-manager.sh 2>/dev/null | tail -1)
+```
+
+If empty, report: "sandbox-manager.sh not found. Reinstall plugin: `/plugin install aimi-engineering`" and STOP.
+
+```bash
+# Build image script
+BUILD_IMG=$(ls ~/.claude/plugins/cache/*/aimi-engineering/*/skills/docker-sandbox/scripts/build-project-image.sh 2>/dev/null | tail -1)
+```
+
+If empty, report: "build-project-image.sh not found. Reinstall plugin: `/plugin install aimi-engineering`" and STOP.
+
+**Use `$AIMI_CLI`, `$SANDBOX_MGR`, and `$BUILD_IMG` for ALL subsequent script calls.**
+
+## Step 1: Handle Subcommands
+
+Check if `$ARGUMENTS` contains a subcommand:
+
+### `status`
+If arguments start with `status`:
+```bash
+$AIMI_CLI swarm-status
+```
+Format the output as a summary table showing each container's name, task file, branch, status, and story progress. STOP.
+
+### `resume`
+If arguments start with `resume`:
+1. Run `$AIMI_CLI swarm-status` to load existing swarm state
+2. Identify containers with status `pending` or `running`
+3. For containers with status `pending`: they need ACP adapter invocation (jump to Step 5)
+4. For containers with status `running`: check actual Docker status via `$SANDBOX_MGR status <name>`
+   - If Docker says container is still running, report it and skip
+   - If Docker says container exited, update swarm state to `failed` or `completed` based on exit code
+5. If there are still pending containers, proceed to Step 5 for fan-out
+6. If all containers are terminal, report summary and STOP
+
+### `cleanup`
+If arguments start with `cleanup`:
+1. Run `$AIMI_CLI swarm-status` to check for active containers
+2. For each container entry:
+   - Run `$SANDBOX_MGR remove <containerName>` to stop and remove the Docker container
+3. Run `$AIMI_CLI swarm-cleanup` to remove terminal entries from state
+4. Report: "Swarm cleanup complete." STOP.
+
+### Default (no subcommand or `--file`)
+Proceed to Step 2.
+
+## Step 2: Discover Task Files
+
+### Single file mode (`--file` flag)
+If `$ARGUMENTS` contains `--file <path>`:
+- Validate the file exists and ends with `.json`
+- Use that single file as the selection
+- Skip to Step 3
+
+### Multi-select discovery mode
+Glob for task files:
+```bash
+ls -t .aimi/tasks/*-tasks.json 2>/dev/null
+```
+
+If no files found:
+```
+No task files found in .aimi/tasks/. Run /aimi:plan to create a task list first.
+```
+STOP.
+
+Present the discovered files to the user:
+```
+Found [N] task file(s):
+
+  1. .aimi/tasks/2026-03-01-feature-auth-tasks.json (feat/auth, 5 stories)
+  2. .aimi/tasks/2026-03-01-feature-ui-tasks.json (feat/ui, 3 stories)
+  3. .aimi/tasks/2026-03-01-bugfix-login-tasks.json (bug/login, 2 stories)
+
+Select files to execute (comma-separated numbers, or "all"):
+```
+
+For each file, extract metadata with:
+```bash
+jq -r '.metadata | "\(.branchName) — \(.title)"' <file>
+```
+
+And count stories:
+```bash
+jq '[.userStories[] | select(.status == "pending")] | length' <file>
+```
+
+Use `AskUserQuestion` to get the selection. Parse the response:
+- `all` -> select all files
+- `1,3` -> select files 1 and 3
+- `1` -> select file 1
+
+Validate the selection. If invalid, ask again.
+
+Store the selected files as `SELECTED_TASK_FILES`.
+
+### Max containers limit
+
+Read `maxContainers` from context. Default: **4**.
+
+If the user provides `--max <N>` in arguments, use that value instead.
+
+If `len(SELECTED_TASK_FILES) > maxContainers`:
+```
+Selected [N] task files but maxContainers is [maxContainers].
+Only the first [maxContainers] will be executed. Remaining files can be run with /aimi:swarm resume.
+```
+
+Truncate `SELECTED_TASK_FILES` to `maxContainers`.
+
+## Step 3: Initialize Swarm State
+
+### Check for existing active swarm
+```bash
+$AIMI_CLI swarm-status 2>/dev/null
+```
+
+If an active swarm exists with running/pending containers, ask the user:
+```
+An active swarm exists with [N] running/pending containers.
+
+Options:
+  1. Resume existing swarm (add new tasks alongside)
+  2. Force reinitialize (stops existing containers)
+  3. Cancel
+
+Select option:
+```
+
+- Option 1: Proceed without reinitializing, add new containers to existing state
+- Option 2: Run cleanup first, then reinitialize
+- Option 3: STOP
+
+### Initialize new swarm state
+```bash
+$AIMI_CLI swarm-init
+```
+
+If using `--force` (option 2 above):
+```bash
+$AIMI_CLI swarm-init --force
+```
+
+Store the returned `swarmId`.
+
+### Resolve git remote URL
+```bash
+git remote get-url origin
+```
+
+Store as `REPO_URL`. If no remote, report error and STOP:
+```
+No git remote 'origin' found. The swarm needs a remote URL so containers can clone the repo.
+Set one with: git remote add origin <url>
+```
+
+Report:
+```
+Swarm initialized: [swarmId]
+Task files: [count]
+Max containers: [maxContainers]
+```
+
+## Step 4: Provision Containers
+
+### Check Sysbox runtime
+```bash
+$SANDBOX_MGR check-runtime
+```
+
+If Sysbox is not available, report the error and STOP.
+
+### Build project image
+```bash
+$BUILD_IMG
+```
+
+This builds (or reuses) `aimi-sandbox-<project-slug>:latest`. Store the image tag from the output.
+
+Parse the image tag from the build output. The script logs `Image tag    : <tag>` or `Done. Image: <tag>`. Extract the tag value and store as `PROJECT_IMAGE`.
+
+### Create containers sequentially
+
+For each task file in `SELECTED_TASK_FILES`:
+1. Read metadata:
+   ```bash
+   jq -r '.metadata.branchName' <taskFile>
+   ```
+   Store as `BRANCH`.
+
+2. Derive container name from the task file:
+   - Extract the feature slug from the filename (e.g., `2026-03-01-feature-auth-tasks.json` -> `feature-auth`)
+   - Container name: `aimi-swarm-<slug>` (must match `^aimi-[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
+
+3. Create the container:
+   ```bash
+   $SANDBOX_MGR create <containerName> --image <PROJECT_IMAGE> --task-file <taskFile> --branch <BRANCH>
+   ```
+
+4. Parse the JSON output to get `containerId`.
+
+5. Register in swarm state:
+   ```bash
+   $AIMI_CLI swarm-add <containerId> <containerName> <taskFile> <BRANCH>
+   ```
+
+6. Count stories for progress tracking:
+   ```bash
+   jq '.userStories | length' <taskFile>
+   ```
+   Update initial story progress:
+   ```bash
+   $AIMI_CLI swarm-update <containerName> --status pending --story-progress '{"total":<N>,"completed":0,"failed":0,"inProgress":0,"pending":<N>}'
+   ```
+
+Report container creation:
+```
+Provisioned [N] containers:
+  - [containerName]: [taskFile] ([branch])
+  ...
+```
+
+If any container creation fails, mark it as `failed` in swarm state and continue with the rest. Report which containers failed.
+
+## Step 5: Fan Out — Parallel ACP Adapter Invocations
+
+**CRITICAL:** This step spawns one Task agent per container. All Task calls MUST be emitted in a SINGLE tool-call turn so they execute concurrently.
+
+For each container with status `pending` in the swarm state:
+
+1. First, update its status to `running`:
+   ```bash
+   $AIMI_CLI swarm-update <containerName> --status running
+   ```
+
+2. Build the ACP task-request payload:
+   ```json
+   {
+     "type": "task-request",
+     "timestamp": "<ISO 8601 now>",
+     "swarmId": "<swarmId>",
+     "containerId": "<containerId>",
+     "payload": {
+       "taskFilePath": "<taskFile>",
+       "branchName": "<branch>",
+       "repoUrl": "<REPO_URL>"
+     }
+   }
+   ```
+
+3. Spawn a Task agent for this container. In a SINGLE tool-call turn, emit ALL Task calls:
+
+```
+Task(
+    subagent_type: "general-purpose",
+    description: "Swarm worker: [containerName] executing [taskFile]",
+    prompt: """
+You are a swarm worker agent managing a Docker sandbox container.
+
+## Container Info
+- Name: [containerName]
+- Container ID: [containerId]
+- Task File: [taskFile]
+- Branch: [branch]
+- Swarm ID: [swarmId]
+
+## Your Job
+
+1. Send the task-request payload to the ACP adapter inside the container via docker exec:
+
+```bash
+echo '<task-request-json>' | docker exec -i [containerName] python3 /opt/aimi/acp-adapter.py
+```
+
+2. Read the NDJSON output lines from stdout. Each line is a JSON message.
+
+3. For each message received:
+   - **progress-update**: Log the story ID and status. If you can parse story progress counts, report them.
+   - **completion**: Record the final status and PR URL (if any). This is the last message.
+   - **error**: Record the error code and message. The container may exit after this.
+
+4. When the process exits (docker exec returns):
+   - If exit code 0 and last message was completion with status "completed": report SUCCESS
+   - If exit code non-zero or last message was error/failed: report FAILURE with details
+   - Capture the last 20 lines of output for the summary
+
+5. Report your result as a structured summary:
+```
+SWARM_WORKER_RESULT:
+container: [containerName]
+taskFile: [taskFile]
+branch: [branch]
+status: [completed|failed|stopped]
+prUrl: [url or null]
+errors: [list or empty]
+```
+
+Do NOT modify the tasks.json file. Do NOT modify swarm-state.json. Just run the docker exec and report results.
+"""
+)
+```
+
+**All Task calls must be in ONE tool-call turn.** Wait for all to return.
+
+## Step 6: Collect Results and Update State
+
+After ALL Task agents return, process each result:
+
+### Parse results
+
+For each Task agent result, look for the `SWARM_WORKER_RESULT:` block and parse:
+- `container`: container name
+- `status`: completed, failed, or stopped
+- `prUrl`: PR URL or null
+- `errors`: error list
+
+### Update swarm state
+
+For each result:
+
+```bash
+$AIMI_CLI swarm-update <containerName> --status <status>
+```
+
+If a PR URL was returned:
+```bash
+$AIMI_CLI swarm-update <containerName> --status <status> --pr-url <prUrl>
+```
+
+### Remove containers
+
+For each container (success or failure):
+```bash
+$SANDBOX_MGR remove <containerName>
+```
+
+### Report summary
+
+```
+## Swarm Execution Complete
+
+Swarm ID: [swarmId]
+Duration: [estimated from timestamps]
+
+### Results
+
+| Container | Task File | Branch | Status | PR |
+|-----------|-----------|--------|--------|-----|
+| [name] | [file] | [branch] | completed | [PR URL] |
+| [name] | [file] | [branch] | failed | - |
+...
+
+### Summary
+- Total: [N] containers
+- Completed: [N]
+- Failed: [N]
+
+### Failed Containers
+[For each failed container, show error details]
+
+### Next Steps
+- Review PRs: [list PR URLs]
+- Check failures: `/aimi:swarm status`
+- Clean up: `/aimi:swarm cleanup`
+```
+
+## Error Recovery
+
+### Container creation failure
+If `$SANDBOX_MGR create` fails for a specific container:
+- Mark it as `failed` in swarm state
+- Continue with remaining containers
+- Report the failure in the summary
+
+### ACP adapter failure
+If `docker exec` fails or returns non-zero:
+- Parse any error messages from the output
+- Mark the container as `failed` in swarm state
+- Continue processing other containers
+
+### Partial failure
+Successful containers proceed independently. Failed containers are marked in state. The user can:
+- Review failures: `/aimi:swarm status`
+- Fix and retry individual task files: `/aimi:swarm --file <path>`
+- Clean up: `/aimi:swarm cleanup`
+
+### Interrupted swarm
+If the swarm is interrupted (e.g., user stops the command):
+- Containers continue running in Docker (they are detached)
+- User can resume: `/aimi:swarm resume`
+- User can check status: `/aimi:swarm status`
+- User can clean up: `/aimi:swarm cleanup`
+
+## Resuming Execution
+
+Running `/aimi:swarm resume`:
+1. Loads existing swarm state
+2. Checks each container's actual Docker status
+3. For pending containers: starts ACP adapter invocation
+4. For running containers: waits or checks completion
+5. For terminal containers: updates state if needed
+6. Reports summary when all containers are terminal

--- a/plugins/aimi-engineering/hooks/auto-approve-cli.sh
+++ b/plugins/aimi-engineering/hooks/auto-approve-cli.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # auto-approve-cli.sh
-# Auto-approves only AIMI CLI resolution and invocation commands.
+# Auto-approves only AIMI CLI and Worktree Manager resolution and invocation commands.
+# Rejects shell metacharacter chaining and enforces subcommand whitelists.
 
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
@@ -11,17 +12,92 @@ fi
 
 ALLOW='{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"allow"}}}'
 
-# Pattern 1: CLI path resolution (AIMI_CLI=$(ls ~/.claude/plugins/...))
+# --- Helper: Reject shell metacharacters ---
+# Returns 0 (true) if dangerous metacharacters are found after the variable reference.
+has_metacharacters() {
+  local cmd="$1"
+  # Check for: ; && || | $() `` (backticks)
+  if echo "$cmd" | grep -qE ';|&&|\|\||`|\$\('; then
+    return 0
+  fi
+  # Check for pipe (|) that is NOT part of || (already caught above)
+  # We need to check for standalone | that isn't ||
+  if echo "$cmd" | grep -qE '\|' && ! echo "$cmd" | grep -qE '\|\|'; then
+    return 0
+  fi
+  return 1
+}
+
+# --- Pattern 1: AIMI_CLI= assignment ---
+# Validates the assigned path matches the expected plugin cache pattern.
 if echo "$COMMAND" | grep -qE '^AIMI_CLI='; then
-  echo "$ALLOW"
+  if echo "$COMMAND" | grep -qE '^AIMI_CLI=\$\(ls ~/.claude/plugins/cache/[a-zA-Z0-9_-]+/aimi-engineering/[a-zA-Z0-9._-]+/scripts/aimi-cli\.sh\)$'; then
+    echo "$ALLOW"
+    exit 0
+  fi
+  # Invalid path pattern — fall through to normal permission prompt
   exit 0
 fi
 
-# Pattern 2: CLI invocation ($AIMI_CLI ...)
+# --- Pattern 2: $AIMI_CLI invocation with subcommand whitelist ---
 if echo "$COMMAND" | grep -qE '^\$AIMI_CLI\b|^\$\{AIMI_CLI\}'; then
-  echo "$ALLOW"
+  # Reject any shell metacharacters
+  if has_metacharacters "$COMMAND"; then
+    exit 0
+  fi
+
+  # Extract the subcommand (first argument after $AIMI_CLI or ${AIMI_CLI})
+  SUBCMD=$(echo "$COMMAND" | sed -E 's/^\$AIMI_CLI\s+//; s/^\$\{AIMI_CLI\}\s+//' | awk '{print $1}')
+
+  # Whitelist of allowed CLI subcommands
+  case "$SUBCMD" in
+    init-session|find-tasks|status|metadata|next-story|current-story|\
+    list-ready|mark-in-progress|mark-complete|mark-failed|mark-skipped|\
+    count-pending|validate-deps|validate-stories|cascade-skip|\
+    get-branch|get-state|clear-state|help)
+      echo "$ALLOW"
+      exit 0
+      ;;
+    *)
+      # Unknown subcommand — fall through to normal permission prompt
+      exit 0
+      ;;
+  esac
+fi
+
+# --- Pattern 3: WORKTREE_MGR= assignment ---
+# Validates the assigned path matches the expected worktree manager plugin path.
+if echo "$COMMAND" | grep -qE '^WORKTREE_MGR='; then
+  if echo "$COMMAND" | grep -qE '^WORKTREE_MGR=\$\(ls ~/.claude/plugins/cache/[a-zA-Z0-9_-]+/aimi-engineering/[a-zA-Z0-9._-]+/skills/git-worktree/scripts/worktree-manager\.sh\)$'; then
+    echo "$ALLOW"
+    exit 0
+  fi
+  # Invalid path pattern — fall through to normal permission prompt
   exit 0
 fi
 
-# Everything else — normal permission prompt
+# --- Pattern 4: $WORKTREE_MGR invocation with subcommand whitelist ---
+if echo "$COMMAND" | grep -qE '^\$WORKTREE_MGR\b|^\$\{WORKTREE_MGR\}'; then
+  # Reject any shell metacharacters
+  if has_metacharacters "$COMMAND"; then
+    exit 0
+  fi
+
+  # Extract the subcommand (first argument after $WORKTREE_MGR or ${WORKTREE_MGR})
+  SUBCMD=$(echo "$COMMAND" | sed -E 's/^\$WORKTREE_MGR\s+//; s/^\$\{WORKTREE_MGR\}\s+//' | awk '{print $1}')
+
+  # Whitelist of allowed worktree manager subcommands
+  case "$SUBCMD" in
+    create|remove|merge|list|help)
+      echo "$ALLOW"
+      exit 0
+      ;;
+    *)
+      # Unknown subcommand — fall through to normal permission prompt
+      exit 0
+      ;;
+  esac
+fi
+
+# --- Everything else — normal permission prompt ---
 exit 0

--- a/plugins/aimi-engineering/hooks/auto-approve-cli.sh
+++ b/plugins/aimi-engineering/hooks/auto-approve-cli.sh
@@ -53,7 +53,7 @@ if echo "$COMMAND" | grep -qE '^\$AIMI_CLI\b|^\$\{AIMI_CLI\}'; then
   case "$SUBCMD" in
     init-session|find-tasks|status|metadata|next-story|current-story|\
     list-ready|mark-in-progress|mark-complete|mark-failed|mark-skipped|\
-    count-pending|validate-deps|validate-stories|cascade-skip|\
+    count-pending|validate-deps|validate-stories|cascade-skip|reset-orphaned|\
     get-branch|get-state|clear-state|help)
       echo "$ALLOW"
       exit 0

--- a/plugins/aimi-engineering/skills/docker-sandbox/SKILL.md
+++ b/plugins/aimi-engineering/skills/docker-sandbox/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: docker-sandbox
+description: "Provision and manage Docker sandbox containers for parallel task execution. Provides Sysbox-isolated environments where Claude Code agents execute story-executor flows autonomously. Triggers on: swarm, sandbox, parallel docker, container execution."
+user-invocable: false
+---
+
+# Docker Sandbox
+
+Provision Sysbox-isolated Docker containers that run Claude Code agents autonomously, one container per task file, with ACP (Agent Communication Protocol) for orchestrator-to-container communication.
+
+---
+
+## The Job
+
+Provide the infrastructure layer for `/aimi:swarm`: container lifecycle management, image building, and ACP message transport. Each task file gets its own sandbox container with a full agent running the story-executor flow inside it.
+
+---
+
+## Prerequisites
+
+| Requirement | How to Check | Install Guide |
+|-------------|-------------|---------------|
+| Docker Engine | `docker version` | [docs.docker.com/engine/install](https://docs.docker.com/engine/install/) |
+| Sysbox runtime | `docker info --format '{{.Runtimes}}'` must include `sysbox-runc` | [github.com/nestybox/sysbox](https://github.com/nestybox/sysbox#installation) |
+| `ANTHROPIC_API_KEY` env var | `echo $ANTHROPIC_API_KEY` | Set in shell profile or `.env` |
+| Git remote `origin` | `git remote get-url origin` | `git remote add origin <url>` |
+| Optional: `GITHUB_TOKEN` | `echo $GITHUB_TOKEN` | Needed for PR creation inside containers |
+
+**Sysbox is a hard requirement.** It enables secure nested Docker (Docker-in-Docker) without `--privileged` mode. Containers run with user-namespace isolation — root inside the container maps to an unprivileged user on the host.
+
+---
+
+## Components
+
+### Scripts
+
+| Script | Location | Purpose |
+|--------|----------|---------|
+| `sandbox-manager.sh` | `skills/docker-sandbox/scripts/` | Container lifecycle: create, remove, list, status, cleanup, check-runtime |
+| `build-project-image.sh` | `skills/docker-sandbox/scripts/` | Build per-project Docker image with checksum-based rebuild skipping |
+| `acp-adapter.py` | `skills/docker-sandbox/scripts/` | ACP protocol handler inside containers — reads task-request from stdin, runs Claude Code CLI, streams progress via stdout |
+
+### Docker
+
+| File | Location | Purpose |
+|------|----------|---------|
+| `Dockerfile.base` | `skills/docker-sandbox/docker/` | Base image with Claude Code CLI, git, Node.js, Python |
+| `Dockerfile.project.template` | `skills/docker-sandbox/docker/` | Template for per-project image layer (project files, dependencies) |
+
+### Command
+
+| Command | File | Purpose |
+|---------|------|---------|
+| `/aimi:swarm` | `commands/swarm.md` | Orchestration entry point — discovery, provisioning, fan-out, result collection |
+
+### CLI Extensions
+
+These subcommands are added to `aimi-cli.sh`:
+
+| Subcommand | Purpose |
+|------------|---------|
+| `swarm-init` | Initialize swarm state file |
+| `swarm-add` | Register a container in swarm state |
+| `swarm-update` | Update container status and progress |
+| `swarm-remove` | Remove a container entry from state |
+| `swarm-status` | Read current swarm state |
+| `swarm-list` | List active containers |
+| `swarm-cleanup` | Remove terminal entries from state |
+
+---
+
+## Architecture Overview
+
+See [references/architecture.md](./references/architecture.md) for the full architecture diagram.
+
+### Key Design Decisions
+
+1. **One container per task file** — complete isolation between features
+2. **Sysbox runtime** — secure nested Docker without `--privileged`
+3. **ACP over stdio** — JSON-lines over `docker exec -i` pipes (no network ports)
+4. **Layered images** — base `aimi-sandbox` + per-project layer with checksum-based caching
+5. **File-based state** — `swarm-state.json` with `flock` advisory locking
+6. **State reconciliation** — automatic zombie detection before status and resume
+
+---
+
+## Execution Flow
+
+1. `/aimi:swarm` discovers task files, user selects which to execute
+2. `build-project-image.sh` builds (or reuses) per-project Docker image
+3. `sandbox-manager.sh create` provisions Sysbox-isolated containers
+4. `swarm-init` / `swarm-add` register containers in `swarm-state.json`
+5. Parallel Task agents invoke `docker exec -i <container> python3 /opt/aimi/acp-adapter.py`
+6. ACP adapter receives `task-request`, runs Claude Code CLI headless inside container
+7. Container streams `progress-update` messages as stories complete
+8. Container sends `completion` message when all stories finish
+9. Orchestrator collects results, updates swarm state, removes containers
+
+---
+
+## Available Capabilities for Task-Spawned Agents
+
+Agents spawned by `/aimi:swarm` as swarm workers have access to:
+
+| Tool | Purpose |
+|------|---------|
+| `Bash` | Run `docker exec`, `$SANDBOX_MGR`, `$BUILD_IMG`, `$AIMI_CLI` commands |
+| `Read` | Read task files and swarm state |
+| `Glob` | Discover task files |
+
+Workers do NOT modify `tasks.json` or `swarm-state.json` directly. They run `docker exec` to invoke the ACP adapter and report results back to the orchestrator.
+
+---
+
+## State Management
+
+### Swarm State File
+
+Location: `.aimi/swarm-state.json`
+
+Tracks all containers in the current swarm. See [references/swarm-state-schema.json](./references/swarm-state-schema.json) for the full JSON Schema.
+
+### Container Status Lifecycle
+
+```
+pending -> running -> completed
+                   -> failed
+                   -> stopped
+```
+
+### State Reconciliation
+
+Runs automatically before `status` display and `resume` operations. Compares `swarm-state.json` entries against actual Docker daemon state via `sandbox-manager.sh status`.
+
+Detects: zombie entries, silent completions, silent failures, unexpected stops, already-started containers. See [references/architecture.md](./references/architecture.md) for details.
+
+---
+
+## ACP Message Protocol
+
+Transport: JSON-lines (NDJSON) over `docker exec -i` stdin/stdout pipes.
+
+Four message types:
+
+| Type | Direction | Purpose |
+|------|-----------|---------|
+| `task-request` | Orchestrator -> Container | Assign task file and branch |
+| `progress-update` | Container -> Orchestrator | Report story status changes |
+| `completion` | Container -> Orchestrator | Final container result |
+| `error` | Container -> Orchestrator | Non-recoverable container error |
+
+See [references/acp-messages.md](./references/acp-messages.md) for full message schemas and validation rules.
+
+---
+
+## Resource Limits
+
+Container resource limits are configurable via environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AIMI_SANDBOX_CPUS` | `2` | CPU cores per container |
+| `AIMI_SANDBOX_MEMORY` | `4g` | Memory limit per container |
+| `AIMI_SANDBOX_SWAP` | `4g` | Swap limit per container |
+| `AIMI_SANDBOX_DISK` | `8g` | Disk limit per container |
+
+---
+
+## Input Sanitization
+
+### Container Names
+
+Container names must match: `^aimi-[a-zA-Z0-9][a-zA-Z0-9_-]*$`
+
+Validation rules:
+- Must start with the `aimi-` prefix
+- After prefix, must start with an alphanumeric character
+- Only alphanumeric characters, hyphens, and underscores allowed after that
+- No spaces, dots, or special characters
+- Validated by `sandbox-manager.sh` before any Docker operation
+
+### Task File Paths
+
+Task file paths are validated before use:
+- Must end with `.json`
+- Must exist on disk (checked before container creation)
+- Must be a relative path (no absolute paths or `..` traversal)
+- Must be under `.aimi/tasks/` directory
+- Path traversal patterns (`..`, `~`, `$`) are rejected
+
+### Branch Names
+
+Branch names must match: `^[a-zA-Z0-9][a-zA-Z0-9/_-]*$`
+
+This is the same validation used by `aimi-cli.sh` for all git branch operations.
+
+### Environment Variable Keys
+
+When passed via ACP `task-request.payload.envVars`:
+- Keys must match `^[A-Z_][A-Z0-9_]*$`
+- Values must be strings (no command substitution allowed)
+
+---
+
+## Auto-Approve Hooks
+
+The following patterns are auto-approved in `hooks/auto-approve-cli.sh`:
+
+- `$SANDBOX_MGR` with subcommand whitelist: `create`, `remove`, `list`, `status`, `cleanup`, `check-runtime`
+- `$BUILD_IMG` with path validation
+- `$AIMI_CLI swarm-*` subcommands
+- `docker exec -i aimi-*` for ACP adapter communication (restricted to `aimi-` prefixed containers running `python3 /opt/aimi/acp-adapter.py`)
+
+---
+
+## References
+
+| Document | Description |
+|----------|-------------|
+| [architecture.md](./references/architecture.md) | Architecture overview with ASCII diagram |
+| [swarm-state-schema.json](./references/swarm-state-schema.json) | JSON Schema for swarm-state.json |
+| [acp-messages.md](./references/acp-messages.md) | ACP message types, schemas, and validation |
+| [example-swarm-state.json](./references/example-swarm-state.json) | Example swarm state file |
+| [example-acp-messages.json](./references/example-acp-messages.json) | Example ACP message payloads |

--- a/plugins/aimi-engineering/skills/docker-sandbox/docker/.dockerignore
+++ b/plugins/aimi-engineering/skills/docker-sandbox/docker/.dockerignore
@@ -1,0 +1,52 @@
+# =============================================================================
+# .dockerignore — aimi-sandbox Docker build context
+# =============================================================================
+# Exclude files that should never be sent to the Docker daemon during builds.
+
+# Version control
+.git
+.gitignore
+
+# Environment and secrets — never bake into images
+.env
+.env.*
+*.pem
+*.key
+credentials.json
+
+# OS artifacts
+.DS_Store
+Thumbs.db
+
+# Editor and IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Node.js
+node_modules/
+npm-debug.log*
+yarn-error.log*
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+.venv/
+venv/
+
+# Build artifacts
+dist/
+build/
+*.tar.gz
+
+# Documentation (not needed in image)
+*.md
+!README.md
+LICENSE
+
+# Test fixtures and coverage
+coverage/
+.nyc_output/

--- a/plugins/aimi-engineering/skills/docker-sandbox/docker/Dockerfile.base
+++ b/plugins/aimi-engineering/skills/docker-sandbox/docker/Dockerfile.base
@@ -1,0 +1,119 @@
+# =============================================================================
+# Dockerfile.base — aimi-sandbox base image
+# =============================================================================
+# Base image for aimi-sandbox containers. Per-project images (Dockerfile.project)
+# layer on top of this with project-specific dependencies.
+#
+# Included tools:
+#   - Git, curl, jq
+#   - Node.js 20 LTS (from base image)
+#   - Python 3.12
+#   - Docker CLI + Docker Compose plugin (daemon provided by Sysbox)
+#   - GitHub CLI (gh)
+#   - Claude Code CLI (via npm)
+#
+# Build:
+#   docker build -f Dockerfile.base -t aimi-sandbox:base .
+# =============================================================================
+
+FROM node:20-slim AS base
+
+LABEL maintainer="aimi-engineering"
+LABEL description="Base image for aimi-sandbox with common development tools"
+
+# ---------------------------------------------------------------------------
+# Environment variables
+# ---------------------------------------------------------------------------
+# Placeholders — set at container runtime, never bake real secrets into images
+ENV ANTHROPIC_API_KEY=""
+ENV GITHUB_TOKEN=""
+ENV IS_SANDBOX=1
+
+# Prevent interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# ---------------------------------------------------------------------------
+# System packages: git, curl, jq, Python 3.12, GPG utilities
+# ---------------------------------------------------------------------------
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        gnupg \
+        jq \
+        lsb-release \
+        openssh-client \
+        python3 \
+        python3-pip \
+        python3-venv \
+        sudo \
+        unzip \
+        wget \
+    && rm -rf /var/lib/apt/lists/*
+
+# ---------------------------------------------------------------------------
+# Docker CLI + Docker Compose plugin
+# Only the CLI — the daemon is provided by the Sysbox runtime on the host.
+# ---------------------------------------------------------------------------
+RUN install -m 0755 -d /etc/apt/keyrings \
+    && curl -fsSL https://download.docker.com/linux/debian/gpg \
+       | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
+    && chmod a+r /etc/apt/keyrings/docker.gpg \
+    && echo \
+       "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
+       https://download.docker.com/linux/debian \
+       $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+       > /etc/apt/sources.list.d/docker.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        docker-ce-cli \
+        docker-compose-plugin \
+    && rm -rf /var/lib/apt/lists/*
+
+# ---------------------------------------------------------------------------
+# GitHub CLI (gh)
+# ---------------------------------------------------------------------------
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+       | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo \
+       "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] \
+       https://cli.github.com/packages stable main" \
+       > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends gh \
+    && rm -rf /var/lib/apt/lists/*
+
+# ---------------------------------------------------------------------------
+# Claude Code CLI (installed globally via npm)
+# ---------------------------------------------------------------------------
+RUN npm install -g @anthropic-ai/claude-code && npm cache clean --force
+
+# ---------------------------------------------------------------------------
+# Non-root user: aimi (UID 1001)
+# ---------------------------------------------------------------------------
+RUN groupadd --gid 1001 aimi \
+    && useradd --uid 1001 --gid 1001 --create-home --shell /bin/bash aimi \
+    && echo "aimi ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/aimi \
+    && chmod 0440 /etc/sudoers.d/aimi
+
+# Give aimi user access to docker socket (when mounted)
+RUN groupadd -f docker && usermod -aG docker aimi
+
+# ---------------------------------------------------------------------------
+# Workspace
+# ---------------------------------------------------------------------------
+RUN mkdir -p /workspace && chown aimi:aimi /workspace
+WORKDIR /workspace
+
+# Switch to non-root user
+USER aimi
+
+# ---------------------------------------------------------------------------
+# Healthcheck — verify Claude Code CLI is available
+# ---------------------------------------------------------------------------
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD which claude || exit 1
+
+# Default entrypoint
+CMD ["bash"]

--- a/plugins/aimi-engineering/skills/docker-sandbox/docker/Dockerfile.project.template
+++ b/plugins/aimi-engineering/skills/docker-sandbox/docker/Dockerfile.project.template
@@ -1,0 +1,47 @@
+# =============================================================================
+# Dockerfile.project.template — per-project aimi-sandbox image
+# =============================================================================
+# Layers project-specific dependencies on top of the aimi-sandbox base image.
+#
+# Users copy this template to their project root as:
+#   .aimi/Dockerfile.sandbox
+#
+# Then customise the COPY and RUN directives for their project. The build
+# script (scripts/build-project-image.sh) picks it up automatically.
+#
+# IMPORTANT: The FROM line MUST reference aimi-sandbox — the build script
+# validates this before building.
+# =============================================================================
+
+FROM aimi-sandbox:base
+
+# ---------------------------------------------------------------------------
+# Project-specific system packages (uncomment / edit as needed)
+# ---------------------------------------------------------------------------
+# USER root
+# RUN apt-get update && apt-get install -y --no-install-recommends \
+#         <your-packages-here> \
+#     && rm -rf /var/lib/apt/lists/*
+# USER aimi
+
+# ---------------------------------------------------------------------------
+# Project dependency files — copy lockfiles first for layer caching
+# ---------------------------------------------------------------------------
+# COPY package.json package-lock.json ./
+# COPY requirements.txt ./
+
+# ---------------------------------------------------------------------------
+# Install project dependencies
+# ---------------------------------------------------------------------------
+# RUN npm ci --ignore-scripts
+# RUN pip install --no-cache-dir -r requirements.txt
+
+# ---------------------------------------------------------------------------
+# Copy project source (optional — usually bind-mounted at runtime instead)
+# ---------------------------------------------------------------------------
+# COPY . .
+
+# ---------------------------------------------------------------------------
+# Default working directory (inherited from base: /workspace)
+# ---------------------------------------------------------------------------
+WORKDIR /workspace

--- a/plugins/aimi-engineering/skills/docker-sandbox/references/acp-messages.md
+++ b/plugins/aimi-engineering/skills/docker-sandbox/references/acp-messages.md
@@ -1,0 +1,245 @@
+# ACP Message Schema Reference
+
+Agent Communication Protocol (ACP) messages are JSON payloads exchanged between the swarm orchestrator and sandbox containers. Every message has a `type` field that determines its shape.
+
+---
+
+## Message Envelope
+
+All ACP messages share a common envelope:
+
+```json
+{
+  "type": "string",
+  "timestamp": "ISO 8601 date-time",
+  "swarmId": "UUID v4",
+  "containerId": "Docker container ID"
+}
+```
+
+| Field         | Type   | Required | Description                                      |
+|---------------|--------|----------|--------------------------------------------------|
+| `type`        | string | Yes      | Message type discriminator                        |
+| `timestamp`   | string | Yes      | ISO 8601 timestamp when the message was created   |
+| `swarmId`     | string | Yes      | UUID of the swarm this message belongs to          |
+| `containerId` | string | Yes      | Docker container ID that sent or receives the msg  |
+
+---
+
+## Message Types
+
+### 1. `task-request`
+
+**Direction:** Orchestrator -> Container
+
+Sent by the orchestrator to assign a task file to a sandbox container. The container reads the task file and begins executing stories.
+
+#### Schema
+
+```json
+{
+  "type": "task-request",
+  "timestamp": "2026-03-01T10:00:00Z",
+  "swarmId": "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+  "containerId": "abc123def456",
+  "payload": {
+    "taskFilePath": ".aimi/tasks/2026-03-01-feature-tasks.json",
+    "branchName": "feat/my-feature",
+    "repoUrl": "https://github.com/org/repo.git",
+    "envVars": {
+      "NODE_ENV": "development",
+      "DATABASE_URL": "postgres://localhost:5432/dev"
+    }
+  }
+}
+```
+
+#### Payload Fields
+
+| Field          | Type   | Required | Description                                                        |
+|----------------|--------|----------|--------------------------------------------------------------------|
+| `taskFilePath` | string | Yes      | Relative path to the tasks.json file to execute                     |
+| `branchName`   | string | Yes      | Git branch to check out and work on. Must match `^[a-zA-Z0-9][a-zA-Z0-9/_-]*$` |
+| `repoUrl`      | string | Yes      | Git remote URL to clone inside the container                        |
+| `envVars`      | object | No       | Key-value pairs of environment variables to set in the container. Keys and values must be strings. Defaults to `{}` |
+
+#### Validation
+
+- `branchName` must match `^[a-zA-Z0-9][a-zA-Z0-9/_-]*$`
+- `taskFilePath` must end with `.json`
+- `repoUrl` must be a valid URL (https or ssh)
+- `envVars` keys must match `^[A-Z_][A-Z0-9_]*$`
+
+---
+
+### 2. `progress-update`
+
+**Direction:** Container -> Orchestrator
+
+Sent by a container when a story's status changes. The orchestrator uses this to update `swarm-state.json`.
+
+#### Schema
+
+```json
+{
+  "type": "progress-update",
+  "timestamp": "2026-03-01T10:05:00Z",
+  "swarmId": "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+  "containerId": "abc123def456",
+  "payload": {
+    "storyId": "US-001",
+    "status": "completed",
+    "output": "Migration created and applied. Schema validated. Typecheck passes."
+  }
+}
+```
+
+#### Payload Fields
+
+| Field     | Type   | Required | Description                                                    |
+|-----------|--------|----------|----------------------------------------------------------------|
+| `storyId` | string | Yes      | ID of the story being reported on (e.g., `US-001`)              |
+| `status`  | string | Yes      | New story status. One of: `pending`, `in_progress`, `completed`, `failed`, `skipped` |
+| `output`  | string | Yes      | Human-readable summary of what happened (max 2000 chars)        |
+
+#### Validation
+
+- `storyId` must match `^US-\d{3}$`
+- `status` must be one of: `pending`, `in_progress`, `completed`, `failed`, `skipped`
+- `output` must not exceed 2000 characters
+
+---
+
+### 3. `completion`
+
+**Direction:** Container -> Orchestrator
+
+Sent by a container when it finishes all assigned stories (success or failure). This is the final message a container sends before exiting.
+
+#### Schema
+
+```json
+{
+  "type": "completion",
+  "timestamp": "2026-03-01T11:30:00Z",
+  "swarmId": "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+  "containerId": "abc123def456",
+  "payload": {
+    "status": "completed",
+    "prUrl": "https://github.com/org/repo/pull/42",
+    "errors": []
+  }
+}
+```
+
+#### Payload Fields
+
+| Field    | Type     | Required | Description                                                                |
+|----------|----------|----------|----------------------------------------------------------------------------|
+| `status` | string   | Yes      | Final container status. One of: `completed`, `failed`, `stopped`            |
+| `prUrl`  | string or null | Yes | URL of the pull request created, or `null` if no PR was created             |
+| `errors` | array    | Yes      | Array of error strings encountered during execution. Empty array if none    |
+
+#### Validation
+
+- `status` must be one of: `completed`, `failed`, `stopped`
+- `prUrl` must be a valid URL or `null`
+- Each entry in `errors` must be a string (max 500 chars per entry, max 50 entries)
+
+#### Status Meanings
+
+| Status      | Meaning                                                     |
+|-------------|-------------------------------------------------------------|
+| `completed` | All stories finished (some may have failed individually)     |
+| `failed`    | Container-level failure (crash, resource exhaustion, etc.)   |
+| `stopped`   | Container was explicitly stopped by orchestrator or user     |
+
+---
+
+### 4. `error`
+
+**Direction:** Container -> Orchestrator
+
+Sent by a container when a non-recoverable error occurs. Unlike `progress-update` with `failed` status (which is story-level), this indicates a container-level problem.
+
+#### Schema
+
+```json
+{
+  "type": "error",
+  "timestamp": "2026-03-01T10:15:00Z",
+  "swarmId": "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+  "containerId": "abc123def456",
+  "payload": {
+    "code": "CONTAINER_OOM",
+    "message": "Container exceeded memory limit (4GB). Process killed by OOM killer."
+  }
+}
+```
+
+#### Payload Fields
+
+| Field     | Type   | Required | Description                                              |
+|-----------|--------|----------|----------------------------------------------------------|
+| `code`    | string | Yes      | Machine-readable error code (SCREAMING_SNAKE_CASE)        |
+| `message` | string | Yes      | Human-readable error description (max 2000 chars)         |
+
+#### Standard Error Codes
+
+| Code                   | Description                                          |
+|------------------------|------------------------------------------------------|
+| `CONTAINER_OOM`        | Container ran out of memory                           |
+| `CONTAINER_TIMEOUT`    | Container exceeded execution time limit               |
+| `GIT_CLONE_FAILED`     | Failed to clone the repository                        |
+| `GIT_CHECKOUT_FAILED`  | Failed to check out the specified branch              |
+| `TASK_FILE_NOT_FOUND`  | The specified task file does not exist                 |
+| `TASK_FILE_INVALID`    | The task file failed schema validation                |
+| `ACP_CONNECTION_LOST`  | Lost connection to the orchestrator                   |
+| `AGENT_CRASH`          | The agent process inside the container crashed         |
+| `UNKNOWN_ERROR`        | Unclassified error                                    |
+
+#### Validation
+
+- `code` must match `^[A-Z][A-Z0-9_]*$`
+- `message` must not exceed 2000 characters
+
+---
+
+## Message Flow
+
+```
+Orchestrator                    Container
+    |                               |
+    |--- task-request ------------->|
+    |                               |
+    |<-- progress-update (US-001) --|  (in_progress)
+    |<-- progress-update (US-001) --|  (completed)
+    |<-- progress-update (US-002) --|  (in_progress)
+    |<-- progress-update (US-002) --|  (completed)
+    |                               |
+    |<-- completion ----------------|
+    |                               |
+```
+
+Error flow:
+
+```
+Orchestrator                    Container
+    |                               |
+    |--- task-request ------------->|
+    |                               |
+    |<-- progress-update (US-001) --|  (in_progress)
+    |<-- error ---------------------|  (CONTAINER_OOM)
+    |                               X  (container exits)
+```
+
+---
+
+## Transport
+
+ACP messages are exchanged via **stdout/stdin pipes** between the orchestrator process and the container's ACP process. Each message is a single line of JSON (newline-delimited JSON / NDJSON).
+
+- One JSON object per line
+- No trailing commas
+- UTF-8 encoding
+- Maximum message size: 64 KB

--- a/plugins/aimi-engineering/skills/docker-sandbox/references/architecture.md
+++ b/plugins/aimi-engineering/skills/docker-sandbox/references/architecture.md
@@ -1,0 +1,251 @@
+# Docker Sandbox Architecture
+
+Overview of the docker-sandbox skill architecture, covering container topology, image layering, ACP message flow, and state management.
+
+---
+
+## System Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                           Host Machine                                  │
+│                                                                         │
+│  ┌───────────────────────────────────────────────────────────────────┐  │
+│  │                     Claude Code CLI (Host)                        │  │
+│  │                                                                   │  │
+│  │  ┌─────────────┐                                                  │  │
+│  │  │ /aimi:swarm  │  Orchestrator entry point                       │  │
+│  │  └──────┬──────┘                                                  │  │
+│  │         │                                                         │  │
+│  │         ├── Discovers task files (.aimi/tasks/*-tasks.json)        │  │
+│  │         ├── Builds project image (build-project-image.sh)         │  │
+│  │         ├── Provisions containers (sandbox-manager.sh)            │  │
+│  │         ├── Tracks state (aimi-cli.sh swarm-*)                    │  │
+│  │         │                                                         │  │
+│  │         ▼                                                         │  │
+│  │  ┌─────────────────── Fan-Out ───────────────────┐                │  │
+│  │  │  Parallel Task agents (one per container)      │                │  │
+│  │  │                                                │                │  │
+│  │  │  ┌──────────┐  ┌──────────┐  ┌──────────┐     │                │  │
+│  │  │  │ Worker 1 │  │ Worker 2 │  │ Worker N │     │                │  │
+│  │  │  └────┬─────┘  └────┬─────┘  └────┬─────┘     │                │  │
+│  │  └───────┼─────────────┼─────────────┼────────────┘                │  │
+│  └──────────┼─────────────┼─────────────┼────────────────────────────┘  │
+│             │ docker      │ docker      │ docker                        │
+│             │ exec -i     │ exec -i     │ exec -i                       │
+│             │ (stdio)     │ (stdio)     │ (stdio)                       │
+│  ┌──────────▼──────────┐ ┌▼──────────┐ ┌▼──────────┐                   │
+│  │ Container 1         │ │Container 2│ │Container N│                   │
+│  │ (Sysbox runtime)    │ │(Sysbox)   │ │(Sysbox)   │                   │
+│  │                     │ │           │ │           │                   │
+│  │ acp-adapter.py      │ │ acp-      │ │ acp-      │                   │
+│  │   ↕ stdio           │ │ adapter   │ │ adapter   │                   │
+│  │ Claude Code CLI     │ │ Claude CLI│ │ Claude CLI│                   │
+│  │   ↕                 │ │           │ │           │                   │
+│  │ Git worktree        │ │ worktree  │ │ worktree  │                   │
+│  │ (cloned repo)       │ │           │ │           │                   │
+│  └─────────────────────┘ └───────────┘ └───────────┘                   │
+│                                                                         │
+│  State: .aimi/swarm-state.json (flock-locked)                           │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Docker Image Layering
+
+```
+┌─────────────────────────────────────────┐
+│         aimi-sandbox-<project>:latest   │  Per-project layer
+│                                         │  - Project source code (git clone)
+│  FROM aimi-sandbox:base                 │  - Project dependencies (npm/pip/etc)
+│  COPY . /workspace                      │  - .aimi/ configuration
+│  RUN install-deps                       │  - Checksum-based rebuild skipping
+├─────────────────────────────────────────┤
+│         aimi-sandbox:base               │  Base image (Dockerfile.base)
+│                                         │  - Ubuntu + Sysbox-compatible init
+│  Claude Code CLI (headless)             │  - Node.js, Python, Git
+│  acp-adapter.py at /opt/aimi/           │  - Claude Code CLI pre-installed
+│  Git, SSH, curl                         │  - ACP adapter copied to /opt/aimi/
+│  Node.js, Python runtime               │  - ANTHROPIC_API_KEY passed at runtime
+└─────────────────────────────────────────┘
+```
+
+### Image Build Flow
+
+```
+build-project-image.sh
+    │
+    ├── Check if aimi-sandbox:base exists
+    │   └── If not: build from Dockerfile.base
+    │
+    ├── Derive project slug from git repo name
+    │
+    ├── Check if aimi-sandbox-<slug>:latest exists
+    │   └── If exists: compare Dockerfile checksum
+    │       ├── Match: reuse existing image (skip rebuild)
+    │       └── Mismatch: rebuild
+    │
+    └── Build from Dockerfile.project.template
+        └── Output: aimi-sandbox-<slug>:latest
+```
+
+---
+
+## ACP Message Flow
+
+```
+Orchestrator (Host)                    Container (Sysbox)
+       │                                      │
+       │  ┌─ docker exec -i ──────────────┐   │
+       │  │                                │   │
+       │  │  stdin ──────────────────────► │   │
+       │  │  task-request JSON             │   │
+       │  │                                │   │
+       │  │                  acp-adapter.py│   │
+       │  │                       │        │   │
+       │  │                       ▼        │   │
+       │  │              Claude Code CLI   │   │
+       │  │              (headless mode)   │   │
+       │  │                       │        │   │
+       │  │  stdout ◄──────────── │        │   │
+       │  │  progress-update (NDJSON)      │   │
+       │  │  progress-update (NDJSON)      │   │
+       │  │  ...                           │   │
+       │  │  completion (NDJSON)           │   │
+       │  │                                │   │
+       │  └────────────────────────────────┘   │
+       │                                      │
+```
+
+### Message Types
+
+| Type | Direction | When |
+|------|-----------|------|
+| `task-request` | Host -> Container | Container startup, assigns task file |
+| `progress-update` | Container -> Host | Each story status change |
+| `completion` | Container -> Host | All stories finished (final message) |
+| `error` | Container -> Host | Non-recoverable container failure |
+
+See [acp-messages.md](./acp-messages.md) for full schemas and validation rules.
+
+---
+
+## Container Lifecycle
+
+```
+                    sandbox-manager.sh
+                          │
+          ┌───────────────┼───────────────┐
+          │               │               │
+          ▼               ▼               ▼
+       create          status          remove
+          │               │               │
+          ▼               │               ▼
+   ┌──────────┐           │        ┌──────────┐
+   │ pending  │───────────┘        │ (gone)   │
+   └────┬─────┘                    └──────────┘
+        │ ACP task-request                ▲
+        ▼                                 │
+   ┌──────────┐                           │
+   │ running  │───────────────────────────┤
+   └────┬─────┘   remove (after          │
+        │         completion/failure)     │
+        ├──────────────┐                  │
+        ▼              ▼                  │
+   ┌──────────┐  ┌──────────┐            │
+   │completed │  │ failed   │────────────┘
+   └──────────┘  └──────────┘    cleanup
+```
+
+---
+
+## State Management
+
+### Swarm State File
+
+Location: `.aimi/swarm-state.json`
+
+Managed exclusively through `aimi-cli.sh swarm-*` subcommands with `flock` advisory locking for concurrent access safety.
+
+```
+aimi-cli.sh
+    │
+    ├── swarm-init      Create new swarm state file
+    ├── swarm-add       Register container entry
+    ├── swarm-update    Update container status/progress
+    ├── swarm-remove    Remove container entry
+    ├── swarm-status    Read current state
+    ├── swarm-list      List active containers
+    └── swarm-cleanup   Remove terminal entries
+```
+
+### Concurrency Model
+
+- **flock advisory locking** on `.aimi/.state.lock` prevents concurrent state corruption
+- **Atomic writes** via temp file + `mv` pattern
+- **Reconciliation before reads** ensures displayed state matches Docker daemon reality
+
+See [swarm-state-schema.json](./swarm-state-schema.json) for the full JSON Schema definition.
+
+---
+
+## State Reconciliation
+
+Automatic reconciliation runs before `status` display and `resume` operations.
+
+```
+swarm-state.json              Docker Daemon
+       │                           │
+       │     For each container:   │
+       ├──────────────────────────►│
+       │   sandbox-manager.sh      │
+       │   status <name>           │
+       │◄──────────────────────────┤
+       │   {exists, swarmState,    │
+       │    exitCode}              │
+       │                           │
+       ▼                           │
+  Compare states                   │
+       │                           │
+       ├── Match: no action        │
+       ├── Zombie: mark failed     │
+       ├── Silent completion:      │
+       │   mark completed          │
+       ├── Silent failure:         │
+       │   mark failed             │
+       └── Unexpected stop:        │
+           mark stopped            │
+```
+
+### Detection Scenarios
+
+| Scenario | State Says | Docker Says | Action |
+|----------|-----------|-------------|--------|
+| Zombie | `running` or `pending` | Container not found | Mark `failed` |
+| Silent completion | `running` | Exited, code 0 | Mark `completed` |
+| Silent failure | `running` | Exited, code != 0 | Mark `failed` |
+| Unexpected stop | `running` | Paused/removing | Mark `stopped` |
+| Already started | `pending` | Running | Mark `running` |
+
+---
+
+## Security Model
+
+### Sysbox Isolation
+
+- User-namespace mapping: container root maps to unprivileged host user
+- No `--privileged` flag required
+- Secure nested Docker support (Docker-in-Docker)
+- Resource limits enforced via cgroups (CPU, memory, swap, disk)
+
+### Auto-Approve Scope
+
+Only these patterns are auto-approved (defined in `hooks/auto-approve-cli.sh`):
+
+1. `$SANDBOX_MGR` with whitelisted subcommands only
+2. `$BUILD_IMG` with path validation
+3. `$AIMI_CLI swarm-*` subcommands only
+4. `docker exec -i aimi-*` restricted to ACP adapter invocations
+
+No wildcard Docker approvals. No `--privileged` approvals.

--- a/plugins/aimi-engineering/skills/docker-sandbox/references/example-acp-messages.json
+++ b/plugins/aimi-engineering/skills/docker-sandbox/references/example-acp-messages.json
@@ -1,0 +1,102 @@
+[
+  {
+    "_comment": "1. Orchestrator sends task-request to a container",
+    "type": "task-request",
+    "timestamp": "2026-03-01T10:00:00Z",
+    "swarmId": "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+    "containerId": "abc123def456",
+    "payload": {
+      "taskFilePath": ".aimi/tasks/2026-03-01-user-auth-tasks.json",
+      "branchName": "feat/user-auth",
+      "repoUrl": "https://github.com/org/repo.git",
+      "envVars": {
+        "NODE_ENV": "development",
+        "DATABASE_URL": "postgres://localhost:5432/dev"
+      }
+    }
+  },
+  {
+    "_comment": "2. Container reports story US-001 started",
+    "type": "progress-update",
+    "timestamp": "2026-03-01T10:01:00Z",
+    "swarmId": "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+    "containerId": "abc123def456",
+    "payload": {
+      "storyId": "US-001",
+      "status": "in_progress",
+      "output": "Starting story US-001: Add status field to tasks table."
+    }
+  },
+  {
+    "_comment": "3. Container reports story US-001 completed",
+    "type": "progress-update",
+    "timestamp": "2026-03-01T10:15:00Z",
+    "swarmId": "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+    "containerId": "abc123def456",
+    "payload": {
+      "storyId": "US-001",
+      "status": "completed",
+      "output": "Migration created and applied. Added status column with enum type. Typecheck passes."
+    }
+  },
+  {
+    "_comment": "4. Container reports story US-002 started",
+    "type": "progress-update",
+    "timestamp": "2026-03-01T10:16:00Z",
+    "swarmId": "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+    "containerId": "abc123def456",
+    "payload": {
+      "storyId": "US-002",
+      "status": "in_progress",
+      "output": "Starting story US-002: Display status badge on task cards."
+    }
+  },
+  {
+    "_comment": "5. Container reports story US-002 failed",
+    "type": "progress-update",
+    "timestamp": "2026-03-01T10:30:00Z",
+    "swarmId": "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+    "containerId": "abc123def456",
+    "payload": {
+      "storyId": "US-002",
+      "status": "failed",
+      "output": "Typecheck failed: Property 'statusColor' does not exist on type 'TaskCardProps'. Badge component created but type errors remain."
+    }
+  },
+  {
+    "_comment": "6. Container sends completion with partial failure",
+    "type": "completion",
+    "timestamp": "2026-03-01T10:31:00Z",
+    "swarmId": "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+    "containerId": "abc123def456",
+    "payload": {
+      "status": "completed",
+      "prUrl": "https://github.com/org/repo/pull/42",
+      "errors": [
+        "US-002 failed: Typecheck error on TaskCardProps"
+      ]
+    }
+  },
+  {
+    "_comment": "7. Container sends error on OOM",
+    "type": "error",
+    "timestamp": "2026-03-01T10:45:00Z",
+    "swarmId": "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+    "containerId": "def456abc123",
+    "payload": {
+      "code": "CONTAINER_OOM",
+      "message": "Container exceeded memory limit (4GB). Process killed by OOM killer."
+    }
+  },
+  {
+    "_comment": "8. Container sends error on failed git clone",
+    "type": "error",
+    "timestamp": "2026-03-01T10:02:00Z",
+    "swarmId": "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+    "containerId": "789abc123def",
+    "payload": {
+      "code": "GIT_CLONE_FAILED",
+      "message": "Failed to clone repository: authentication required. Verify that the container has access to the repo."
+    }
+  }
+]

--- a/plugins/aimi-engineering/skills/docker-sandbox/references/example-swarm-state.json
+++ b/plugins/aimi-engineering/skills/docker-sandbox/references/example-swarm-state.json
@@ -1,0 +1,79 @@
+{
+  "swarmId": "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+  "createdAt": "2026-03-01T10:00:00Z",
+  "updatedAt": "2026-03-01T11:35:00Z",
+  "containers": [
+    {
+      "containerId": "abc123def456abc123def456abc123def456abc123def456abc123def456abc12345",
+      "containerName": "aimi-sandbox-US-001",
+      "taskFilePath": ".aimi/tasks/2026-03-01-user-auth-tasks.json",
+      "branchName": "feat/user-auth",
+      "status": "completed",
+      "prUrl": "https://github.com/org/repo/pull/42",
+      "storyProgress": {
+        "total": 4,
+        "completed": 4,
+        "failed": 0,
+        "inProgress": 0,
+        "pending": 0
+      },
+      "createdAt": "2026-03-01T10:00:00Z",
+      "updatedAt": "2026-03-01T11:30:00Z",
+      "acpPid": null
+    },
+    {
+      "containerId": "def456abc123def456abc123def456abc123def456abc123def456abc123def45678",
+      "containerName": "aimi-sandbox-US-005",
+      "taskFilePath": ".aimi/tasks/2026-03-01-user-auth-tasks.json",
+      "branchName": "feat/user-auth-ui",
+      "status": "running",
+      "prUrl": null,
+      "storyProgress": {
+        "total": 3,
+        "completed": 1,
+        "failed": 0,
+        "inProgress": 1,
+        "pending": 1
+      },
+      "createdAt": "2026-03-01T10:05:00Z",
+      "updatedAt": "2026-03-01T11:35:00Z",
+      "acpPid": 12345
+    },
+    {
+      "containerId": "789abc123def456789abc123def456789abc123def456789abc123def456789abcd",
+      "containerName": "aimi-sandbox-US-008",
+      "taskFilePath": ".aimi/tasks/2026-03-01-user-auth-tasks.json",
+      "branchName": "feat/user-auth-tests",
+      "status": "failed",
+      "prUrl": null,
+      "storyProgress": {
+        "total": 2,
+        "completed": 0,
+        "failed": 1,
+        "inProgress": 0,
+        "pending": 1
+      },
+      "createdAt": "2026-03-01T10:10:00Z",
+      "updatedAt": "2026-03-01T11:00:00Z",
+      "acpPid": null
+    },
+    {
+      "containerId": "ccc111222333444555666777888999aaabbbccc111222333444555666777888999aa",
+      "containerName": "aimi-sandbox-US-010",
+      "taskFilePath": ".aimi/tasks/2026-03-01-user-auth-tasks.json",
+      "branchName": "feat/user-auth-docs",
+      "status": "pending",
+      "prUrl": null,
+      "storyProgress": {
+        "total": 1,
+        "completed": 0,
+        "failed": 0,
+        "inProgress": 0,
+        "pending": 1
+      },
+      "createdAt": "2026-03-01T10:15:00Z",
+      "updatedAt": "2026-03-01T10:15:00Z",
+      "acpPid": null
+    }
+  ]
+}

--- a/plugins/aimi-engineering/skills/docker-sandbox/references/swarm-state-schema.json
+++ b/plugins/aimi-engineering/skills/docker-sandbox/references/swarm-state-schema.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://aimi.engineering/schemas/swarm-state/v1",
+  "title": "Swarm State",
+  "description": "Tracks the state of a docker-sandbox swarm: which containers are running, what tasks they execute, and their current lifecycle status.",
+  "type": "object",
+  "required": ["swarmId", "createdAt", "updatedAt", "containers"],
+  "additionalProperties": false,
+  "properties": {
+    "swarmId": {
+      "type": "string",
+      "description": "Unique identifier for this swarm instance (UUID v4).",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+    },
+    "createdAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp when the swarm was created."
+    },
+    "updatedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp of the last state mutation."
+    },
+    "containers": {
+      "type": "array",
+      "description": "Array of container entries, one per sandbox worker.",
+      "items": {
+        "$ref": "#/definitions/Container"
+      }
+    }
+  },
+  "definitions": {
+    "Container": {
+      "type": "object",
+      "required": [
+        "containerId",
+        "containerName",
+        "taskFilePath",
+        "branchName",
+        "status",
+        "storyProgress",
+        "createdAt",
+        "updatedAt"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "containerId": {
+          "type": "string",
+          "description": "Docker container ID (full 64-char hex or short 12-char).",
+          "pattern": "^[0-9a-f]{12,64}$"
+        },
+        "containerName": {
+          "type": "string",
+          "description": "Human-readable container name (e.g., 'aimi-sandbox-US-001').",
+          "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+        },
+        "taskFilePath": {
+          "type": "string",
+          "description": "Relative path to the tasks.json file this container is executing (e.g., '.aimi/tasks/2026-03-01-feature-tasks.json')."
+        },
+        "branchName": {
+          "type": "string",
+          "description": "Git branch the container is working on.",
+          "pattern": "^[a-zA-Z0-9][a-zA-Z0-9/_-]*$"
+        },
+        "status": {
+          "$ref": "#/definitions/ContainerStatus"
+        },
+        "prUrl": {
+          "type": ["string", "null"],
+          "description": "Pull request URL created by this container, or null if not yet created.",
+          "format": "uri"
+        },
+        "storyProgress": {
+          "$ref": "#/definitions/StoryProgress"
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 timestamp when the container was created."
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 timestamp of the last status change for this container."
+        },
+        "acpPid": {
+          "type": ["integer", "null"],
+          "description": "Process ID of the ACP (Agent Communication Protocol) process inside this container. Null if not yet started or already exited.",
+          "minimum": 1
+        }
+      }
+    },
+    "ContainerStatus": {
+      "type": "string",
+      "description": "Lifecycle status of a sandbox container.",
+      "enum": ["pending", "running", "completed", "failed", "stopped"]
+    },
+    "StoryProgress": {
+      "type": "object",
+      "description": "Tracks how many stories in the task file have been processed.",
+      "required": ["total", "completed", "failed", "inProgress", "pending"],
+      "additionalProperties": false,
+      "properties": {
+        "total": {
+          "type": "integer",
+          "description": "Total number of user stories in the task file.",
+          "minimum": 0
+        },
+        "completed": {
+          "type": "integer",
+          "description": "Number of stories with status 'completed'.",
+          "minimum": 0
+        },
+        "failed": {
+          "type": "integer",
+          "description": "Number of stories with status 'failed'.",
+          "minimum": 0
+        },
+        "inProgress": {
+          "type": "integer",
+          "description": "Number of stories with status 'in_progress'.",
+          "minimum": 0
+        },
+        "pending": {
+          "type": "integer",
+          "description": "Number of stories with status 'pending'.",
+          "minimum": 0
+        }
+      }
+    }
+  }
+}

--- a/plugins/aimi-engineering/skills/docker-sandbox/scripts/acp-adapter.py
+++ b/plugins/aimi-engineering/skills/docker-sandbox/scripts/acp-adapter.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""
+ACP Adapter for Claude Code CLI inside Docker containers.
+
+Reads a JSON task-request payload from stdin, invokes Claude Code CLI
+in headless mode, and streams progress/completion/error messages back
+to the host via stdout as JSON-lines (NDJSON).
+
+Transport: stdin/stdout pipes (one JSON object per line).
+Logging: stderr only (to avoid mixing with protocol messages).
+
+Usage:
+    docker exec -i <container> python /opt/aimi/acp-adapter.py
+
+Environment:
+    ANTHROPIC_API_KEY  - Required. Claude API key for headless mode.
+    CONTAINER_ID       - Optional. Docker container ID for message envelope.
+    SWARM_ID           - Optional. Swarm UUID for message envelope.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+REQUIRED_ENV_VARS = ["ANTHROPIC_API_KEY"]
+
+VALID_TASK_REQUEST_FIELDS = {"taskFilePath", "branchName", "repoUrl", "envVars"}
+REQUIRED_TASK_REQUEST_FIELDS = {"taskFilePath", "branchName", "repoUrl"}
+
+BRANCH_NAME_PATTERN_CHARS = set(
+    "abcdefghijklmnopqrstuvwxyz"
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    "0123456789/_-"
+)
+
+
+# ---------------------------------------------------------------------------
+# Globals for signal handling
+# ---------------------------------------------------------------------------
+
+_claude_process = None  # type: subprocess.Popen | None
+_interrupted = False
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def log(message: str) -> None:
+    """Log a message to stderr (never stdout)."""
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    print(f"[acp-adapter {timestamp}] {message}", file=sys.stderr, flush=True)
+
+
+def iso_now() -> str:
+    """Return the current UTC time as ISO 8601 string."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def emit(message: dict) -> None:
+    """Write a single JSON-line message to stdout."""
+    line = json.dumps(message, separators=(",", ":"))
+    sys.stdout.write(line + "\n")
+    sys.stdout.flush()
+
+
+def envelope(msg_type: str, payload: dict) -> dict:
+    """Wrap a payload in the ACP message envelope."""
+    return {
+        "type": msg_type,
+        "timestamp": iso_now(),
+        "swarmId": os.environ.get("SWARM_ID", "00000000-0000-0000-0000-000000000000"),
+        "containerId": os.environ.get("CONTAINER_ID", "unknown"),
+        "payload": payload,
+    }
+
+
+def emit_progress(story_id: str, status: str, output: str) -> None:
+    """Emit a progress-update message."""
+    emit(envelope("progress-update", {
+        "storyId": story_id,
+        "status": status,
+        "output": output[:2000],
+    }))
+
+
+def emit_completion(status: str, pr_url: str | None = None,
+                    errors: list[str] | None = None) -> None:
+    """Emit a completion message."""
+    emit(envelope("completion", {
+        "status": status,
+        "prUrl": pr_url,
+        "errors": [e[:500] for e in (errors or [])][:50],
+    }))
+
+
+def emit_error(code: str, message: str) -> None:
+    """Emit an error message."""
+    emit(envelope("error", {
+        "code": code,
+        "message": message[:2000],
+    }))
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+def validate_branch_name(name: str) -> bool:
+    """Validate branch name against ^[a-zA-Z0-9][a-zA-Z0-9/_-]*$."""
+    if not name:
+        return False
+    first_char = name[0]
+    if not (first_char.isascii() and first_char.isalnum()):
+        return False
+    return all(c in BRANCH_NAME_PATTERN_CHARS for c in name)
+
+
+def validate_task_file_path(path: str) -> bool:
+    """Validate that taskFilePath ends with .json."""
+    return isinstance(path, str) and path.endswith(".json")
+
+
+def validate_repo_url(url: str) -> bool:
+    """Validate that repoUrl looks like a valid git URL."""
+    if not isinstance(url, str):
+        return False
+    return url.startswith("https://") or url.startswith("git@")
+
+
+def validate_env_var_key(key: str) -> bool:
+    """Validate env var key matches ^[A-Z_][A-Z0-9_]*$."""
+    if not key:
+        return False
+    first = key[0]
+    if not (first.isupper() or first == "_"):
+        return False
+    return all(c.isupper() or c.isdigit() or c == "_" for c in key)
+
+
+def validate_task_request(payload: dict) -> list[str]:
+    """Validate a task-request payload. Returns list of error strings."""
+    errors = []
+
+    for field in REQUIRED_TASK_REQUEST_FIELDS:
+        if field not in payload:
+            errors.append(f"Missing required field: {field}")
+
+    if "taskFilePath" in payload and not validate_task_file_path(payload["taskFilePath"]):
+        errors.append("taskFilePath must end with .json")
+
+    if "branchName" in payload and not validate_branch_name(payload["branchName"]):
+        errors.append(
+            "branchName must match ^[a-zA-Z0-9][a-zA-Z0-9/_-]*$"
+        )
+
+    if "repoUrl" in payload and not validate_repo_url(payload["repoUrl"]):
+        errors.append("repoUrl must start with https:// or git@")
+
+    if "envVars" in payload:
+        env_vars = payload["envVars"]
+        if not isinstance(env_vars, dict):
+            errors.append("envVars must be an object")
+        else:
+            for key in env_vars:
+                if not validate_env_var_key(key):
+                    errors.append(
+                        f"envVars key '{key}' must match ^[A-Z_][A-Z0-9_]*$"
+                    )
+                if not isinstance(env_vars[key], str):
+                    errors.append(f"envVars value for '{key}' must be a string")
+
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Signal handling
+# ---------------------------------------------------------------------------
+
+def handle_sigterm(signum: int, frame: object) -> None:
+    """Handle SIGTERM: kill Claude subprocess and report interrupted status."""
+    global _interrupted
+    _interrupted = True
+    log("Received SIGTERM, shutting down gracefully...")
+
+    if _claude_process is not None and _claude_process.poll() is None:
+        log("Terminating Claude Code subprocess...")
+        try:
+            _claude_process.terminate()
+            try:
+                _claude_process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                log("Subprocess did not exit in time, sending SIGKILL...")
+                _claude_process.kill()
+                _claude_process.wait(timeout=3)
+        except OSError as exc:
+            log(f"Error terminating subprocess: {exc}")
+
+    emit_completion("stopped", errors=["Process interrupted by SIGTERM"])
+    sys.exit(130)
+
+
+# ---------------------------------------------------------------------------
+# Core execution
+# ---------------------------------------------------------------------------
+
+def build_prompt(payload: dict) -> str:
+    """Build the prompt string for Claude Code CLI from the task payload."""
+    parts = [
+        "You are an autonomous agent executing a task inside a Docker container.",
+        "",
+        f"## Task File: {payload['taskFilePath']}",
+        f"## Branch: {payload['branchName']}",
+        f"## Repository: {payload['repoUrl']}",
+        "",
+        "Execute the stories in the task file. For each story:",
+        "1. Read the story requirements and acceptance criteria",
+        "2. Implement the changes",
+        "3. Verify acceptance criteria are met",
+        "4. Commit with a descriptive message",
+        "",
+        "Work through stories in dependency order. Skip stories whose "
+        "dependencies have failed.",
+    ]
+
+    if payload.get("envVars"):
+        parts.append("")
+        parts.append("## Environment Variables")
+        for key, value in payload["envVars"].items():
+            parts.append(f"- {key}={value}")
+
+    return "\n".join(parts)
+
+
+def run_claude(prompt: str) -> tuple[int, str]:
+    """
+    Invoke Claude Code CLI in headless mode and stream output.
+
+    Returns (exit_code, captured_output).
+    """
+    global _claude_process
+
+    cmd = [
+        "claude",
+        "--dangerously-skip-permissions",
+        "-p",
+        prompt,
+    ]
+
+    log(f"Launching Claude Code CLI: {' '.join(cmd[:3])} ...")
+
+    output_lines = []
+
+    try:
+        _claude_process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,  # line-buffered
+        )
+
+        # Stream stdout line by line as progress updates
+        if _claude_process.stdout is not None:
+            for line in _claude_process.stdout:
+                stripped = line.rstrip("\n")
+                if stripped:
+                    output_lines.append(stripped)
+                    # Emit periodic progress with the latest output line
+                    emit_progress(
+                        "US-000",
+                        "in_progress",
+                        stripped,
+                    )
+
+        # Wait for process to finish
+        _claude_process.wait()
+        exit_code = _claude_process.returncode
+
+        # Capture any stderr
+        stderr_output = ""
+        if _claude_process.stderr is not None:
+            stderr_output = _claude_process.stderr.read()
+        if stderr_output:
+            log(f"Claude Code stderr: {stderr_output.strip()}")
+
+        log(f"Claude Code exited with code {exit_code}")
+        return exit_code, "\n".join(output_lines[-20:])  # last 20 lines
+
+    except FileNotFoundError:
+        log("Claude Code CLI not found in PATH")
+        return -1, "Claude Code CLI binary not found"
+    except OSError as exc:
+        log(f"Failed to launch Claude Code CLI: {exc}")
+        return -1, str(exc)
+    finally:
+        _claude_process = None
+
+
+def main() -> int:
+    """Main entry point for the ACP adapter."""
+
+    # Install signal handler
+    signal.signal(signal.SIGTERM, handle_sigterm)
+
+    # --- Validate environment ---
+    missing_vars = [v for v in REQUIRED_ENV_VARS if not os.environ.get(v)]
+    if missing_vars:
+        msg = f"Missing required environment variables: {', '.join(missing_vars)}"
+        log(msg)
+        emit_error("MISSING_ENV_VAR", msg)
+        return 1
+
+    log("ACP adapter started. Waiting for task-request on stdin...")
+
+    # --- Read task-request from stdin ---
+    try:
+        raw_input = sys.stdin.readline()
+        if not raw_input.strip():
+            msg = "Empty input received on stdin"
+            log(msg)
+            emit_error("INVALID_INPUT", msg)
+            return 1
+
+        request = json.loads(raw_input)
+    except json.JSONDecodeError as exc:
+        msg = f"Invalid JSON on stdin: {exc}"
+        log(msg)
+        emit_error("INVALID_INPUT", msg)
+        return 1
+
+    # --- Validate message type ---
+    msg_type = request.get("type")
+    if msg_type != "task-request":
+        msg = f"Expected message type 'task-request', got '{msg_type}'"
+        log(msg)
+        emit_error("INVALID_INPUT", msg)
+        return 1
+
+    # --- Extract and validate payload ---
+    payload = request.get("payload")
+    if not isinstance(payload, dict):
+        msg = "Missing or invalid 'payload' in task-request"
+        log(msg)
+        emit_error("INVALID_INPUT", msg)
+        return 1
+
+    validation_errors = validate_task_request(payload)
+    if validation_errors:
+        msg = "Task request validation failed: " + "; ".join(validation_errors)
+        log(msg)
+        emit_error("TASK_FILE_INVALID", msg)
+        return 1
+
+    log(f"Received task-request: taskFile={payload['taskFilePath']}, "
+        f"branch={payload['branchName']}, repo={payload['repoUrl']}")
+
+    # --- Set any provided environment variables ---
+    env_vars = payload.get("envVars", {})
+    for key, value in env_vars.items():
+        os.environ[key] = value
+        log(f"Set env var: {key}")
+
+    # --- Build prompt and run Claude Code ---
+    prompt = build_prompt(payload)
+
+    emit_progress("US-000", "in_progress", "Starting Claude Code CLI...")
+
+    exit_code, output = run_claude(prompt)
+
+    if _interrupted:
+        # Signal handler already emitted completion
+        return 130
+
+    # --- Map exit code to completion status ---
+    if exit_code == 0:
+        log("Claude Code completed successfully")
+        emit_completion("completed", pr_url=None, errors=[])
+        return 0
+    else:
+        error_msg = f"Claude Code exited with code {exit_code}"
+        log(error_msg)
+        errors = [error_msg]
+        if output:
+            errors.append(f"Last output: {output[:450]}")
+        emit_completion("failed", pr_url=None, errors=errors)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/aimi-engineering/skills/docker-sandbox/scripts/build-project-image.sh
+++ b/plugins/aimi-engineering/skills/docker-sandbox/scripts/build-project-image.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# =============================================================================
+# build-project-image.sh — Build a per-project aimi-sandbox Docker image
+# =============================================================================
+# Checks for .aimi/Dockerfile.sandbox in the project root and builds a
+# project-specific image layered on aimi-sandbox:base. If no Dockerfile is
+# found, the base image is simply tagged as the project image.
+#
+# Features:
+#   - Derives project slug from git repo name or directory basename
+#   - Skips rebuild if image exists and Dockerfile checksum is unchanged
+#   - Validates that Dockerfile.sandbox starts with FROM aimi-sandbox
+#
+# Usage:
+#   ./build-project-image.sh [project-root]
+#
+# Arguments:
+#   project-root  Path to the project root (default: git toplevel or cwd)
+#
+# Output:
+#   Image tagged as: aimi-sandbox-<project-slug>:latest
+# =============================================================================
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+readonly DOCKERFILE_NAME="Dockerfile.sandbox"
+readonly DOCKERFILE_REL_PATH=".aimi/${DOCKERFILE_NAME}"
+readonly BASE_IMAGE="aimi-sandbox:base"
+readonly CHECKSUM_LABEL="org.aimi.dockerfile-checksum"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+log_info() {
+  echo "[aimi-build] $*"
+}
+
+log_error() {
+  echo "[aimi-build] ERROR: $*" >&2
+}
+
+die() {
+  log_error "$@"
+  exit 1
+}
+
+# Derive a URL/filesystem-safe slug from a name.
+# Lowercases, replaces non-alphanumeric chars with hyphens, trims leading/
+# trailing hyphens, and collapses consecutive hyphens.
+slugify() {
+  echo "$1" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed 's/[^a-z0-9]/-/g' \
+    | sed 's/--*/-/g' \
+    | sed 's/^-//;s/-$//'
+}
+
+# ---------------------------------------------------------------------------
+# Resolve project root
+# ---------------------------------------------------------------------------
+
+if [[ $# -ge 1 ]]; then
+  PROJECT_ROOT="$(cd "$1" && pwd)"
+else
+  PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+fi
+
+if [[ ! -d "${PROJECT_ROOT}" ]]; then
+  die "Project root does not exist: ${PROJECT_ROOT}"
+fi
+
+# ---------------------------------------------------------------------------
+# Derive project slug
+# ---------------------------------------------------------------------------
+
+# Prefer git remote-based name, fall back to directory basename
+REPO_NAME=""
+if git -C "${PROJECT_ROOT}" rev-parse --is-inside-work-tree &>/dev/null; then
+  REMOTE_URL="$(git -C "${PROJECT_ROOT}" remote get-url origin 2>/dev/null || true)"
+  if [[ -n "${REMOTE_URL}" ]]; then
+    # Extract repo name from remote URL (handles both HTTPS and SSH)
+    REPO_NAME="$(basename "${REMOTE_URL}" .git)"
+  fi
+fi
+
+if [[ -z "${REPO_NAME}" ]]; then
+  REPO_NAME="$(basename "${PROJECT_ROOT}")"
+fi
+
+PROJECT_SLUG="$(slugify "${REPO_NAME}")"
+IMAGE_TAG="aimi-sandbox-${PROJECT_SLUG}:latest"
+
+log_info "Project root : ${PROJECT_ROOT}"
+log_info "Project slug : ${PROJECT_SLUG}"
+log_info "Image tag    : ${IMAGE_TAG}"
+
+# ---------------------------------------------------------------------------
+# Locate Dockerfile.sandbox
+# ---------------------------------------------------------------------------
+
+DOCKERFILE_PATH="${PROJECT_ROOT}/${DOCKERFILE_REL_PATH}"
+
+if [[ ! -f "${DOCKERFILE_PATH}" ]]; then
+  log_info "No ${DOCKERFILE_REL_PATH} found — tagging base image as ${IMAGE_TAG}"
+  docker tag "${BASE_IMAGE}" "${IMAGE_TAG}"
+  log_info "Done. Image: ${IMAGE_TAG}"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Validate Dockerfile.sandbox
+# ---------------------------------------------------------------------------
+
+# The first non-comment, non-blank line must start with "FROM aimi-sandbox"
+FIRST_INSTRUCTION="$(grep -E '^\s*[^#]' "${DOCKERFILE_PATH}" | head -n 1 | xargs)"
+if [[ ! "${FIRST_INSTRUCTION}" =~ ^FROM[[:space:]]+aimi-sandbox ]]; then
+  die "${DOCKERFILE_NAME} must start with 'FROM aimi-sandbox...' (found: '${FIRST_INSTRUCTION}')"
+fi
+
+log_info "Validated: ${DOCKERFILE_NAME} extends aimi-sandbox"
+
+# ---------------------------------------------------------------------------
+# Checksum-based skip — avoid rebuilding when Dockerfile hasn't changed
+# ---------------------------------------------------------------------------
+
+CURRENT_CHECKSUM="$(sha256sum "${DOCKERFILE_PATH}" | awk '{print $1}')"
+
+# Check if image already exists and retrieve its stored checksum label
+EXISTING_CHECKSUM=""
+if docker image inspect "${IMAGE_TAG}" &>/dev/null; then
+  EXISTING_CHECKSUM="$(
+    docker image inspect "${IMAGE_TAG}" \
+      --format "{{index .Config.Labels \"${CHECKSUM_LABEL}\"}}" 2>/dev/null || true
+  )"
+fi
+
+if [[ "${CURRENT_CHECKSUM}" == "${EXISTING_CHECKSUM}" ]]; then
+  log_info "Dockerfile unchanged (checksum: ${CURRENT_CHECKSUM:0:12}...) — skipping rebuild"
+  log_info "Done. Image: ${IMAGE_TAG}"
+  exit 0
+fi
+
+log_info "Building project image (checksum: ${CURRENT_CHECKSUM:0:12}...)"
+
+# ---------------------------------------------------------------------------
+# Build the project image
+# ---------------------------------------------------------------------------
+
+docker build \
+  -f "${DOCKERFILE_PATH}" \
+  -t "${IMAGE_TAG}" \
+  --label "${CHECKSUM_LABEL}=${CURRENT_CHECKSUM}" \
+  "${PROJECT_ROOT}"
+
+log_info "Done. Image: ${IMAGE_TAG}"

--- a/plugins/aimi-engineering/skills/docker-sandbox/scripts/sandbox-manager.sh
+++ b/plugins/aimi-engineering/skills/docker-sandbox/scripts/sandbox-manager.sh
@@ -1,0 +1,619 @@
+#!/usr/bin/env bash
+
+# =============================================================================
+# sandbox-manager.sh — Docker container lifecycle for Aimi sandbox workers
+# =============================================================================
+# Manages creating, monitoring, and cleaning up Docker containers that run
+# autonomous agent workers inside Sysbox-isolated sandboxes.
+#
+# Follows worktree-manager.sh patterns: idempotent operations, validation
+# functions, colored output, error handling, case statement structure.
+#
+# Usage:
+#   sandbox-manager.sh <command> [options]
+#
+# Commands:
+#   create <name> --image <image> [--task-file <path>] [--branch <branch>]
+#   remove <name>
+#   list
+#   status <name>
+#   cleanup
+#   check-runtime
+#   help
+# =============================================================================
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Colors for output
+# ---------------------------------------------------------------------------
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# ---------------------------------------------------------------------------
+# Configurable resource limits (env vars with defaults)
+# ---------------------------------------------------------------------------
+AIMI_SANDBOX_CPUS="${AIMI_SANDBOX_CPUS:-2}"
+AIMI_SANDBOX_MEMORY="${AIMI_SANDBOX_MEMORY:-4g}"
+AIMI_SANDBOX_SWAP="${AIMI_SANDBOX_SWAP:-4g}"
+AIMI_SANDBOX_DISK="${AIMI_SANDBOX_DISK:-8g}"
+
+# Container name prefix
+readonly AIMI_PREFIX="aimi-"
+# Label used to tag aimi-managed containers
+readonly AIMI_LABEL="org.aimi.sandbox"
+# Label for task file association
+readonly AIMI_TASK_LABEL="org.aimi.task-file"
+# Sysbox runtime name
+readonly SYSBOX_RUNTIME="sysbox-runc"
+# Sysbox install URL
+readonly SYSBOX_INSTALL_URL="https://github.com/nestybox/sysbox/blob/master/docs/user-guide/install-package.md"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+log_info() {
+  echo -e "${BLUE}[aimi-sandbox]${NC} $*"
+}
+
+log_success() {
+  echo -e "${GREEN}[aimi-sandbox]${NC} $*"
+}
+
+log_warn() {
+  echo -e "${YELLOW}[aimi-sandbox]${NC} $*" >&2
+}
+
+log_error() {
+  echo -e "${RED}[aimi-sandbox]${NC} ERROR: $*" >&2
+}
+
+die() {
+  log_error "$@"
+  exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+# Validate container name matches required pattern: aimi-<slug>
+# Slug must start with alphanumeric, then allow alphanumeric, underscore, hyphen
+validate_container_name() {
+  local name="$1"
+  if ! [[ "$name" =~ ^aimi-[a-zA-Z0-9][a-zA-Z0-9_-]*$ ]]; then
+    die "Invalid container name: '${name}'. Must match ^aimi-[a-zA-Z0-9][a-zA-Z0-9_-]*\$"
+  fi
+}
+
+# Ensure Docker is available
+require_docker() {
+  if ! command -v docker &>/dev/null; then
+    die "Docker is not installed or not in PATH"
+  fi
+  if ! docker info &>/dev/null; then
+    die "Docker daemon is not running or current user lacks permissions"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# check-runtime: Verify Sysbox runtime is registered
+# ---------------------------------------------------------------------------
+cmd_check_runtime() {
+  require_docker
+
+  # Check if sysbox-runc is registered in Docker daemon
+  local runtimes
+  runtimes=$(docker info --format '{{json .Runtimes}}' 2>/dev/null || echo "{}")
+
+  if echo "$runtimes" | grep -q "${SYSBOX_RUNTIME}"; then
+    log_success "Sysbox runtime '${SYSBOX_RUNTIME}' is available"
+    echo "{\"available\": true, \"runtime\": \"${SYSBOX_RUNTIME}\"}"
+    return 0
+  else
+    log_error "Sysbox runtime '${SYSBOX_RUNTIME}' is NOT registered with Docker"
+    echo ""
+    echo -e "${RED}Sysbox is required for secure container-in-container sandboxing.${NC}"
+    echo ""
+    echo -e "${YELLOW}Install Sysbox:${NC}"
+    echo "  ${SYSBOX_INSTALL_URL}"
+    echo ""
+    echo -e "${YELLOW}After installation, verify with:${NC}"
+    echo "  docker info --format '{{json .Runtimes}}' | grep sysbox-runc"
+    echo ""
+    return 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# create: Spawn a new sandbox container
+# ---------------------------------------------------------------------------
+cmd_create() {
+  local name=""
+  local image=""
+  local task_file=""
+  local branch=""
+
+  # Parse arguments
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --image)
+        image="$2"
+        shift 2
+        ;;
+      --task-file)
+        task_file="$2"
+        shift 2
+        ;;
+      --branch)
+        branch="$2"
+        shift 2
+        ;;
+      -*)
+        die "Unknown option: $1"
+        ;;
+      *)
+        if [[ -z "$name" ]]; then
+          name="$1"
+        else
+          die "Unexpected argument: $1"
+        fi
+        shift
+        ;;
+    esac
+  done
+
+  # Validate required arguments
+  if [[ -z "$name" ]]; then
+    die "Container name required. Usage: sandbox-manager.sh create <name> --image <image>"
+  fi
+  if [[ -z "$image" ]]; then
+    die "Image required. Usage: sandbox-manager.sh create <name> --image <image>"
+  fi
+
+  # Ensure name has aimi- prefix
+  local container_name
+  if [[ "$name" == aimi-* ]]; then
+    container_name="$name"
+  else
+    container_name="${AIMI_PREFIX}${name}"
+  fi
+
+  # Validate container name
+  validate_container_name "$container_name"
+
+  # Require Docker
+  require_docker
+
+  # Validate Sysbox runtime is available — hard-fail if absent
+  if ! cmd_check_runtime &>/dev/null; then
+    echo ""
+    die "Sysbox runtime is required but not available. Install from: ${SYSBOX_INSTALL_URL}"
+  fi
+
+  # Collision detection: check if container already exists
+  local existing_state
+  existing_state=$(docker inspect --format '{{.State.Status}}' "$container_name" 2>/dev/null || echo "")
+
+  if [[ -n "$existing_state" ]]; then
+    if [[ "$existing_state" == "running" ]]; then
+      die "Container '${container_name}' already exists and is running. Remove it first or use a different name."
+    else
+      # Container exists but is not running (exited, created, etc.) — recreate
+      log_warn "Container '${container_name}' exists in state '${existing_state}'. Removing and recreating..."
+      docker rm -f "$container_name" &>/dev/null || true
+    fi
+  fi
+
+  # Create per-container bridge network
+  local network_name="${container_name}-net"
+  if ! docker network inspect "$network_name" &>/dev/null; then
+    log_info "Creating bridge network: ${network_name}"
+    docker network create --driver bridge "$network_name" >/dev/null
+  else
+    log_info "Network '${network_name}' already exists, reusing"
+  fi
+
+  # Build docker run arguments
+  local -a run_args=(
+    "--runtime=${SYSBOX_RUNTIME}"
+    "--name" "$container_name"
+    "--hostname" "$container_name"
+    "--detach"
+    "--cpus=${AIMI_SANDBOX_CPUS}"
+    "--memory=${AIMI_SANDBOX_MEMORY}"
+    "--memory-swap=${AIMI_SANDBOX_SWAP}"
+    "--network" "$network_name"
+    "--label" "${AIMI_LABEL}=true"
+  )
+
+  # Add task file label if provided
+  if [[ -n "$task_file" ]]; then
+    run_args+=("--label" "${AIMI_TASK_LABEL}=${task_file}")
+  fi
+
+  # Inject environment variables from host
+  if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
+    run_args+=("--env" "ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}")
+  else
+    log_warn "ANTHROPIC_API_KEY is not set in host environment"
+  fi
+
+  if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    run_args+=("--env" "GITHUB_TOKEN=${GITHUB_TOKEN}")
+  else
+    log_warn "GITHUB_TOKEN is not set in host environment"
+  fi
+
+  # Always set IS_SANDBOX=1
+  run_args+=("--env" "IS_SANDBOX=1")
+
+  # Add branch as env var if provided
+  if [[ -n "$branch" ]]; then
+    run_args+=("--env" "AIMI_BRANCH=${branch}")
+  fi
+
+  # Run the container
+  log_info "Creating container: ${container_name}"
+  log_info "  Image    : ${image}"
+  log_info "  CPUs     : ${AIMI_SANDBOX_CPUS}"
+  log_info "  Memory   : ${AIMI_SANDBOX_MEMORY}"
+  log_info "  Swap     : ${AIMI_SANDBOX_SWAP}"
+  log_info "  Network  : ${network_name}"
+  log_info "  Runtime  : ${SYSBOX_RUNTIME}"
+
+  local container_id
+  container_id=$(docker run "${run_args[@]}" "$image" 2>&1) || {
+    # Clean up network on failure
+    docker network rm "$network_name" &>/dev/null || true
+    die "Failed to create container: ${container_id}"
+  }
+
+  log_success "Container created successfully"
+
+  # Output JSON result
+  cat <<EOF
+{
+  "containerId": "${container_id}",
+  "name": "${container_name}",
+  "image": "${image}",
+  "network": "${network_name}",
+  "runtime": "${SYSBOX_RUNTIME}",
+  "resources": {
+    "cpus": "${AIMI_SANDBOX_CPUS}",
+    "memory": "${AIMI_SANDBOX_MEMORY}",
+    "swap": "${AIMI_SANDBOX_SWAP}"
+  }
+}
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# remove: Stop and remove a container by name (idempotent)
+# ---------------------------------------------------------------------------
+cmd_remove() {
+  local name="$1"
+
+  if [[ -z "$name" ]]; then
+    die "Container name required. Usage: sandbox-manager.sh remove <name>"
+  fi
+
+  # Ensure name has aimi- prefix
+  local container_name
+  if [[ "$name" == aimi-* ]]; then
+    container_name="$name"
+  else
+    container_name="${AIMI_PREFIX}${name}"
+  fi
+
+  validate_container_name "$container_name"
+  require_docker
+
+  local network_name="${container_name}-net"
+
+  # Stop and remove container (idempotent — no error if already gone)
+  if docker inspect "$container_name" &>/dev/null; then
+    log_info "Stopping container: ${container_name}"
+    docker stop "$container_name" &>/dev/null || true
+    log_info "Removing container: ${container_name}"
+    docker rm -f "$container_name" &>/dev/null || true
+    log_success "Container '${container_name}' removed"
+  else
+    log_warn "Container '${container_name}' does not exist (already removed)"
+  fi
+
+  # Remove associated network (idempotent)
+  if docker network inspect "$network_name" &>/dev/null; then
+    log_info "Removing network: ${network_name}"
+    docker network rm "$network_name" &>/dev/null || true
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# list: Output running aimi-* containers in JSON format
+# ---------------------------------------------------------------------------
+cmd_list() {
+  require_docker
+
+  # Query all containers with our label
+  local containers
+  containers=$(docker ps -a \
+    --filter "label=${AIMI_LABEL}=true" \
+    --format '{{.Names}}\t{{.Status}}\t{{.CreatedAt}}\t{{.Label "org.aimi.task-file"}}' \
+    2>/dev/null || echo "")
+
+  if [[ -z "$containers" ]]; then
+    echo '{"containers": []}'
+    return 0
+  fi
+
+  # Build JSON array
+  local json_items=""
+  local first=true
+
+  while IFS=$'\t' read -r name status created task_file; do
+    if [[ "$first" == true ]]; then
+      first=false
+    else
+      json_items+=","
+    fi
+
+    # Escape any special JSON characters in fields
+    status="${status//\"/\\\"}"
+    created="${created//\"/\\\"}"
+    task_file="${task_file//\"/\\\"}"
+
+    json_items+="
+    {
+      \"name\": \"${name}\",
+      \"status\": \"${status}\",
+      \"created\": \"${created}\",
+      \"taskFile\": \"${task_file}\"
+    }"
+  done <<< "$containers"
+
+  cat <<EOF
+{
+  "containers": [${json_items}
+  ]
+}
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# status: Query single container health and map to swarm-state enum
+# ---------------------------------------------------------------------------
+cmd_status() {
+  local name="$1"
+
+  if [[ -z "$name" ]]; then
+    die "Container name required. Usage: sandbox-manager.sh status <name>"
+  fi
+
+  # Ensure name has aimi- prefix
+  local container_name
+  if [[ "$name" == aimi-* ]]; then
+    container_name="$name"
+  else
+    container_name="${AIMI_PREFIX}${name}"
+  fi
+
+  validate_container_name "$container_name"
+  require_docker
+
+  # Check if container exists
+  if ! docker inspect "$container_name" &>/dev/null; then
+    cat <<EOF
+{
+  "name": "${container_name}",
+  "exists": false,
+  "swarmState": "not_found"
+}
+EOF
+    return 0
+  fi
+
+  # Get container details
+  local docker_state
+  docker_state=$(docker inspect --format '{{.State.Status}}' "$container_name" 2>/dev/null)
+  local exit_code
+  exit_code=$(docker inspect --format '{{.State.ExitCode}}' "$container_name" 2>/dev/null)
+  local started_at
+  started_at=$(docker inspect --format '{{.State.StartedAt}}' "$container_name" 2>/dev/null)
+  local finished_at
+  finished_at=$(docker inspect --format '{{.State.FinishedAt}}' "$container_name" 2>/dev/null)
+  local image
+  image=$(docker inspect --format '{{.Config.Image}}' "$container_name" 2>/dev/null)
+
+  # Map Docker state to swarm-state enum
+  # Swarm states: pending, running, completed, failed, stopped
+  local swarm_state
+  case "$docker_state" in
+    created)
+      swarm_state="pending"
+      ;;
+    running|restarting)
+      swarm_state="running"
+      ;;
+    paused)
+      swarm_state="stopped"
+      ;;
+    exited)
+      if [[ "$exit_code" == "0" ]]; then
+        swarm_state="completed"
+      else
+        swarm_state="failed"
+      fi
+      ;;
+    dead)
+      swarm_state="failed"
+      ;;
+    removing)
+      swarm_state="stopped"
+      ;;
+    *)
+      swarm_state="unknown"
+      ;;
+  esac
+
+  cat <<EOF
+{
+  "name": "${container_name}",
+  "exists": true,
+  "dockerState": "${docker_state}",
+  "swarmState": "${swarm_state}",
+  "exitCode": ${exit_code},
+  "image": "${image}",
+  "startedAt": "${started_at}",
+  "finishedAt": "${finished_at}"
+}
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# cleanup: Remove all stopped aimi-* containers and prune associated volumes
+# ---------------------------------------------------------------------------
+cmd_cleanup() {
+  require_docker
+
+  log_info "Cleaning up stopped Aimi sandbox containers..."
+
+  # Find all stopped containers with our label
+  local stopped
+  stopped=$(docker ps -a \
+    --filter "label=${AIMI_LABEL}=true" \
+    --filter "status=exited" \
+    --filter "status=dead" \
+    --filter "status=created" \
+    --format '{{.Names}}' \
+    2>/dev/null || echo "")
+
+  if [[ -z "$stopped" ]]; then
+    log_success "No stopped Aimi containers to clean up"
+    return 0
+  fi
+
+  local count=0
+  while IFS= read -r container_name; do
+    [[ -z "$container_name" ]] && continue
+
+    local network_name="${container_name}-net"
+
+    log_info "Removing container: ${container_name}"
+    docker rm -f "$container_name" &>/dev/null || true
+
+    # Remove associated network
+    if docker network inspect "$network_name" &>/dev/null; then
+      log_info "Removing network: ${network_name}"
+      docker network rm "$network_name" &>/dev/null || true
+    fi
+
+    count=$((count + 1))
+  done <<< "$stopped"
+
+  # Prune dangling volumes associated with aimi containers
+  log_info "Pruning dangling volumes..."
+  docker volume prune -f --filter "label=${AIMI_LABEL}=true" &>/dev/null || true
+
+  log_success "Cleanup complete: removed ${count} container(s)"
+}
+
+# ---------------------------------------------------------------------------
+# help: Show usage information
+# ---------------------------------------------------------------------------
+show_help() {
+  cat << EOF
+Aimi Sandbox Manager — Docker container lifecycle for sandbox workers
+
+Usage: sandbox-manager.sh <command> [options]
+
+Commands:
+  create <name> --image <image> [options]  Create a new sandbox container
+    --task-file <path>                     Associate with a task file
+    --branch <branch>                      Git branch to pass as AIMI_BRANCH env
+
+  remove <name>                  Stop and remove a container (idempotent)
+  list                           List all aimi-* containers (JSON output)
+  status <name>                  Query container health (JSON output)
+  cleanup                        Remove all stopped aimi-* containers
+  check-runtime                  Verify Sysbox runtime is available
+  help                           Show this help message
+
+Environment Variables:
+  AIMI_SANDBOX_CPUS     CPU limit (default: 2)
+  AIMI_SANDBOX_MEMORY   Memory limit (default: 4g)
+  AIMI_SANDBOX_SWAP     Memory+swap limit (default: 4g)
+  AIMI_SANDBOX_DISK     Disk limit label (default: 8g)
+  ANTHROPIC_API_KEY     Injected into container
+  GITHUB_TOKEN          Injected into container
+
+Container Naming:
+  Containers are named as aimi-<slug>
+  Name must match: ^aimi-[a-zA-Z0-9][a-zA-Z0-9_-]*$
+
+Networking:
+  Each container gets its own bridge network: <container-name>-net
+  No cross-container network access
+
+Runtime:
+  Requires Sysbox (sysbox-runc) for secure container isolation
+  Install: ${SYSBOX_INSTALL_URL}
+
+Examples:
+  sandbox-manager.sh check-runtime
+  sandbox-manager.sh create my-task --image aimi-sandbox:base
+  sandbox-manager.sh create aimi-feat-login --image aimi-sandbox-myapp:latest --task-file .aimi/tasks/login.json
+  sandbox-manager.sh status aimi-feat-login
+  sandbox-manager.sh list
+  sandbox-manager.sh remove aimi-feat-login
+  sandbox-manager.sh cleanup
+
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Main command handler
+# ---------------------------------------------------------------------------
+main() {
+  local command="${1:-help}"
+
+  case "$command" in
+    create)
+      shift
+      cmd_create "$@"
+      ;;
+    remove|rm)
+      shift
+      cmd_remove "${1:-}"
+      ;;
+    list|ls)
+      cmd_list
+      ;;
+    status)
+      shift
+      cmd_status "${1:-}"
+      ;;
+    cleanup|clean)
+      cmd_cleanup
+      ;;
+    check-runtime)
+      cmd_check_runtime
+      ;;
+    help|--help|-h)
+      show_help
+      ;;
+    *)
+      log_error "Unknown command: $command"
+      echo ""
+      show_help
+      exit 1
+      ;;
+  esac
+}
+
+# Run
+main "$@"

--- a/plugins/aimi-engineering/skills/git-worktree/scripts/worktree-manager.sh
+++ b/plugins/aimi-engineering/skills/git-worktree/scripts/worktree-manager.sh
@@ -385,14 +385,14 @@ merge_worktree() {
   echo -e "${BLUE}Merging branch '$worktree_branch' into '$target_branch'...${NC}"
 
   # Checkout the target branch (validated above, -- not used here as it changes checkout semantics)
-  git checkout "$target_branch" 2>/dev/null
+  git checkout "$target_branch"
   if [[ $? -ne 0 ]]; then
     echo -e "${RED}Error: Failed to checkout target branch: $target_branch${NC}"
     exit 1
   fi
 
   # Attempt the merge
-  if git merge -- "$worktree_branch" 2>/dev/null; then
+  if git merge -- "$worktree_branch"; then
     local merge_hash
     merge_hash=$(git rev-parse HEAD)
     echo -e "${GREEN}Merge successful!${NC}"
@@ -457,14 +457,14 @@ merge_all_worktrees() {
     fi
 
     # Checkout target branch
-    git checkout "$target_branch" 2>/dev/null
+    git checkout "$target_branch"
     if [[ $? -ne 0 ]]; then
       echo -e "${RED}Error: Failed to checkout target branch: $target_branch${NC}"
       exit 1
     fi
 
     # Attempt merge
-    if git merge "$resolved_branch" 2>/dev/null; then
+    if git merge "$resolved_branch"; then
       local merge_hash
       merge_hash=$(git rev-parse HEAD)
       echo -e "${GREEN}  Merged '$branch' successfully (commit: $merge_hash)${NC}"


### PR DESCRIPTION
## Summary

- Harden `aimi-cli.sh` with portable file locking, input validation, content checks, orphaned story recovery, and `maxConcurrency` guard
- Rewrite `execute.md` to use foreground fan-out parallel execution (no background polling), single-source worker prompts from `story-executor/SKILL.md`, and agent-driven merge conflict resolution
- Harden `worktree-manager.sh` and `auto-approve-cli.sh` with subcommand whitelists, path validation, and non-interactive operation
- Add Docker sandbox infrastructure: base image, per-project Dockerfile template, `sandbox-manager.sh` for container lifecycle, ACP adapter for Claude Code CLI in containers, and swarm state schemas
- Add `/aimi:swarm` orchestration command for multi-container parallel execution via ACP messaging

## Changes

- **CLI hardening** (`aimi-cli.sh`): flock-based locking (with macOS fallback), `resolve_path()`, `validate_story_exists()`, `reset-orphaned`, content validation, stale state recovery, swarm state management commands. 65 test assertions.
- **Execution engine** (`execute.md`): foreground Task fan-out replacing background polling, wave-based parallelism with adaptive concurrency, cascade-skip on failure, deadlock detection, story notes passthrough.
- **Worker prompt** (`story-executor/SKILL.md`): single source of truth for worker instructions, referenced by both `execute.md` and `next.md`.
- **Worktree manager** (`worktree-manager.sh`): `remove` subcommand, non-interactive operation, visible merge error output.
- **Auto-approve hook** (`auto-approve-cli.sh`): subcommand whitelist, chaining rejection, sandbox/swarm/Docker patterns.
- **Docker sandbox** (new skill): `Dockerfile.base`, `Dockerfile.project.template`, `build-project-image.sh`, `sandbox-manager.sh`, `acp-adapter.py`, ACP message schema, swarm state schema, architecture docs.
- **Swarm command** (`swarm.md`): orchestrates multi-container execution with state reconciliation, status/resume/cleanup.

## Test plan

- [ ] Run `bash scripts/test-aimi-cli.sh` — all 65 assertions pass
- [ ] Run `/aimi:execute` on a multi-story tasks file — verify wave-based fan-out completes all stories
- [ ] Run `/aimi:execute` on a single-story wave — verify inline execution (no worktree overhead)
- [ ] Interrupt execution mid-wave, re-run `/aimi:execute` — verify orphaned story recovery and resume
- [ ] Verify `auto-approve-cli.sh` rejects unknown subcommands and chained commands
