### PR TITLE
feat: Swarm subscription auth detection and SSH agent passthrough

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and swarm orchestration.",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "author": {
         "name": "Stanley Takamatsu",
         "url": "https://github.com/aimi-so"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and swarm orchestration.",
-      "version": "1.21.0",
+      "version": "1.22.0",
       "author": {
         "name": "Stanley Takamatsu",
         "url": "https://github.com/aimi-so"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.23.0] - 2026-03-01
+
+### Added
+
+- **swarm.md**: Subscription auth detection in Step 2.5 — checks for `~/.claude/.credentials.json` (or `$CLAUDE_CONFIG_DIR/.credentials.json`)
+- **swarm.md**: `CLAUDE_AUTH=subscription` variable set when subscription credentials found
+- **swarm.md**: `--mount-claude-config` flag passthrough to `sandbox-manager.sh create` when subscription auth detected
+- **swarm.md**: Credential summary now displays `Claude` field showing subscription auth status
+
+### Changed
+
+- **swarm.md**: `ANTHROPIC_API_KEY` check is now a warning (not hard stop) when subscription auth is available
+- **swarm.md**: Hard stop message updated to mention both `ANTHROPIC_API_KEY` and Claude config directory options
+- **swarm.md**: Resume subcommand container recreation now passes `--mount-claude-config` when subscription auth detected
+- **swarm.md**: Resume fan-out re-detection now includes `CLAUDE_AUTH` alongside `AUTH_METHOD`
+
 ## [1.22.0] - 2026-03-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.22.0] - 2026-03-01
+
+### Added
+
+- **Dockerfile.base**: Pre-populate SSH known_hosts for GitHub, GitLab, and Bitbucket during image build
+- **sandbox-manager.sh**: New `--ssh-agent` flag to forward host SSH_AUTH_SOCK into containers
+- **acp-adapter.py**: SSH clone support with protocol detection (git@/ssh:// vs https://)
+- **swarm.md**: Credential auto-detection step (Step 2.5) — detects ANTHROPIC_API_KEY, GITHUB_TOKEN via env/gh-cli/SSH agent
+- **swarm.md**: Git remote fallback chain — tries origin, upstream, then first available remote
+- **swarm.md**: AUTH_METHOD-to-protocol mismatch warnings (SSH auth with HTTPS remote, and vice versa)
+- **swarm.md**: `--ssh-agent` flag passthrough in container provisioning when SSH auth detected
+- **swarm.md**: Container creation command logging for debugging
+- **swarm.md**: Resume subcommand now uses the same fallback chain and credential detection
+
+### Fixed
+
+- **swarm.md**: No longer hard-fails when `origin` remote is missing — falls back to other remotes
+- **swarm.md**: Resume subcommand no longer hard-codes `git remote get-url origin`
+- **acp-adapter.py**: SSH URLs no longer attempt HTTPS credential helper setup
+
 ## [1.21.0] - 2026-03-01
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -538,9 +538,17 @@ Invalid characters (spaces, semicolons, quotes) trigger validation errors.
 
 ## Version History
 
-**Current Version:** 1.21.0
+**Current Version:** 1.22.0
 
 ### Recent Changes
+
+**v1.22.0** - Swarm Zero-Config Credentials & Git Remote Fallback
+- Credential auto-detection: ANTHROPIC_API_KEY from env, GITHUB_TOKEN via env/gh-cli/SSH agent priority chain
+- Git remote fallback chain: origin → upstream → first available (no more hard-fail on missing origin)
+- SSH agent forwarding: `--ssh-agent` flag in sandbox-manager.sh, SSH clone support in acp-adapter.py
+- Pre-populated SSH known_hosts in Dockerfile.base (GitHub, GitLab, Bitbucket)
+- AUTH_METHOD-to-protocol mismatch warnings
+- Resume subcommand uses same fallback chain and credential detection
 
 **v1.17.0** - Swarm State Reconciliation & Auto-Approve Hooks
 - Automatic state reconciliation before `status` display and `resume` operations

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi"

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi"

--- a/plugins/aimi-engineering/commands/swarm.md
+++ b/plugins/aimi-engineering/commands/swarm.md
@@ -353,6 +353,90 @@ Only the first [maxContainers] will be executed. Remaining files can be run with
 
 Truncate `SELECTED_TASK_FILES` to `maxContainers`.
 
+## Step 2.5: Detect Credentials
+
+**CRITICAL:** Detect required credentials BEFORE provisioning any containers. This step fails fast if the Anthropic API key is missing, preventing wasted Docker resources.
+
+### Check ANTHROPIC_API_KEY (required)
+
+```bash
+echo "${ANTHROPIC_API_KEY:0:8}..." 2>/dev/null
+```
+
+If the variable is empty or unset, STOP immediately with:
+```
+ANTHROPIC_API_KEY not found in environment. Claude Code requires this to be set.
+Export it with: export ANTHROPIC_API_KEY=sk-ant-...
+```
+
+Store the masked key prefix for the summary (e.g., `sk-ant-a...`).
+
+### Detect GitHub credentials (optional, fallback chain)
+
+Try each method in priority order. Stop at the first success.
+
+**Priority 1: GITHUB_TOKEN environment variable**
+
+```bash
+echo "${GITHUB_TOKEN:0:8}..." 2>/dev/null
+```
+
+If non-empty, set `GH_AUTH_METHOD=token` and store the masked prefix. Proceed to the credential summary.
+
+**Priority 2: gh CLI authentication**
+
+```bash
+DETECTED_GH_TOKEN=$(timeout 5 gh auth token 2>/dev/null)
+```
+
+If the command succeeds (exit code 0) and output is non-empty:
+- Export the result so sandbox-manager.sh can pick it up:
+  ```bash
+  export GITHUB_TOKEN="$DETECTED_GH_TOKEN"
+  ```
+- Set `GH_AUTH_METHOD=gh-cli`
+- Store the masked prefix (`${DETECTED_GH_TOKEN:0:8}...`)
+- Proceed to the credential summary.
+
+**Priority 3: SSH agent**
+
+```bash
+test -S "${SSH_AUTH_SOCK:-}" 2>/dev/null && echo "SSH agent available"
+```
+
+If the test succeeds (SSH_AUTH_SOCK points to an existing socket):
+- Set `GH_AUTH_METHOD=ssh`
+- Set `AUTH_METHOD=ssh` for later use by container provisioning
+- Proceed to the credential summary.
+
+**Priority 4: No credentials found**
+
+If none of the above succeeded:
+- Set `GH_AUTH_METHOD=none`
+- WARN (do not stop):
+  ```
+  No GitHub credentials found. Only public repos will work.
+  Set GITHUB_TOKEN, run 'gh auth login', or start an SSH agent.
+  ```
+
+### Credential summary
+
+Display the detected credentials:
+
+```
+Credentials:
+  API Key  : found (sk-ant-a...)
+  GitHub   : gh-cli (ghp_Ax7f...)
+  Auth     : HTTPS
+```
+
+The `Auth` field displays:
+- `HTTPS` when `GH_AUTH_METHOD` is `token` or `gh-cli`
+- `SSH` when `GH_AUTH_METHOD` is `ssh`
+- `none` when `GH_AUTH_METHOD` is `none`
+
+Proceed to Step 3.
+
 ## Step 3: Initialize Swarm State
 
 ### Check for existing active swarm

--- a/plugins/aimi-engineering/commands/swarm.md
+++ b/plugins/aimi-engineering/commands/swarm.md
@@ -199,7 +199,7 @@ If arguments start with `resume`:
 
 7. **Fan out pending containers:**
    If there are containers with status `pending` (either originally pending or reset from failed):
-   - Resolve `REPO_URL` from `git remote get-url origin` if not already known.
+   - Resolve `REPO_URL` using the **same fallback chain as Step 3** (try `origin`, then `upstream`, then first available remote from `git remote`). If no remotes are found, STOP with: `"No git remotes found. Add one with: git remote add origin <url>"`. Log which remote was selected and its URL. Detect the remote URL protocol (SSH vs HTTPS) and log any AUTH_METHOD mismatch warning, same as Step 3.
    - Proceed to Step 5 (fan-out) for these pending containers only.
    - After fan-out and result collection, proceed to Step 6 for state update and reporting.
 
@@ -492,16 +492,71 @@ $AIMI_CLI swarm-init --force
 
 Store the returned `swarmId`.
 
-### Resolve git remote URL
+### Resolve git remote URL (fallback chain)
+
+Try remotes in priority order: `origin`, `upstream`, then the first available remote.
+
+**Priority 1: origin**
 ```bash
-git remote get-url origin
+REPO_URL=$(git remote get-url origin 2>/dev/null)
+SELECTED_REMOTE="origin"
 ```
 
-Store as `REPO_URL`. If no remote, report error and STOP:
+**Priority 2: upstream** (if origin not found)
+```bash
+if [ -z "$REPO_URL" ]; then
+  REPO_URL=$(git remote get-url upstream 2>/dev/null)
+  SELECTED_REMOTE="upstream"
+fi
 ```
-No git remote 'origin' found. The swarm needs a remote URL so containers can clone the repo.
-Set one with: git remote add origin <url>
+
+**Priority 3: first available remote** (if neither origin nor upstream found)
+```bash
+if [ -z "$REPO_URL" ]; then
+  FIRST_REMOTE=$(git remote | head -1)
+  if [ -n "$FIRST_REMOTE" ]; then
+    REPO_URL=$(git remote get-url "$FIRST_REMOTE" 2>/dev/null)
+    SELECTED_REMOTE="$FIRST_REMOTE"
+  fi
+fi
 ```
+
+**No remotes found — hard stop:**
+
+If `REPO_URL` is still empty after all three attempts, STOP with:
+```
+No git remotes found. Add one with: git remote add origin <url>
+```
+
+If a remote was found, log which remote was selected:
+```
+Git remote: using '[SELECTED_REMOTE]' → [REPO_URL]
+```
+
+### Detect remote URL protocol
+
+After resolving `REPO_URL`, detect whether it uses SSH or HTTPS:
+
+- If `REPO_URL` starts with `git@` or `ssh://` → log: `Remote protocol: SSH`
+- If `REPO_URL` starts with `https://` → log: `Remote protocol: HTTPS`
+- Otherwise → log: `Remote protocol: unknown`
+
+Store the detected protocol as `REMOTE_PROTOCOL` (`ssh`, `https`, or `unknown`).
+
+### AUTH_METHOD vs remote protocol mismatch warning
+
+Compare `AUTH_METHOD` (from Step 2.5 credential detection) with `REMOTE_PROTOCOL`:
+
+- If `AUTH_METHOD` is `ssh` but `REMOTE_PROTOCOL` is `https`:
+  ```
+  Warning: SSH auth detected but remote URL is HTTPS. Clone may need GITHUB_TOKEN.
+  ```
+- If `AUTH_METHOD` is NOT `ssh` (i.e., `token`, `gh-cli`, or `none`) but `REMOTE_PROTOCOL` is `ssh`:
+  ```
+  Warning: No SSH auth detected but remote URL is SSH. Clone may need SSH agent forwarding.
+  ```
+
+**Proceed regardless** — do not block on a mismatch. The actual clone attempt inside the container will determine success or failure.
 
 Report:
 ```

--- a/plugins/aimi-engineering/commands/swarm.md
+++ b/plugins/aimi-engineering/commands/swarm.md
@@ -186,10 +186,17 @@ If arguments start with `resume`:
       ```
    b. Read the task file path and branch from the swarm state entry.
    c. Verify the task file still exists on disk. If not, report error and skip this container.
-   d. Recreate the container (follows same pattern as Step 4 in the main flow):
+   d. Recreate the container (follows same pattern as Step 4 in the main flow).
+
+      If `AUTH_METHOD=ssh` (re-detect credentials using the same Step 2.5 logic if not already set in this session), append `--ssh-agent`:
       ```bash
+      # With SSH auth:
+      $SANDBOX_MGR create <containerName> --image <PROJECT_IMAGE> --task-file <taskFile> --branch <BRANCH> --ssh-agent
+      # Without SSH auth:
       $SANDBOX_MGR create <containerName> --image <PROJECT_IMAGE> --task-file <taskFile> --branch <BRANCH>
       ```
+      **Log the full container creation command for debugging** before executing it.
+
       **Note:** `PROJECT_IMAGE` must be resolved. Run `$BUILD_IMG` to build/reuse the project image if not already available.
    e. Parse the new `containerId` from the JSON output.
    f. Update the swarm state with the new container ID and reset status to `pending`:
@@ -199,6 +206,7 @@ If arguments start with `resume`:
 
 7. **Fan out pending containers:**
    If there are containers with status `pending` (either originally pending or reset from failed):
+   - Re-detect credentials using the **same Step 2.5 logic** if `AUTH_METHOD` is not already set in this session. This ensures `AUTH_METHOD=ssh` is available for any container recreation that may have occurred in step 6d.
    - Resolve `REPO_URL` using the **same fallback chain as Step 3** (try `origin`, then `upstream`, then first available remote from `git remote`). If no remotes are found, STOP with: `"No git remotes found. Add one with: git remote add origin <url>"`. Log which remote was selected and its URL. Detect the remote URL protocol (SSH vs HTTPS) and log any AUTH_METHOD mismatch warning, same as Step 3.
    - Proceed to Step 5 (fan-out) for these pending containers only.
    - After fan-out and result collection, proceed to Step 6 for state update and reporting.
@@ -597,15 +605,29 @@ For each task file in `SELECTED_TASK_FILES`:
    - Container name: `aimi-swarm-<slug>` (must match `^aimi-[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
 
 3. Create the container:
+
+   Build the create command, conditionally appending `--ssh-agent` when SSH auth was detected in Step 2.5:
+
    ```bash
-   $SANDBOX_MGR create <containerName> --image <PROJECT_IMAGE> --task-file <taskFile> --branch <BRANCH>
+   # If AUTH_METHOD=ssh (set in Step 2.5), append --ssh-agent to forward the host SSH agent socket
+   if [ "$AUTH_METHOD" = "ssh" ]; then
+     $SANDBOX_MGR create <containerName> --image <PROJECT_IMAGE> --task-file <taskFile> --branch <BRANCH> --ssh-agent
+   else
+     $SANDBOX_MGR create <containerName> --image <PROJECT_IMAGE> --task-file <taskFile> --branch <BRANCH>
+   fi
    ```
+
+   **Log the full container creation command for debugging** before executing it:
+   ```
+   [swarm] create: $SANDBOX_MGR create <containerName> --image <PROJECT_IMAGE> --task-file <taskFile> --branch <BRANCH> [--ssh-agent]
+   ```
+   (Include `--ssh-agent` in the log line only when `AUTH_METHOD=ssh`.)
 
 4. Parse the JSON output to get `containerId`.
 
-5. Register in swarm state:
+5. Register in swarm state (include the resolved `REPO_URL` for resume support):
    ```bash
-   $AIMI_CLI swarm-add <containerId> <containerName> <taskFile> <BRANCH>
+   $AIMI_CLI swarm-add <containerId> <containerName> <taskFile> <BRANCH> --repo-url <REPO_URL>
    ```
 
 6. Count stories for progress tracking:

--- a/plugins/aimi-engineering/commands/swarm.md
+++ b/plugins/aimi-engineering/commands/swarm.md
@@ -188,12 +188,18 @@ If arguments start with `resume`:
    c. Verify the task file still exists on disk. If not, report error and skip this container.
    d. Recreate the container (follows same pattern as Step 4 in the main flow).
 
-      If `AUTH_METHOD=ssh` (re-detect credentials using the same Step 2.5 logic if not already set in this session), append `--ssh-agent`:
+      Re-detect credentials using the same Step 2.5 logic if not already set in this session. Build the create command with conditional flags:
       ```bash
-      # With SSH auth:
-      $SANDBOX_MGR create <containerName> --image <PROJECT_IMAGE> --task-file <taskFile> --branch <BRANCH> --ssh-agent
-      # Without SSH auth:
-      $SANDBOX_MGR create <containerName> --image <PROJECT_IMAGE> --task-file <taskFile> --branch <BRANCH>
+      # Build create command with conditional flags
+      CREATE_FLAGS=""
+      if [ "$AUTH_METHOD" = "ssh" ]; then
+        CREATE_FLAGS="$CREATE_FLAGS --ssh-agent"
+      fi
+      if [ "$CLAUDE_AUTH" = "subscription" ]; then
+        CREATE_FLAGS="$CREATE_FLAGS --mount-claude-config"
+      fi
+
+      $SANDBOX_MGR create <containerName> --image <PROJECT_IMAGE> --task-file <taskFile> --branch <BRANCH> $CREATE_FLAGS
       ```
       **Log the full container creation command for debugging** before executing it.
 
@@ -206,7 +212,7 @@ If arguments start with `resume`:
 
 7. **Fan out pending containers:**
    If there are containers with status `pending` (either originally pending or reset from failed):
-   - Re-detect credentials using the **same Step 2.5 logic** if `AUTH_METHOD` is not already set in this session. This ensures `AUTH_METHOD=ssh` is available for any container recreation that may have occurred in step 6d.
+   - Re-detect credentials using the **same Step 2.5 logic** if `AUTH_METHOD` or `CLAUDE_AUTH` is not already set in this session. This ensures `AUTH_METHOD=ssh` and `CLAUDE_AUTH=subscription` are available for any container recreation that may have occurred in step 6d.
    - Resolve `REPO_URL` using the **same fallback chain as Step 3** (try `origin`, then `upstream`, then first available remote from `git remote`). If no remotes are found, STOP with: `"No git remotes found. Add one with: git remote add origin <url>"`. Log which remote was selected and its URL. Detect the remote URL protocol (SSH vs HTTPS) and log any AUTH_METHOD mismatch warning, same as Step 3.
    - Proceed to Step 5 (fan-out) for these pending containers only.
    - After fan-out and result collection, proceed to Step 6 for state update and reporting.
@@ -363,21 +369,37 @@ Truncate `SELECTED_TASK_FILES` to `maxContainers`.
 
 ## Step 2.5: Detect Credentials
 
-**CRITICAL:** Detect required credentials BEFORE provisioning any containers. This step fails fast if the Anthropic API key is missing, preventing wasted Docker resources.
+**CRITICAL:** Detect required credentials BEFORE provisioning any containers. This step fails fast if no authentication method is available, preventing wasted Docker resources.
 
-### Check ANTHROPIC_API_KEY (required)
+### Check subscription auth (Claude config directory)
+
+```bash
+CLAUDE_CONFIG="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+test -f "$CLAUDE_CONFIG/.credentials.json" 2>/dev/null && echo "Subscription auth found"
+```
+
+If the credentials file exists:
+- Set `CLAUDE_AUTH=subscription`
+- Log: `"Subscription auth detected: $CLAUDE_CONFIG/.credentials.json"`
+
+### Check ANTHROPIC_API_KEY
 
 ```bash
 echo "${ANTHROPIC_API_KEY:0:8}..." 2>/dev/null
 ```
 
-If the variable is empty or unset, STOP immediately with:
-```
-ANTHROPIC_API_KEY not found in environment. Claude Code requires this to be set.
-Export it with: export ANTHROPIC_API_KEY=sk-ant-...
-```
+The behavior depends on whether subscription auth was detected above:
 
-Store the masked key prefix for the summary (e.g., `sk-ant-a...`).
+- **If ANTHROPIC_API_KEY is set:** Store the masked key prefix for the summary (e.g., `sk-ant-a...`). Proceed normally regardless of `CLAUDE_AUTH`.
+- **If ANTHROPIC_API_KEY is NOT set AND `CLAUDE_AUTH=subscription`:** WARN (do not stop):
+  ```
+  ANTHROPIC_API_KEY not set, using subscription auth.
+  ```
+  Proceed — the subscription credentials will be mounted into containers.
+- **If ANTHROPIC_API_KEY is NOT set AND `CLAUDE_AUTH` is NOT `subscription`:** STOP immediately with:
+  ```
+  No authentication found. Set ANTHROPIC_API_KEY or mount Claude config directory (~/.claude/.credentials.json).
+  ```
 
 ### Detect GitHub credentials (optional, fallback chain)
 
@@ -434,9 +456,18 @@ Display the detected credentials:
 ```
 Credentials:
   API Key  : found (sk-ant-a...)
+  Claude   : subscription (config dir)
   GitHub   : gh-cli (ghp_Ax7f...)
   Auth     : HTTPS
 ```
+
+The `API Key` field displays:
+- `found (<masked prefix>)` when `ANTHROPIC_API_KEY` is set
+- `not set (using subscription auth)` when `ANTHROPIC_API_KEY` is not set but `CLAUDE_AUTH=subscription`
+
+The `Claude` field displays:
+- `subscription (config dir)` when `CLAUDE_AUTH=subscription`
+- `none` when subscription auth is not detected
 
 The `Auth` field displays:
 - `HTTPS` when `GH_AUTH_METHOD` is `token` or `gh-cli`
@@ -606,22 +637,26 @@ For each task file in `SELECTED_TASK_FILES`:
 
 3. Create the container:
 
-   Build the create command, conditionally appending `--ssh-agent` when SSH auth was detected in Step 2.5:
+   Build the create command, conditionally appending `--ssh-agent` and/or `--mount-claude-config` based on auth detected in Step 2.5:
 
    ```bash
-   # If AUTH_METHOD=ssh (set in Step 2.5), append --ssh-agent to forward the host SSH agent socket
+   # Build create command with conditional flags
+   CREATE_FLAGS=""
    if [ "$AUTH_METHOD" = "ssh" ]; then
-     $SANDBOX_MGR create <containerName> --image <PROJECT_IMAGE> --task-file <taskFile> --branch <BRANCH> --ssh-agent
-   else
-     $SANDBOX_MGR create <containerName> --image <PROJECT_IMAGE> --task-file <taskFile> --branch <BRANCH>
+     CREATE_FLAGS="$CREATE_FLAGS --ssh-agent"
    fi
+   if [ "$CLAUDE_AUTH" = "subscription" ]; then
+     CREATE_FLAGS="$CREATE_FLAGS --mount-claude-config"
+   fi
+
+   $SANDBOX_MGR create <containerName> --image <PROJECT_IMAGE> --task-file <taskFile> --branch <BRANCH> $CREATE_FLAGS
    ```
 
    **Log the full container creation command for debugging** before executing it:
    ```
-   [swarm] create: $SANDBOX_MGR create <containerName> --image <PROJECT_IMAGE> --task-file <taskFile> --branch <BRANCH> [--ssh-agent]
+   [swarm] create: $SANDBOX_MGR create <containerName> --image <PROJECT_IMAGE> --task-file <taskFile> --branch <BRANCH> [--ssh-agent] [--mount-claude-config]
    ```
-   (Include `--ssh-agent` in the log line only when `AUTH_METHOD=ssh`.)
+   (Include `--ssh-agent` only when `AUTH_METHOD=ssh`. Include `--mount-claude-config` only when `CLAUDE_AUTH=subscription`.)
 
 4. Parse the JSON output to get `containerId`.
 

--- a/plugins/aimi-engineering/skills/docker-sandbox/docker/Dockerfile.base
+++ b/plugins/aimi-engineering/skills/docker-sandbox/docker/Dockerfile.base
@@ -90,6 +90,15 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
 RUN npm install -g @anthropic-ai/claude-code && npm cache clean --force
 
 # ---------------------------------------------------------------------------
+# Pre-populate SSH known_hosts for common Git hosting providers
+# Prevents host-key verification prompts during git clone over SSH.
+# ---------------------------------------------------------------------------
+RUN mkdir -p /etc/ssh \
+    && ssh-keyscan -t ed25519,rsa,ecdsa github.com gitlab.com bitbucket.org \
+       >> /etc/ssh/ssh_known_hosts 2>/dev/null \
+    && chmod 644 /etc/ssh/ssh_known_hosts
+
+# ---------------------------------------------------------------------------
 # Non-root user: aimi (UID 1001)
 # ---------------------------------------------------------------------------
 RUN groupadd --gid 1001 aimi \

--- a/plugins/aimi-engineering/skills/docker-sandbox/scripts/acp-adapter.py
+++ b/plugins/aimi-engineering/skills/docker-sandbox/scripts/acp-adapter.py
@@ -246,10 +246,12 @@ def provision_repo(payload: dict) -> bool:
 
     Steps:
       1. Skip if /workspace/.git already exists (already provisioned).
-      2. Configure git credential helper if GITHUB_TOKEN is set.
-      3. Clone repoUrl into /workspace.
-      4. Checkout or create the target branch.
-      5. Verify the task file exists at the expected path.
+      2. Detect URL protocol (SSH vs HTTPS).
+      3. For HTTPS: configure git credential helper if GITHUB_TOKEN is set.
+         For SSH: set GIT_SSH_COMMAND with BatchMode and ConnectTimeout.
+      4. Clone repoUrl into /workspace.
+      5. Checkout or create the target branch.
+      6. Verify the task file exists at the expected path.
 
     Returns True on success. On failure, emits an error and returns False.
     """
@@ -261,27 +263,38 @@ def provision_repo(payload: dict) -> bool:
         os.chdir(WORKSPACE_DIR)
         return True
 
-    # 2. Set up git credential helper for GITHUB_TOKEN if present
-    token = os.environ.get("GITHUB_TOKEN")
-    if token:
-        log("Configuring git credential helper for GITHUB_TOKEN")
-        try:
-            subprocess.run(
-                [
-                    "git", "config", "--global", "credential.helper",
-                    "!f() { echo username=x-access-token; echo password="
-                    + token + "; }; f",
-                ],
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-        except subprocess.CalledProcessError as exc:
-            log(f"Failed to configure git credential helper: {exc.stderr}")
-            # Non-fatal — clone might still work via other auth methods
-
-    # 3. Clone the repository
+    # 2. Detect URL protocol
     repo_url = payload["repoUrl"]
+    is_ssh = repo_url.startswith("git@") or repo_url.startswith("ssh://")
+
+    if is_ssh:
+        # 3a. SSH: configure GIT_SSH_COMMAND to prevent hanging on missing
+        # agent and set a reasonable connect timeout
+        log("SSH URL detected, configuring GIT_SSH_COMMAND for non-interactive clone")
+        os.environ["GIT_SSH_COMMAND"] = (
+            "ssh -o BatchMode=yes -o ConnectTimeout=10"
+        )
+    else:
+        # 3b. HTTPS: set up git credential helper for GITHUB_TOKEN if present
+        token = os.environ.get("GITHUB_TOKEN")
+        if token:
+            log("Configuring git credential helper for GITHUB_TOKEN")
+            try:
+                subprocess.run(
+                    [
+                        "git", "config", "--global", "credential.helper",
+                        "!f() { echo username=x-access-token; echo password="
+                        + token + "; }; f",
+                    ],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+            except subprocess.CalledProcessError as exc:
+                log(f"Failed to configure git credential helper: {exc.stderr}")
+                # Non-fatal — clone might still work via other auth methods
+
+    # 4. Clone the repository
     log(f"Cloning repository {repo_url} into {WORKSPACE_DIR}")
     try:
         subprocess.run(
@@ -291,15 +304,28 @@ def provision_repo(payload: dict) -> bool:
             text=True,
         )
     except subprocess.CalledProcessError as exc:
-        msg = f"git clone failed: {exc.stderr.strip() or exc.stdout.strip()}"
+        stderr_text = exc.stderr.strip() or exc.stdout.strip()
+        msg = f"git clone failed: {stderr_text}"
         log(msg)
+
+        # For SSH URLs, provide a helpful hint about SSH agent forwarding
+        if is_ssh:
+            ssh_hint = (
+                "SSH clone failed. Ensure the SSH agent is forwarded into "
+                "the container (docker run --mount type=bind,src=$SSH_AUTH_SOCK,"
+                "target=/ssh-agent -e SSH_AUTH_SOCK=/ssh-agent) and that the "
+                "SSH key has access to the repository."
+            )
+            log(ssh_hint)
+            msg = f"{msg}. {ssh_hint}"
+
         emit_error("GIT_CLONE_FAILED", msg)
         return False
 
-    # 4. Change into workspace directory
+    # 5. Change into workspace directory
     os.chdir(WORKSPACE_DIR)
 
-    # 5. Checkout the target branch
+    # 6. Checkout the target branch
     branch_name = payload["branchName"]
     log(f"Checking out branch: {branch_name}")
     try:
@@ -331,7 +357,7 @@ def provision_repo(payload: dict) -> bool:
             emit_error("GIT_CHECKOUT_FAILED", msg)
             return False
 
-    # 6. Verify the task file exists
+    # 7. Verify the task file exists
     task_file = payload["taskFilePath"]
     if not os.path.isfile(task_file):
         msg = f"Task file not found at {task_file} after clone"

--- a/plugins/aimi-engineering/skills/docker-sandbox/scripts/acp-adapter.py
+++ b/plugins/aimi-engineering/skills/docker-sandbox/scripts/acp-adapter.py
@@ -14,7 +14,10 @@ Usage:
     docker exec <container> python /opt/aimi/acp-adapter.py --input /tmp/acp-payload.json
 
 Environment:
-    ANTHROPIC_API_KEY  - Required. Claude API key for headless mode.
+    ANTHROPIC_API_KEY  - Claude API key for headless mode (required unless
+                         CLAUDE_CONFIG_DIR is set with valid subscription auth).
+    CLAUDE_CONFIG_DIR  - Path to mounted Claude config directory containing
+                         .credentials.json for subscription-based auth.
     CONTAINER_ID       - Optional. Docker container ID for message envelope.
     SWARM_ID           - Optional. Swarm UUID for message envelope.
 """
@@ -35,7 +38,7 @@ from datetime import datetime, timezone
 # Constants
 # ---------------------------------------------------------------------------
 
-REQUIRED_ENV_VARS = ["ANTHROPIC_API_KEY"]
+REQUIRED_ENV_VARS = []
 
 VALID_TASK_REQUEST_FIELDS = {"taskFilePath", "branchName", "repoUrl", "envVars"}
 REQUIRED_TASK_REQUEST_FIELDS = {"taskFilePath", "branchName", "repoUrl"}
@@ -512,6 +515,29 @@ def main() -> int:
         log(msg)
         emit_error("MISSING_ENV_VAR", msg)
         return 1
+
+    # --- Validate authentication ---
+    has_api_key = bool(os.environ.get("ANTHROPIC_API_KEY"))
+    claude_config_dir = os.environ.get("CLAUDE_CONFIG_DIR")
+    has_claude_config = bool(claude_config_dir) and os.path.isdir(claude_config_dir)
+
+    if not has_api_key and not has_claude_config:
+        msg = ("No authentication found. Set ANTHROPIC_API_KEY env var "
+               "or mount Claude config directory (CLAUDE_CONFIG_DIR)")
+        log(msg)
+        emit_error("MISSING_ENV_VAR", msg)
+        return 1
+
+    if has_claude_config:
+        creds_path = os.path.join(claude_config_dir, ".credentials.json")
+        if not os.path.isfile(creds_path):
+            log(f"Warning: CLAUDE_CONFIG_DIR is set but {creds_path} not found — "
+                "subscription auth may fail")
+        else:
+            log(f"Using subscription auth from {claude_config_dir}")
+
+    if has_api_key:
+        log("Using ANTHROPIC_API_KEY for authentication")
 
     # --- Parse --input argument (file-based alternative to stdin) ---
     input_file = None

--- a/plugins/aimi-engineering/skills/docker-sandbox/scripts/sandbox-manager.sh
+++ b/plugins/aimi-engineering/skills/docker-sandbox/scripts/sandbox-manager.sh
@@ -13,7 +13,7 @@
 #   sandbox-manager.sh <command> [options]
 #
 # Commands:
-#   create <name> --image <image> [--task-file <path>] [--branch <branch>] [--ssh-agent]
+#   create <name> --image <image> [--task-file <path>] [--branch <branch>] [--ssh-agent] [--mount-claude-config]
 #   remove <name>
 #   list
 #   status <name>
@@ -142,6 +142,7 @@ cmd_create() {
   local container_id_env=""
   local swarm_id_env=""
   local ssh_agent=false
+  local mount_claude_config=false
 
   # Parse arguments
   while [[ $# -gt 0 ]]; do
@@ -168,6 +169,10 @@ cmd_create() {
         ;;
       --ssh-agent)
         ssh_agent=true
+        shift
+        ;;
+      --mount-claude-config)
+        mount_claude_config=true
         shift
         ;;
       -*)
@@ -290,6 +295,18 @@ cmd_create() {
       run_args+=("--env" "SSH_AUTH_SOCK=/tmp/ssh-agent.sock")
     else
       log_warn "SSH agent forwarding requested but SSH_AUTH_SOCK is not set or socket does not exist"
+    fi
+  fi
+
+  # Claude config directory mounting (read-only)
+  if [[ "$mount_claude_config" == true ]]; then
+    local claude_config_dir="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+    if [[ -d "$claude_config_dir" ]]; then
+      log_info "Mounting Claude config directory (read-only): $claude_config_dir"
+      run_args+=("-v" "${claude_config_dir}:/home/aimi/.claude:ro")
+      run_args+=("--env" "CLAUDE_CONFIG_DIR=/home/aimi/.claude")
+    else
+      log_warn "Claude config directory not found: $claude_config_dir — skipping mount"
     fi
   fi
 
@@ -572,6 +589,7 @@ Commands:
     --container-id <id>                    Pass CONTAINER_ID env to container
     --swarm-id <id>                        Pass SWARM_ID env to container
     --ssh-agent                            Forward host SSH agent into container
+    --mount-claude-config                  Mount host ~/.claude/ read-only for subscription auth
 
   remove <name>                  Stop and remove a container (idempotent)
   list                           List all aimi-* containers (JSON output)
@@ -587,6 +605,7 @@ Environment Variables:
   AIMI_SANDBOX_DISK     Disk limit label (default: 8g)
   ANTHROPIC_API_KEY     Injected into container
   GITHUB_TOKEN          Injected into container
+  CLAUDE_CONFIG_DIR     Host Claude config path (default: ~/.claude, used with --mount-claude-config)
 
 Container Naming:
   Containers are named as aimi-<slug>

--- a/plugins/aimi-engineering/skills/docker-sandbox/scripts/sandbox-manager.sh
+++ b/plugins/aimi-engineering/skills/docker-sandbox/scripts/sandbox-manager.sh
@@ -13,7 +13,7 @@
 #   sandbox-manager.sh <command> [options]
 #
 # Commands:
-#   create <name> --image <image> [--task-file <path>] [--branch <branch>]
+#   create <name> --image <image> [--task-file <path>] [--branch <branch>] [--ssh-agent]
 #   remove <name>
 #   list
 #   status <name>
@@ -141,6 +141,7 @@ cmd_create() {
   local branch=""
   local container_id_env=""
   local swarm_id_env=""
+  local ssh_agent=false
 
   # Parse arguments
   while [[ $# -gt 0 ]]; do
@@ -164,6 +165,10 @@ cmd_create() {
       --swarm-id)
         swarm_id_env="$2"
         shift 2
+        ;;
+      --ssh-agent)
+        ssh_agent=true
+        shift
         ;;
       -*)
         die "Unknown option: $1"
@@ -275,6 +280,17 @@ cmd_create() {
   fi
   if [[ -n "$swarm_id_env" ]]; then
     run_args+=("--env" "SWARM_ID=${swarm_id_env}")
+  fi
+
+  # SSH agent forwarding
+  if [[ "$ssh_agent" == true ]]; then
+    if [[ -n "${SSH_AUTH_SOCK:-}" ]] && [[ -S "${SSH_AUTH_SOCK}" ]]; then
+      log_info "SSH agent forwarding enabled"
+      run_args+=("-v" "${SSH_AUTH_SOCK}:/tmp/ssh-agent.sock")
+      run_args+=("--env" "SSH_AUTH_SOCK=/tmp/ssh-agent.sock")
+    else
+      log_warn "SSH agent forwarding requested but SSH_AUTH_SOCK is not set or socket does not exist"
+    fi
   fi
 
   # Advisory warning: per-container disk limits require specific storage driver config
@@ -555,6 +571,7 @@ Commands:
     --branch <branch>                      Git branch to pass as AIMI_BRANCH env
     --container-id <id>                    Pass CONTAINER_ID env to container
     --swarm-id <id>                        Pass SWARM_ID env to container
+    --ssh-agent                            Forward host SSH agent into container
 
   remove <name>                  Stop and remove a container (idempotent)
   list                           List all aimi-* containers (JSON output)


### PR DESCRIPTION
### Summary

- Add credential auto-detection (Step 2.5) to the swarm command — detects subscription auth (`~/.claude/.credentials.json`), `ANTHROPIC_API_KEY`, GitHub token (env / `gh auth token` / SSH agent) before provisioning containers
- Add `--ssh-agent` flag to `sandbox-manager.sh` to forward the host SSH agent into containers via socket bind-mount
- Add `--mount-claude-config` flag to `sandbox-manager.sh` to mount the host `~/.claude/` directory read-only for subscription-based auth
- Update `acp-adapter.py` to support SSH clone URLs (protocol detection, `GIT_SSH_COMMAND` configuration, helpful error hints) and make `ANTHROPIC_API_KEY` optional when `CLAUDE_CONFIG_DIR` is present
- Add git remote fallback chain (origin → upstream → first available) replacing the hard-fail on missing `origin`
- Pre-populate SSH `known_hosts` in the base Docker image for GitHub, GitLab, and Bitbucket

### Motivation

Users with Claude subscriptions (instead of raw API keys) and users who authenticate with SSH keys rather than HTTPS tokens were unable to use the swarm. This change makes the swarm work out-of-the-box for all common authentication setups by auto-detecting credentials and passing the appropriate flags to container provisioning.

### Changes

| File | What changed |
|------|-------------|
| `commands/swarm.md` | New Step 2.5 credential detection, remote fallback chain, protocol mismatch warnings, conditional `--ssh-agent` / `--mount-claude-config` flags in create commands, resume subcommand alignment |
| `scripts/sandbox-manager.sh` | New `--ssh-agent` and `--mount-claude-config` flags with SSH socket forwarding and read-only config mount |
| `scripts/acp-adapter.py` | SSH URL detection, `GIT_SSH_COMMAND` setup, `ANTHROPIC_API_KEY` made optional with `CLAUDE_CONFIG_DIR` fallback, auth validation logic |
| `docker/Dockerfile.base` | `ssh-keyscan` for GitHub/GitLab/Bitbucket known hosts |
| `CHANGELOG.md` | v1.22.0 and v1.23.0 entries |

### Test plan

- [ ] Run `/aimi:swarm` with `ANTHROPIC_API_KEY` set, no subscription auth — verify existing behavior unchanged
- [ ] Run `/aimi:swarm` with subscription auth only (no `ANTHROPIC_API_KEY`) — verify `--mount-claude-config` is passed and containers start successfully
- [ ] Run `/aimi:swarm` with SSH remote URL and SSH agent — verify `--ssh-agent` is passed and clone succeeds inside container
- [ ] Run `/aimi:swarm` with no `origin` remote but an `upstream` remote — verify fallback chain resolves correctly
- [ ] Run `/aimi:swarm resume` — verify credential re-detection and flag passthrough on container recreation
- [ ] Verify credential summary output shows correct auth methods