### PR TITLE
Reduce plugin token footprint across agents, skills, and commands

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and swarm orchestration.",
-      "version": "1.23.0",
+      "version": "1.23.1",
       "author": {
         "name": "Stanley Takamatsu",
         "url": "https://github.com/aimi-so"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.23.1] - 2026-03-02
+
+### Changed
+
+- **commands**: Extract CLI path resolution boilerplate to shared reference at `commands/references/cli-path-resolution.md`
+- **execute.md**: Replace Step 0 CLI resolution block with pointer to shared reference
+- **status.md**: Replace Step 0 CLI resolution block with pointer to shared reference
+- **next.md**: Replace Step 0 CLI resolution block with pointer to shared reference
+- **swarm.md**: Replace AIMI CLI resolution block in Step 0 with pointer to shared reference
+
 ## [1.23.0] - 2026-03-01
 
 ### Added

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi"

--- a/plugins/aimi-engineering/CLAUDE.md
+++ b/plugins/aimi-engineering/CLAUDE.md
@@ -83,32 +83,8 @@ Learnings are stored in project files (not separate progress log):
 
 ## Tasks File Schema
 
-### Required Fields
-
-```json
-{
-  "schemaVersion": "3.0",
-  "metadata": {
-    "title": "feat: Add feature name",
-    "type": "feat|ref|bug|chore",
-    "branchName": "feat/feature-name",
-    "createdAt": "YYYY-MM-DD",
-    "planPath": null,
-    "brainstormPath": null,
-    "maxConcurrency": 4
-  },
-  "userStories": [{
-    "id": "US-XXX",
-    "title": "string (max 200)",
-    "description": "string (max 500)",
-    "acceptanceCriteria": ["string"],
-    "priority": 1,
-    "status": "pending",
-    "dependsOn": [],
-    "notes": ""
-  }]
-}
-```
+> **Schema:** See `task-format-v3.md` in `skills/task-planner/references/`. Full v3 specification with status state machine, dependency system, and validation rules.
+> Key fields: `schemaVersion`, `metadata{title,type,branchName,maxConcurrency}`, `userStories[]{id,title,description,acceptanceCriteria,status,dependsOn}`
 
 
 ## Performance Guidelines

--- a/plugins/aimi-engineering/agents/design/aimi-design-implementation-reviewer.md
+++ b/plugins/aimi-engineering/agents/design/aimi-design-implementation-reviewer.md
@@ -11,12 +11,6 @@ user: "I've finished implementing the hero section based on the Figma design"
 assistant: "I'll review how well your implementation matches the Figma design."
 <commentary>Since UI implementation has been completed, use the design-implementation-reviewer agent to compare the live version with Figma.</commentary>
 </example>
-<example>
-Context: After the general code agent has implemented design changes.
-user: "Update the button styles to match the new design system"
-assistant: "I've updated the button styles. Now let me verify the implementation matches the Figma specifications."
-<commentary>After implementing design changes, proactively use the design-implementation-reviewer to ensure accuracy.</commentary>
-</example>
 </examples>
 
 You are an expert UI/UX implementation reviewer specializing in ensuring pixel-perfect fidelity between Figma designs and live implementations. You have deep expertise in visual design principles, CSS, responsive design, and cross-browser compatibility.

--- a/plugins/aimi-engineering/agents/design/aimi-design-iterator.md
+++ b/plugins/aimi-engineering/agents/design/aimi-design-iterator.md
@@ -7,28 +7,10 @@ model: inherit
 
 <examples>
 <example>
-Context: User asks to change button color but result still looks off.
-user: "Change the button to blue"
-assistant: [makes change, takes screenshot] "The button is now blue, but I notice the overall color balance still feels off. Would you like me to use the design-iterator agent with 5 iterations to systematically improve the color harmony and visual balance?"
-<commentary>PROACTIVE USE: After a simple change doesn't fully resolve the design issue, suggest the design-iterator to do deeper work.</commentary>
-</example>
-<example>
 Context: User's design request leads to something that doesn't look right.
 user: "Make the hero section more modern"
 assistant: [makes initial changes] "I've added some modern elements, but the result isn't quite coming together. This looks like it needs iterative refinement. Let me use the design-iterator agent with 10 iterations to systematically improve typography, spacing, colors, and visual hierarchy until it feels polished."
 <commentary>PROACTIVE USE: When initial design work produces mediocre results, automatically suggest or use the design-iterator for comprehensive improvement.</commentary>
-</example>
-<example>
-Context: User wants explicit iterative refinement.
-user: "The features section looks boring, iterate on it 10 times"
-assistant: "I'll use the design-iterator agent to systematically refine your features section through 10 iterations of visual improvements"
-<commentary>User explicitly requests iteration, use design-iterator directly.</commentary>
-</example>
-<example>
-Context: Design task requires research and multiple passes.
-user: "Look at how Stripe does their pricing page and make mine better"
-assistant: "I'll launch the design-iterator agent with 8 iterations to research Stripe's design patterns and progressively apply those insights to your pricing page"
-<commentary>Competitor research combined with iterative refinement benefits from the systematic approach.</commentary>
 </example>
 </examples>
 

--- a/plugins/aimi-engineering/agents/design/aimi-figma-design-sync.md
+++ b/plugins/aimi-engineering/agents/design/aimi-figma-design-sync.md
@@ -11,16 +11,6 @@ Context: User has just implemented a new component and wants to ensure it matche
 user: "I've just finished implementing the hero section component. Can you check if it matches the Figma design at https://figma.com/file/abc123/design?node-id=45:678"
 assistant: "I'll use the figma-design-sync agent to compare your implementation with the Figma design and fix any differences."
 </example>
-<example>
-Context: User is working on responsive design and wants to verify mobile breakpoint matches design.
-user: "The mobile view doesn't look quite right. Here's the Figma: https://figma.com/file/xyz789/mobile?node-id=12:34"
-assistant: "Let me use the figma-design-sync agent to identify the differences and fix them."
-</example>
-<example>
-Context: After initial fixes, user wants to verify the implementation now matches.
-user: "Can you check if the button component matches the design now?"
-assistant: "I'll run the figma-design-sync agent again to verify the implementation matches the Figma design."
-</example>
 </examples>
 
 You are an expert design-to-code synchronization specialist with deep expertise in visual design systems, web development, CSS/Tailwind styling, and automated quality assurance. Your mission is to ensure pixel-perfect alignment between Figma designs and their web implementations through systematic comparison, detailed analysis, and precise code adjustments.

--- a/plugins/aimi-engineering/agents/docs/aimi-ankane-readme-writer.md
+++ b/plugins/aimi-engineering/agents/docs/aimi-ankane-readme-writer.md
@@ -12,12 +12,6 @@ user: "I need to write a README for my new search gem called 'turbo-search'"
 assistant: "I'll use the ankane-readme-writer agent to create a properly formatted README following the Ankane style guide"
 <commentary>Since the user needs a README for a Ruby gem and wants to follow best practices, use the ankane-readme-writer agent to ensure it follows the Ankane template structure.</commentary>
 </example>
-<example>
-Context: User has an existing README that needs to be reformatted.
-user: "Can you update my gem's README to follow the Ankane style?"
-assistant: "Let me use the ankane-readme-writer agent to reformat your README according to the Ankane template"
-<commentary>The user explicitly wants to follow Ankane style, so use the specialized agent for this formatting standard.</commentary>
-</example>
 </examples>
 
 You are an expert Ruby gem documentation writer specializing in the Ankane-style README format. You have deep knowledge of Ruby ecosystem conventions and excel at creating clear, concise documentation that follows Andrew Kane's proven template structure.

--- a/plugins/aimi-engineering/agents/research/aimi-best-practices-researcher.md
+++ b/plugins/aimi-engineering/agents/research/aimi-best-practices-researcher.md
@@ -6,12 +6,6 @@ model: inherit
 
 <examples>
 <example>
-Context: User wants to know the best way to structure GitHub issues for their Rails project.
-user: "I need to create some GitHub issues for our project. Can you research best practices for writing good issues?"
-assistant: "I'll use the aimi-best-practices-researcher agent to gather comprehensive information about GitHub issue best practices, including examples from successful projects and Rails-specific conventions."
-<commentary>Since the user is asking for research on best practices, use the aimi-best-practices-researcher agent to gather external documentation and examples.</commentary>
-</example>
-<example>
 Context: User is implementing a new authentication system and wants to follow security best practices.
 user: "We're adding JWT authentication to our Rails API. What are the current best practices?"
 assistant: "Let me use the aimi-best-practices-researcher agent to research current JWT authentication best practices, security considerations, and Rails-specific implementation patterns."

--- a/plugins/aimi-engineering/agents/research/aimi-codebase-researcher.md
+++ b/plugins/aimi-engineering/agents/research/aimi-codebase-researcher.md
@@ -11,18 +11,6 @@ user: "I need to understand how this project is organized and what patterns they
 assistant: "I'll use the aimi-codebase-researcher agent to conduct a thorough analysis of the repository structure and patterns."
 <commentary>Since the user needs comprehensive repository research, use the aimi-codebase-researcher agent to examine all aspects of the project.</commentary>
 </example>
-<example>
-Context: User is preparing to create a GitHub issue and wants to follow project conventions.
-user: "Before I create this issue, can you check what format and labels this project uses?"
-assistant: "Let me use the aimi-codebase-researcher agent to examine the repository's issue patterns and guidelines."
-<commentary>The user needs to understand issue formatting conventions, so use the aimi-codebase-researcher agent to analyze existing issues and templates.</commentary>
-</example>
-<example>
-Context: User is implementing a new feature and wants to follow existing patterns.
-user: "I want to add a new service object - what patterns does this codebase use?"
-assistant: "I'll use the aimi-codebase-researcher agent to search for existing implementation patterns in the codebase."
-<commentary>Since the user needs to understand implementation patterns, use the aimi-codebase-researcher agent to search and analyze the codebase.</commentary>
-</example>
 </examples>
 
 **Note: The current year is 2026.** Use this when searching for recent documentation and patterns.

--- a/plugins/aimi-engineering/agents/research/aimi-framework-docs-researcher.md
+++ b/plugins/aimi-engineering/agents/research/aimi-framework-docs-researcher.md
@@ -11,12 +11,6 @@ user: "I need to implement file uploads using Active Storage"
 assistant: "I'll use the aimi-framework-docs-researcher agent to gather comprehensive documentation about Active Storage"
 <commentary>Since the user needs to understand a framework/library feature, use the aimi-framework-docs-researcher agent to collect all relevant documentation and best practices.</commentary>
 </example>
-<example>
-Context: The user is troubleshooting an issue with a gem.
-user: "Why is the turbo-rails gem not working as expected?"
-assistant: "Let me use the aimi-framework-docs-researcher agent to investigate the turbo-rails documentation and source code"
-<commentary>The user needs to understand library behavior, so the aimi-framework-docs-researcher agent should be used to gather documentation and explore the gem's source.</commentary>
-</example>
 </examples>
 
 **Note: The current year is 2026.** Use this when searching for recent documentation and version information.

--- a/plugins/aimi-engineering/agents/research/aimi-learnings-researcher.md
+++ b/plugins/aimi-engineering/agents/research/aimi-learnings-researcher.md
@@ -11,18 +11,6 @@ user: "I need to add email threading to the brief system"
 assistant: "I'll use the aimi-learnings-researcher agent to check .aimi/solutions/ for any relevant learnings about email processing or brief system implementations."
 <commentary>Since the user is implementing a feature in a documented domain, use the aimi-learnings-researcher agent to surface relevant past solutions before starting work.</commentary>
 </example>
-<example>
-Context: User is debugging a performance issue.
-user: "Brief generation is slow, taking over 5 seconds"
-assistant: "Let me use the aimi-learnings-researcher agent to search for documented performance issues, especially any involving briefs or N+1 queries."
-<commentary>The user has symptoms matching potential documented solutions, so use the aimi-learnings-researcher agent to find relevant learnings before debugging.</commentary>
-</example>
-<example>
-Context: Planning a new feature that touches multiple modules.
-user: "I need to add Stripe subscription handling to the payments module"
-assistant: "I'll use the aimi-learnings-researcher agent to search for any documented learnings about payments, integrations, or Stripe specifically."
-<commentary>Before implementing, check institutional knowledge for gotchas, patterns, and lessons learned in similar domains.</commentary>
-</example>
 </examples>
 
 You are an expert institutional knowledge researcher specializing in efficiently surfacing relevant documented solutions from the team's knowledge base. Your mission is to find and distill applicable learnings before new work begins, preventing repeated mistakes and leveraging proven patterns.

--- a/plugins/aimi-engineering/agents/review/aimi-agent-native-reviewer.md
+++ b/plugins/aimi-engineering/agents/review/aimi-agent-native-reviewer.md
@@ -6,12 +6,6 @@ model: inherit
 
 <examples>
 <example>
-Context: The user added a new feature to their application.
-user: "I just implemented a new email filtering feature"
-assistant: "I'll use the agent-native-reviewer to verify this feature is accessible to agents"
-<commentary>New features need agent-native review to ensure agents can also filter emails, not just humans through UI.</commentary>
-</example>
-<example>
 Context: The user created a new UI workflow.
 user: "I added a multi-step wizard for creating reports"
 assistant: "Let me check if this workflow is agent-native using the agent-native-reviewer"

--- a/plugins/aimi-engineering/agents/review/aimi-architecture-strategist.md
+++ b/plugins/aimi-engineering/agents/review/aimi-architecture-strategist.md
@@ -11,12 +11,6 @@ user: "I just refactored the authentication service to use a new pattern"
 assistant: "I'll use the architecture-strategist agent to review these changes from an architectural perspective"
 <commentary>Since the user has made structural changes to a service, use the architecture-strategist agent to ensure the refactoring aligns with system architecture.</commentary>
 </example>
-<example>
-Context: The user is adding a new microservice to the system.
-user: "I've added a new notification service that integrates with our existing services"
-assistant: "Let me analyze this with the architecture-strategist agent to ensure it fits properly within our system architecture"
-<commentary>New service additions require architectural review to verify proper boundaries and integration patterns.</commentary>
-</example>
 </examples>
 
 You are a System Architecture Expert specializing in analyzing code changes and system design decisions. Your role is to ensure that all modifications align with established architectural patterns, maintain system integrity, and follow best practices for scalable, maintainable software systems.

--- a/plugins/aimi-engineering/agents/review/aimi-code-simplicity-reviewer.md
+++ b/plugins/aimi-engineering/agents/review/aimi-code-simplicity-reviewer.md
@@ -11,12 +11,6 @@ user: "I've finished implementing the user authentication system"
 assistant: "Great! Let me review the implementation for simplicity and minimalism using the code-simplicity-reviewer agent"
 <commentary>Since implementation is complete, use the code-simplicity-reviewer agent to identify simplification opportunities.</commentary>
 </example>
-<example>
-Context: The user has written complex business logic and wants to simplify it.
-user: "I think this order processing logic might be overly complex"
-assistant: "I'll use the code-simplicity-reviewer agent to analyze the complexity and suggest simplifications"
-<commentary>The user is explicitly concerned about complexity, making this a perfect use case for the code-simplicity-reviewer.</commentary>
-</example>
 </examples>
 
 You are a code simplicity expert specializing in minimalism and the YAGNI (You Aren't Gonna Need It) principle. Your mission is to ruthlessly simplify code while maintaining functionality and clarity.

--- a/plugins/aimi-engineering/agents/review/aimi-data-integrity-guardian.md
+++ b/plugins/aimi-engineering/agents/review/aimi-data-integrity-guardian.md
@@ -11,12 +11,6 @@ user: "I've created a migration to add a status column to the orders table"
 assistant: "I'll use the data-integrity-guardian agent to review this migration for safety and data integrity concerns"
 <commentary>Since the user has created a database migration, use the data-integrity-guardian agent to ensure the migration is safe, handles existing data properly, and maintains referential integrity.</commentary>
 </example>
-<example>
-Context: The user has implemented a service that transfers data between models.
-user: "Here's my new service that moves user data from the legacy_users table to the new users table"
-assistant: "Let me have the data-integrity-guardian agent review this data transfer service"
-<commentary>Since this involves moving data between tables, the data-integrity-guardian should review transaction boundaries, data validation, and integrity preservation.</commentary>
-</example>
 </examples>
 
 You are a Data Integrity Guardian, an expert in database design, data migration safety, and data governance. Your deep expertise spans relational database theory, ACID properties, data privacy regulations (GDPR, CCPA), and production database management.

--- a/plugins/aimi-engineering/agents/review/aimi-data-migration-expert.md
+++ b/plugins/aimi-engineering/agents/review/aimi-data-migration-expert.md
@@ -11,12 +11,6 @@ user: "Review this PR that migrates from action_id to action_module_name"
 assistant: "I'll use the data-migration-expert agent to validate the ID mappings and migration safety"
 <commentary>Since the PR involves ID mappings and data migration, use the data-migration-expert to verify the mappings match production and check for swapped values.</commentary>
 </example>
-<example>
-Context: The user has a migration that transforms enum values.
-user: "This migration converts status integers to string enums"
-assistant: "Let me have the data-migration-expert verify the mapping logic and rollback safety"
-<commentary>Enum conversions are high-risk for swapped mappings, making this a perfect use case for data-migration-expert.</commentary>
-</example>
 </examples>
 
 You are a Data Migration Expert. Your mission is to prevent data corruption by validating that migrations match production reality, not fixture or assumed values.

--- a/plugins/aimi-engineering/agents/review/aimi-deployment-verification-agent.md
+++ b/plugins/aimi-engineering/agents/review/aimi-deployment-verification-agent.md
@@ -11,12 +11,6 @@ user: "This PR changes the classification logic, can you create a deployment che
 assistant: "I'll use the deployment-verification-agent to create a Go/No-Go checklist with verification queries"
 <commentary>Since the PR affects production data behavior, use deployment-verification-agent to create concrete verification and rollback plans.</commentary>
 </example>
-<example>
-Context: The user is deploying a migration that backfills data.
-user: "We're about to deploy the user status backfill"
-assistant: "Let me create a deployment verification checklist with pre/post-deploy checks"
-<commentary>Backfills are high-risk deployments that need concrete verification plans and rollback procedures.</commentary>
-</example>
 </examples>
 
 You are a Deployment Verification Agent. Your mission is to produce concrete, executable checklists for risky data deployments so engineers aren't guessing at launch time.

--- a/plugins/aimi-engineering/agents/review/aimi-dhh-rails-reviewer.md
+++ b/plugins/aimi-engineering/agents/review/aimi-dhh-rails-reviewer.md
@@ -11,18 +11,6 @@ user: "I just implemented a new user authentication system using JWT tokens and 
 assistant: "I'll use the DHH Rails reviewer agent to evaluate this implementation"
 <commentary>Since the user has implemented authentication with patterns that might be influenced by JavaScript frameworks (JWT, separate API layer), the dhh-rails-reviewer agent should analyze this critically.</commentary>
 </example>
-<example>
-Context: The user is planning a new Rails feature and wants feedback on the approach.
-user: "I'm thinking of using Redux-style state management for our Rails admin panel"
-assistant: "Let me invoke the DHH Rails reviewer to analyze this architectural decision"
-<commentary>The mention of Redux-style patterns in a Rails app is exactly the kind of thing the dhh-rails-reviewer agent should scrutinize.</commentary>
-</example>
-<example>
-Context: The user has written a Rails service object and wants it reviewed.
-user: "I've created a new service object for handling user registrations with dependency injection"
-assistant: "I'll use the DHH Rails reviewer agent to review this service object implementation"
-<commentary>Dependency injection patterns might be overengineering in Rails context, making this perfect for dhh-rails-reviewer analysis.</commentary>
-</example>
 </examples>
 
 You are David Heinemeier Hansson, creator of Ruby on Rails, reviewing code and architectural decisions. You embody DHH's philosophy: Rails is omakase, convention over configuration, and the majestic monolith. You have zero tolerance for unnecessary complexity, JavaScript framework patterns infiltrating Rails, or developers trying to turn Rails into something it's not.

--- a/plugins/aimi-engineering/agents/review/aimi-julik-frontend-races-reviewer.md
+++ b/plugins/aimi-engineering/agents/review/aimi-julik-frontend-races-reviewer.md
@@ -13,14 +13,6 @@ assistant: "I've implemented the controller. Now let me have Julik take a look a
 Since new Stimulus controller code was written, use the julik-frontend-races-reviewer agent to apply Julik's uncanny knowledge of UI data races and quality checks in JavaScript and Stimulus code.
 </commentary>
 </example>
-<example>
-Context: The user has refactored an existing Stimulus controller.
-user: "Please refactor the controller to slowly animate one of the targets"
-assistant: "I've refactored the controller to slowly animate one of the targets."
-<commentary>
-After modifying existing Stimulus controllers, especially things concerning time and asynchronous operations, use julik-frontend-reviewer to ensure the changes meet Julik's bar for absence of UI races in JavaScript code.
-</commentary>
-</example>
 </examples>
 
 You are Julik, a seasoned full-stack developer with a keen eye for data races and UI quality. You review all code changes with focus on timing, because timing is everything.

--- a/plugins/aimi-engineering/agents/review/aimi-kieran-python-reviewer.md
+++ b/plugins/aimi-engineering/agents/review/aimi-kieran-python-reviewer.md
@@ -13,24 +13,6 @@ assistant: "I've implemented the registration endpoint. Now let me have Kieran r
 Since new endpoint code was written, use the kieran-python-reviewer agent to apply Kieran's strict Python conventions and quality checks.
 </commentary>
 </example>
-<example>
-Context: The user has refactored an existing service class.
-user: "Please refactor the EmailService class to handle attachments"
-assistant: "I've refactored the EmailService to handle attachments."
-<commentary>
-After modifying existing code, especially services, use kieran-python-reviewer to ensure the changes meet Kieran's high bar for code quality.
-</commentary>
-assistant: "Let me have Kieran review these changes to the EmailService."
-</example>
-<example>
-Context: The user has created new utility functions.
-user: "Create a data validation module"
-assistant: "I've created the data validation module."
-<commentary>
-New modules should be reviewed by kieran-python-reviewer to check Pythonic patterns, type hints, and best practices.
-</commentary>
-assistant: "I'll have Kieran review this module to ensure it follows our conventions."
-</example>
 </examples>
 
 You are Kieran, a super senior Python developer with impeccable taste and an exceptionally high bar for Python code quality. You review all code changes with a keen eye for Pythonic patterns, type safety, and maintainability.

--- a/plugins/aimi-engineering/agents/review/aimi-kieran-rails-reviewer.md
+++ b/plugins/aimi-engineering/agents/review/aimi-kieran-rails-reviewer.md
@@ -13,24 +13,6 @@ assistant: "I've implemented the update action. Now let me have Kieran review th
 Since new controller code was written, use the kieran-rails-reviewer agent to apply Kieran's strict Rails conventions and quality checks.
 </commentary>
 </example>
-<example>
-Context: The user has refactored an existing service object.
-user: "Please refactor the EmailProcessor service to handle attachments"
-assistant: "I've refactored the EmailProcessor service to handle attachments."
-<commentary>
-After modifying existing code, especially services, use kieran-rails-reviewer to ensure the changes meet Kieran's high bar for code quality.
-</commentary>
-assistant: "Let me have Kieran review these changes to the EmailProcessor service."
-</example>
-<example>
-Context: The user has created new view components.
-user: "Create a modal component for fact checking"
-assistant: "I've created the fact checking modal component."
-<commentary>
-New components should be reviewed by kieran-rails-reviewer to check naming conventions, clarity, and Rails best practices.
-</commentary>
-assistant: "I'll have Kieran review this new component to ensure it follows our conventions."
-</example>
 </examples>
 
 You are Kieran, a super senior Rails developer with impeccable taste and an exceptionally high bar for Rails code quality. You review all code changes with a keen eye for Rails conventions, clarity, and maintainability.

--- a/plugins/aimi-engineering/agents/review/aimi-kieran-typescript-reviewer.md
+++ b/plugins/aimi-engineering/agents/review/aimi-kieran-typescript-reviewer.md
@@ -13,24 +13,6 @@ assistant: "I've implemented the UserProfile component. Now let me have Kieran r
 Since new component code was written, use the kieran-typescript-reviewer agent to apply Kieran's strict TypeScript conventions and quality checks.
 </commentary>
 </example>
-<example>
-Context: The user has refactored an existing service module.
-user: "Please refactor the EmailService to handle attachments"
-assistant: "I've refactored the EmailService to handle attachments."
-<commentary>
-After modifying existing code, especially services, use kieran-typescript-reviewer to ensure the changes meet Kieran's high bar for code quality.
-</commentary>
-assistant: "Let me have Kieran review these changes to the EmailService."
-</example>
-<example>
-Context: The user has created new utility functions.
-user: "Create a validation utility for user input"
-assistant: "I've created the validation utility functions."
-<commentary>
-New utilities should be reviewed by kieran-typescript-reviewer to check type safety, naming conventions, and TypeScript best practices.
-</commentary>
-assistant: "I'll have Kieran review these utilities to ensure they follow our conventions."
-</example>
 </examples>
 
 You are Kieran, a super senior TypeScript developer with impeccable taste and an exceptionally high bar for TypeScript code quality. You review all code changes with a keen eye for type safety, modern patterns, and maintainability.

--- a/plugins/aimi-engineering/agents/review/aimi-pattern-recognition-specialist.md
+++ b/plugins/aimi-engineering/agents/review/aimi-pattern-recognition-specialist.md
@@ -11,12 +11,6 @@ user: "Can you check our codebase for design patterns and anti-patterns?"
 assistant: "I'll use the pattern-recognition-specialist agent to analyze your codebase for patterns, anti-patterns, and code quality issues."
 <commentary>Since the user is asking for pattern analysis and code quality review, use the Task tool to launch the pattern-recognition-specialist agent.</commentary>
 </example>
-<example>
-Context: After implementing a new feature, the user wants to ensure it follows established patterns.
-user: "I just added a new service layer. Can we check if it follows our existing patterns?"
-assistant: "Let me use the pattern-recognition-specialist agent to analyze the new service layer and compare it with existing patterns in your codebase."
-<commentary>The user wants pattern consistency verification, so use the pattern-recognition-specialist agent to analyze the code.</commentary>
-</example>
 </examples>
 
 You are a Code Pattern Analysis Expert specializing in identifying design patterns, anti-patterns, and code quality issues across codebases. Your expertise spans multiple programming languages with deep knowledge of software architecture principles and best practices.

--- a/plugins/aimi-engineering/agents/review/aimi-performance-oracle.md
+++ b/plugins/aimi-engineering/agents/review/aimi-performance-oracle.md
@@ -13,22 +13,6 @@ assistant: "I'll use the performance-oracle agent to analyze the scalability and
 Since the user is concerned about scalability, use the Task tool to launch the performance-oracle agent to analyze the code for performance issues.
 </commentary>
 </example>
-<example>
-Context: The user is experiencing slow API responses.
-user: "The API endpoint for fetching reports is taking over 2 seconds to respond"
-assistant: "Let me invoke the performance-oracle agent to identify the performance bottlenecks in your API endpoint."
-<commentary>
-The user has a performance issue, so use the performance-oracle agent to analyze and identify bottlenecks.
-</commentary>
-</example>
-<example>
-Context: After writing a data processing algorithm.
-user: "I've written a function to match users based on their preferences"
-assistant: "I've implemented the matching function. Now let me use the performance-oracle agent to ensure it will scale efficiently."
-<commentary>
-After implementing an algorithm, proactively use the performance-oracle agent to verify its performance characteristics.
-</commentary>
-</example>
 </examples>
 
 You are the Performance Oracle, an elite performance optimization expert specializing in identifying and resolving performance bottlenecks in software systems. Your deep expertise spans algorithmic complexity analysis, database optimization, memory management, caching strategies, and system scalability.

--- a/plugins/aimi-engineering/agents/review/aimi-schema-drift-detector.md
+++ b/plugins/aimi-engineering/agents/review/aimi-schema-drift-detector.md
@@ -11,12 +11,6 @@ user: "Review this PR - it adds a new category template"
 assistant: "I'll use the schema-drift-detector agent to verify the schema.rb only contains changes from your migration"
 <commentary>Since the PR includes schema.rb, use schema-drift-detector to catch unrelated changes from local database state.</commentary>
 </example>
-<example>
-Context: The PR has schema changes that look suspicious.
-user: "The schema.rb diff looks larger than expected"
-assistant: "Let me use the schema-drift-detector to identify which schema changes are unrelated to your PR's migrations"
-<commentary>Schema drift is common when developers run migrations from main while on a feature branch.</commentary>
-</example>
 </examples>
 
 You are a Schema Drift Detector. Your mission is to prevent accidental inclusion of unrelated schema.rb changes in PRs - a common issue when developers run migrations from other branches.

--- a/plugins/aimi-engineering/agents/review/aimi-security-sentinel.md
+++ b/plugins/aimi-engineering/agents/review/aimi-security-sentinel.md
@@ -11,18 +11,6 @@ user: "I've just finished implementing the user authentication endpoints. Can yo
 assistant: "I'll use the security-sentinel agent to perform a comprehensive security review of your authentication endpoints."
 <commentary>Since the user is asking for a security review of authentication code, use the security-sentinel agent to scan for vulnerabilities and ensure secure implementation.</commentary>
 </example>
-<example>
-Context: The user is concerned about potential SQL injection vulnerabilities in their database queries.
-user: "I'm worried about SQL injection in our search functionality. Can you review it?"
-assistant: "Let me launch the security-sentinel agent to analyze your search functionality for SQL injection vulnerabilities and other security concerns."
-<commentary>The user explicitly wants a security review focused on SQL injection, which is a core responsibility of the security-sentinel agent.</commentary>
-</example>
-<example>
-Context: After implementing a new feature, the user wants to ensure no sensitive data is exposed.
-user: "I've added the payment processing module. Please check if any sensitive data might be exposed."
-assistant: "I'll deploy the security-sentinel agent to scan for sensitive data exposure and other security vulnerabilities in your payment processing module."
-<commentary>Payment processing involves sensitive data, making this a perfect use case for the security-sentinel agent to identify potential data exposure risks.</commentary>
-</example>
 </examples>
 
 You are an elite Application Security Specialist with deep expertise in identifying and mitigating security vulnerabilities. You think like an attacker, constantly asking: Where are the vulnerabilities? What could go wrong? How could this be exploited?

--- a/plugins/aimi-engineering/agents/workflow/aimi-bug-reproduction-validator.md
+++ b/plugins/aimi-engineering/agents/workflow/aimi-bug-reproduction-validator.md
@@ -11,12 +11,6 @@ user: "Users are reporting that the email processing fails when there are specia
 assistant: "I'll use the bug-reproduction-validator agent to verify if this is an actual bug by attempting to reproduce it"
 <commentary>Since there's a bug report about email processing with special characters, use the bug-reproduction-validator agent to systematically reproduce and validate the issue.</commentary>
 </example>
-<example>
-Context: An issue has been raised about unexpected behavior.
-user: "There's a report that the brief summary isn't including all emails from today"
-assistant: "Let me launch the bug-reproduction-validator agent to investigate and reproduce this reported issue"
-<commentary>A potential bug has been reported about the brief summary functionality, so the bug-reproduction-validator should be used to verify if this is actually a bug.</commentary>
-</example>
 </examples>
 
 You are a meticulous Bug Reproduction Specialist with deep expertise in systematic debugging and issue validation. Your primary mission is to determine whether reported issues are genuine bugs or expected behavior/user errors.

--- a/plugins/aimi-engineering/agents/workflow/aimi-pr-comment-resolver.md
+++ b/plugins/aimi-engineering/agents/workflow/aimi-pr-comment-resolver.md
@@ -12,12 +12,6 @@ user: "The reviewer commented that we should add error handling to the payment p
 assistant: "I'll use the pr-comment-resolver agent to address this comment by implementing the error handling and reporting back"
 <commentary>Since there's a PR comment that needs to be addressed with code changes, use the pr-comment-resolver agent to handle the implementation and resolution.</commentary>
 </example>
-<example>
-Context: Multiple code review comments need to be addressed systematically.
-user: "Can you fix the issues mentioned in the code review? They want better variable names and to extract the validation logic"
-assistant: "Let me use the pr-comment-resolver agent to address these review comments one by one"
-<commentary>The user wants to resolve code review feedback, so the pr-comment-resolver agent should handle making the changes and reporting on each resolution.</commentary>
-</example>
 </examples>
 
 You are an expert code review resolution specialist. Your primary responsibility is to take comments from pull requests or code reviews, implement the requested changes, and provide clear reports on how each comment was resolved.

--- a/plugins/aimi-engineering/agents/workflow/aimi-spec-flow-analyzer.md
+++ b/plugins/aimi-engineering/agents/workflow/aimi-spec-flow-analyzer.md
@@ -6,22 +6,10 @@ model: inherit
 
 <examples>
 <example>
-Context: The user has just finished drafting a specification for OAuth implementation.
-user: "Here's the OAuth spec for our new integration: [OAuth spec details]"
-assistant: "Let me use the aimi-spec-flow-analyzer agent to analyze this OAuth specification for user flows and missing elements."
-<commentary>Since the user has provided a specification document, use the Task tool to launch the aimi-spec-flow-analyzer agent to identify all user flows, edge cases, and missing clarifications.</commentary>
-</example>
-<example>
 Context: The user is planning a new social sharing feature.
 user: "I'm thinking we should add social sharing to posts. Users can share to Twitter, Facebook, and LinkedIn."
 assistant: "This sounds like a feature specification that would benefit from flow analysis. Let me use the aimi-spec-flow-analyzer agent to map out all the user flows and identify any missing pieces."
 <commentary>The user is describing a new feature. Use the aimi-spec-flow-analyzer agent to analyze the feature from the user's perspective, identify all permutations, and surface questions about missing elements.</commentary>
-</example>
-<example>
-Context: The user has created a plan for a new onboarding flow.
-user: "Can you review this onboarding plan and make sure we haven't missed anything?"
-assistant: "I'll use the aimi-spec-flow-analyzer agent to thoroughly analyze this onboarding plan from the user's perspective."
-<commentary>The user is explicitly asking for review of a plan. Use the aimi-spec-flow-analyzer agent to identify all user flows, edge cases, and gaps in the specification.</commentary>
 </example>
 </examples>
 

--- a/plugins/aimi-engineering/commands/execute.md
+++ b/plugins/aimi-engineering/commands/execute.md
@@ -13,30 +13,7 @@ Each wave collects all ready stories. Single-story waves run inline (no worktree
 
 ## Step 0: Resolve CLI Path
 
-**CRITICAL:** The CLI script lives in the plugin install directory, NOT the project directory. Resolve it first:
-
-```bash
-# Glob always finds the latest installed version
-AIMI_CLI=$(ls ~/.claude/plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh 2>/dev/null | tail -1)
-# Fallback to cached cli-path if glob found nothing (edge case)
-if [ -z "$AIMI_CLI" ] && [ -f .aimi/cli-path ] && [ -x "$(cat .aimi/cli-path)" ]; then
-  AIMI_CLI=$(cat .aimi/cli-path)
-fi
-```
-
-If empty, report: "aimi-cli.sh not found. Reinstall plugin: `/plugin install aimi-engineering`" and STOP.
-
-### Version Check
-
-After resolving `$AIMI_CLI`, verify the cached CLI path is current:
-
-```bash
-$AIMI_CLI check-version --quiet --fix
-```
-
-If `check-version` exits 0, no action is needed — proceed normally. The `--quiet` flag suppresses informational output and `--fix` auto-updates a stale cli-path. This does NOT call `cleanup-versions` (cleanup is manual-only).
-
-**Use `$AIMI_CLI` for ALL subsequent script calls in this command.**
+Resolve `$AIMI_CLI` path using glob discovery with fallback, then verify version. See `commands/references/cli-path-resolution.md` for the full resolution logic (glob -> fallback -> version check). Use `$AIMI_CLI` for all subsequent script calls.
 
 ## Step 1: Initialize Session
 

--- a/plugins/aimi-engineering/commands/next.md
+++ b/plugins/aimi-engineering/commands/next.md
@@ -11,30 +11,7 @@ Execute the next pending story using a Task-spawned agent.
 
 ## Step 0: Resolve CLI Path
 
-**CRITICAL:** The CLI script lives in the plugin install directory, NOT the project directory. Resolve it first:
-
-```bash
-# Glob always finds the latest installed version
-AIMI_CLI=$(ls ~/.claude/plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh 2>/dev/null | tail -1)
-# Fallback to cached cli-path if glob found nothing (edge case)
-if [ -z "$AIMI_CLI" ] && [ -f .aimi/cli-path ] && [ -x "$(cat .aimi/cli-path)" ]; then
-  AIMI_CLI=$(cat .aimi/cli-path)
-fi
-```
-
-If empty, report: "aimi-cli.sh not found. Reinstall plugin: `/plugin install aimi-engineering`" and STOP.
-
-### Version Check
-
-After resolving `$AIMI_CLI`, verify the cached CLI path is current:
-
-```bash
-$AIMI_CLI check-version --quiet --fix
-```
-
-If `check-version` exits 0, no action is needed — proceed normally. The `--quiet` flag suppresses informational output and `--fix` auto-updates a stale cli-path. This does NOT call `cleanup-versions` (cleanup is manual-only).
-
-**Use `$AIMI_CLI` for ALL subsequent script calls in this command.**
+Resolve `$AIMI_CLI` path using glob discovery with fallback, then verify version. See `commands/references/cli-path-resolution.md` for the full resolution logic (glob -> fallback -> version check). Use `$AIMI_CLI` for all subsequent script calls.
 
 ## Step 1: Get Next Story
 

--- a/plugins/aimi-engineering/commands/plan.md
+++ b/plugins/aimi-engineering/commands/plan.md
@@ -130,61 +130,8 @@ Write JSON using the Write tool. Validate JSON is well-formed before writing.
 
 ### Output Format
 
-```json
-{
-  "schemaVersion": "3.0",
-  "metadata": {
-    "title": "feat: Feature name",
-    "type": "feat",
-    "branchName": "feat/feature-name",
-    "createdAt": "YYYY-MM-DD",
-    "planPath": null,
-    "maxConcurrency": 4
-  },
-  "userStories": [
-    {
-      "id": "US-001",
-      "title": "Schema/data layer story",
-      "description": "As a [user], I want [feature] so that [benefit]",
-      "acceptanceCriteria": ["Criterion 1", "Typecheck passes"],
-      "priority": 1,
-      "status": "pending",
-      "dependsOn": [],
-      "notes": ""
-    },
-    {
-      "id": "US-002",
-      "title": "Backend story depending on schema",
-      "description": "As a [user], I want [feature] so that [benefit]",
-      "acceptanceCriteria": ["Criterion 1", "Typecheck passes"],
-      "priority": 2,
-      "status": "pending",
-      "dependsOn": ["US-001"],
-      "notes": ""
-    },
-    {
-      "id": "US-003",
-      "title": "Independent UI story",
-      "description": "As a [user], I want [feature] so that [benefit]",
-      "acceptanceCriteria": ["Criterion 1", "Typecheck passes"],
-      "priority": 3,
-      "status": "pending",
-      "dependsOn": ["US-001"],
-      "notes": ""
-    },
-    {
-      "id": "US-004",
-      "title": "Aggregation story needing both",
-      "description": "As a [user], I want [feature] so that [benefit]",
-      "acceptanceCriteria": ["Criterion 1", "Typecheck passes"],
-      "priority": 4,
-      "status": "pending",
-      "dependsOn": ["US-002", "US-003"],
-      "notes": ""
-    }
-  ]
-}
-```
+> **Schema:** See `task-format-v3.md` in `skills/task-planner/references/`. Full v3 specification with complete example, validation rules, and dependency system.
+> Key fields: `schemaVersion`, `metadata{title,type,branchName,createdAt,planPath,maxConcurrency}`, `userStories[]{id,title,description,acceptanceCriteria,priority,status,dependsOn,notes}`
 
 ### Checklist Before Writing
 

--- a/plugins/aimi-engineering/commands/references/cli-path-resolution.md
+++ b/plugins/aimi-engineering/commands/references/cli-path-resolution.md
@@ -1,0 +1,30 @@
+# CLI Path Resolution
+
+Shared reference for resolving `$AIMI_CLI` across all commands. This file is the single source of truth for the CLI resolution logic.
+
+## Resolve CLI Path
+
+**CRITICAL:** The CLI script lives in the plugin install directory, NOT the project directory. Resolve it first:
+
+```bash
+# Glob always finds the latest installed version
+AIMI_CLI=$(ls ~/.claude/plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh 2>/dev/null | tail -1)
+# Fallback to cached cli-path if glob found nothing (edge case)
+if [ -z "$AIMI_CLI" ] && [ -f .aimi/cli-path ] && [ -x "$(cat .aimi/cli-path)" ]; then
+  AIMI_CLI=$(cat .aimi/cli-path)
+fi
+```
+
+If empty, report: "aimi-cli.sh not found. Reinstall plugin: `/plugin install aimi-engineering`" and STOP.
+
+## Version Check
+
+After resolving `$AIMI_CLI`, verify the cached CLI path is current:
+
+```bash
+$AIMI_CLI check-version --quiet --fix
+```
+
+If `check-version` exits 0, no action is needed — proceed normally. The `--quiet` flag suppresses informational output and `--fix` auto-updates a stale cli-path. This does NOT call `cleanup-versions` (cleanup is manual-only).
+
+**Use `$AIMI_CLI` for ALL subsequent script calls in this command.**

--- a/plugins/aimi-engineering/commands/status.md
+++ b/plugins/aimi-engineering/commands/status.md
@@ -43,26 +43,10 @@ If `check-version` exits 0, no action is needed — proceed normally. The `--qui
 $AIMI_CLI status
 ```
 
-This returns JSON:
+This returns JSON with status counts and story list.
 
-```json
-{
-  "schemaVersion": "3.0",
-  "title": "feat: Feature name",
-  "branch": "feat/feature-name",
-  "maxConcurrency": 4,
-  "pending": 3,
-  "in_progress": 1,
-  "completed": 2,
-  "failed": 0,
-  "skipped": 0,
-  "total": 6,
-  "userStories": [
-    {"id": "US-001", "title": "Story title", "status": "completed", "dependsOn": [], "priority": 1, "notes": ""},
-    {"id": "US-002", "title": "Story title", "status": "in_progress", "dependsOn": ["US-001"], "priority": 2, "notes": ""}
-  ]
-}
-```
+> **Schema:** See `task-format-v3.md` in `skills/task-planner/references/`. The CLI status output mirrors the tasks.json structure with added aggregate counts.
+> Key fields: `schemaVersion`, `title`, `branch`, `maxConcurrency`, status counts (`pending`,`in_progress`,`completed`,`failed`,`skipped`,`total`), `userStories[]{id,title,status,dependsOn,priority,notes}`
 
 If no tasks file found, the script exits with error. Report:
 ```

--- a/plugins/aimi-engineering/commands/status.md
+++ b/plugins/aimi-engineering/commands/status.md
@@ -10,30 +10,7 @@ Display the current execution progress using the CLI script.
 
 ## Step 0: Resolve CLI Path
 
-**CRITICAL:** The CLI script lives in the plugin install directory, NOT the project directory. Resolve it first:
-
-```bash
-# Glob always finds the latest installed version
-AIMI_CLI=$(ls ~/.claude/plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh 2>/dev/null | tail -1)
-# Fallback to cached cli-path if glob found nothing (edge case)
-if [ -z "$AIMI_CLI" ] && [ -f .aimi/cli-path ] && [ -x "$(cat .aimi/cli-path)" ]; then
-  AIMI_CLI=$(cat .aimi/cli-path)
-fi
-```
-
-If empty, report: "aimi-cli.sh not found. Reinstall plugin: `/plugin install aimi-engineering`" and STOP.
-
-### Version Check
-
-After resolving `$AIMI_CLI`, verify the cached CLI path is current:
-
-```bash
-$AIMI_CLI check-version --quiet --fix
-```
-
-If `check-version` exits 0, no action is needed — proceed normally. The `--quiet` flag suppresses informational output and `--fix` auto-updates a stale cli-path. This does NOT call `cleanup-versions` (cleanup is manual-only).
-
-**Use `$AIMI_CLI` for ALL subsequent script calls in this command.**
+Resolve `$AIMI_CLI` path using glob discovery with fallback, then verify version. See `commands/references/cli-path-resolution.md` for the full resolution logic (glob -> fallback -> version check). Use `$AIMI_CLI` for all subsequent script calls.
 
 ## Step 1: Get Status via CLI
 

--- a/plugins/aimi-engineering/commands/swarm.md
+++ b/plugins/aimi-engineering/commands/swarm.md
@@ -13,25 +13,9 @@ Execute multiple tasks.json files in parallel Docker sandboxes. Each task file r
 
 **CRITICAL:** Resolve all tool paths from the plugin install directory first.
 
-```bash
-# CLI script
-AIMI_CLI=$(ls ~/.claude/plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh 2>/dev/null | tail -1)
-if [ -z "$AIMI_CLI" ] && [ -f .aimi/cli-path ] && [ -x "$(cat .aimi/cli-path)" ]; then
-  AIMI_CLI=$(cat .aimi/cli-path)
-fi
-```
+### AIMI CLI
 
-If empty, report: "aimi-cli.sh not found. Reinstall plugin: `/plugin install aimi-engineering`" and STOP.
-
-### Version Check
-
-After resolving `$AIMI_CLI`, verify the cached CLI path is current:
-
-```bash
-$AIMI_CLI check-version --quiet --fix
-```
-
-If `check-version` exits 0, no action is needed — proceed normally. The `--quiet` flag suppresses informational output and `--fix` auto-updates a stale cli-path. This does NOT call `cleanup-versions` (cleanup is manual-only).
+Resolve `$AIMI_CLI` path using glob discovery with fallback, then verify version. See `commands/references/cli-path-resolution.md` for the full resolution logic (glob -> fallback -> version check).
 
 ```bash
 # Sandbox manager

--- a/plugins/aimi-engineering/skills/agent-native-architecture/SKILL.md
+++ b/plugins/aimi-engineering/skills/agent-native-architecture/SKILL.md
@@ -6,13 +6,7 @@ description: Build applications where agents are first-class citizens. Use this 
 <why_now>
 ## Why Now
 
-Software agents work reliably now. Claude Code demonstrated that an LLM with access to bash and file tools, operating in a loop until an objective is achieved, can accomplish complex multi-step tasks autonomously.
-
-The surprising discovery: **a really good coding agent is actually a really good general-purpose agent.** The same architecture that lets Claude Code refactor a codebase can let an agent organize your files, manage your reading list, or automate your workflows.
-
-The Claude Code SDK makes this accessible. You can build applications where features aren't code you write—they're outcomes you describe, achieved by an agent with tools, operating in a loop until the outcome is reached.
-
-This opens up a new field: software that works the way Claude Code works, applied to categories far beyond coding.
+Software agents work reliably now. Claude Code proved that an LLM with bash and file tools, looping until an objective is met, can accomplish complex tasks autonomously. The same architecture applies beyond coding — file management, workflows, any domain. The Claude Code SDK makes this accessible: features aren't code you write, they're outcomes agents achieve.
 </why_now>
 
 <core_principles>
@@ -20,155 +14,78 @@ This opens up a new field: software that works the way Claude Code works, applie
 
 ### 1. Parity
 
-**Whatever the user can do through the UI, the agent should be able to achieve through tools.**
+**Whatever the user can do through the UI, the agent must be able to achieve through tools.**
 
-This is the foundational principle. Without it, nothing else matters.
+This doesn't require 1:1 mapping of UI buttons to tools — it requires the agent can achieve the same **outcomes**. Sometimes that's a single tool (`create_note`), sometimes it's composing primitives (`write_file` to a notes directory).
 
-Imagine you build a notes app with a beautiful interface for creating, organizing, and tagging notes. A user asks the agent: "Create a note summarizing my meeting and tag it as urgent."
+**Discipline:** When adding any UI capability, ask: can the agent achieve this outcome? If not, add the necessary tools or primitives.
 
-If you built UI for creating notes but no agent capability to do the same, the agent is stuck. It might apologize or ask clarifying questions, but it can't help—even though the action is trivial for a human using the interface.
-
-**The fix:** Ensure the agent has tools (or combinations of tools) that can accomplish anything the UI can do.
-
-This isn't about creating a 1:1 mapping of UI buttons to tools. It's about ensuring the agent can **achieve the same outcomes**. Sometimes that's a single tool (`create_note`). Sometimes it's composing primitives (`write_file` to a notes directory with proper formatting).
-
-**The discipline:** When adding any UI capability, ask: can the agent achieve this outcome? If not, add the necessary tools or primitives.
-
-A capability map helps:
-
-| User Action | How Agent Achieves It |
-|-------------|----------------------|
-| Create a note | `write_file` to notes directory, or `create_note` tool |
-| Tag a note as urgent | `update_file` metadata, or `tag_note` tool |
-| Search notes | `search_files` or `search_notes` tool |
-| Delete a note | `delete_file` or `delete_note` tool |
-
-**The test:** Pick any action a user can take in your UI. Describe it to the agent. Can it accomplish the outcome?
-
----
+> Read [action-parity-discipline.md](./references/action-parity-discipline.md) for capability mapping workflow.
 
 ### 2. Granularity
 
 **Prefer atomic primitives. Features are outcomes achieved by an agent operating in a loop.**
 
-A tool is a primitive capability: read a file, write a file, run a bash command, store a record, send a notification.
+A tool is a primitive capability (read file, write file, run bash). A **feature** is an outcome described in a prompt, achieved by an agent with tools looping until done.
 
-A **feature** is not a function you write. It's an outcome you describe in a prompt, achieved by an agent that has tools and operates in a loop until the outcome is reached.
-
-**Less granular (limits the agent):**
 ```
-Tool: classify_and_organize_files(files)
-→ You wrote the decision logic
-→ Agent executes your code
-→ To change behavior, you refactor
+Less granular: classify_and_organize_files(files)  → You wrote the logic
+More granular: read_file, write_file, move_file    → Agent makes decisions
+              Prompt: "Organize downloads by content and recency"
 ```
 
-**More granular (empowers the agent):**
-```
-Tools: read_file, write_file, move_file, list_directory, bash
-Prompt: "Organize the user's downloads folder. Analyze each file,
-        determine appropriate locations based on content and recency,
-        and move them there."
-Agent: Operates in a loop—reads files, makes judgments, moves things,
-       checks results—until the folder is organized.
-→ Agent makes the decisions
-→ To change behavior, you edit the prompt
-```
-
-**The key shift:** The agent is pursuing an outcome with judgment, not executing a choreographed sequence. It might encounter unexpected file types, adjust its approach, or ask clarifying questions. The loop continues until the outcome is achieved.
-
-The more atomic your tools, the more flexibly the agent can use them. If you bundle decision logic into tools, you've moved judgment back into code.
-
-**The test:** To change how a feature behaves, do you edit prose or refactor code?
-
----
+**Key shift:** To change how a feature behaves, you edit prose, not refactor code.
 
 ### 3. Composability
 
-**With atomic tools and parity, you can create new features just by writing new prompts.**
+**With atomic tools and parity, new features are just new prompts.**
 
-This is the payoff of the first two principles. When your tools are atomic and the agent can do anything users can do, new features are just new prompts.
+Want a "weekly review" feature? Write a prompt: *"Review files modified this week, summarize changes, suggest three priorities."* The agent uses `list_files`, `read_file`, and judgment. No weekly-review code needed. Users can extend behavior the same way.
 
-Want a "weekly review" feature that summarizes activity and suggests priorities? That's a prompt:
-
-```
-"Review files modified this week. Summarize key changes. Based on
-incomplete items and approaching deadlines, suggest three priorities
-for next week."
-```
-
-The agent uses `list_files`, `read_file`, and its judgment to accomplish this. You didn't write weekly-review code. You described an outcome, and the agent operates in a loop until it's achieved.
-
-**This works for developers and users.** You can ship new features by adding prompts. Users can customize behavior by modifying prompts or creating their own. "When I say 'file this,' always move it to my Action folder and tag it urgent" becomes a user-level prompt that extends the application.
-
-**The constraint:** This only works if tools are atomic enough to be composed in ways you didn't anticipate, and if the agent has parity with users. If tools encode too much logic, or the agent can't access key capabilities, composition breaks down.
-
-**The test:** Can you add a new feature by writing a new prompt section, without adding new code?
-
----
+**Constraint:** Only works if tools are atomic enough for unanticipated composition and the agent has parity.
 
 ### 4. Emergent Capability
 
 **The agent can accomplish things you didn't explicitly design for.**
 
-When tools are atomic, parity is maintained, and prompts are composable, users will ask the agent for things you never anticipated. And often, the agent can figure it out.
+When tools are atomic and parity is maintained, users ask for unanticipated things — and the agent figures them out. This reveals latent demand: observe what users ask, then optimize common patterns with domain tools or dedicated prompts.
 
-*"Cross-reference my meeting notes with my task list and tell me what I've committed to but haven't scheduled."*
-
-You didn't build a "commitment tracker" feature. But if the agent can read notes, read tasks, and reason about them—operating in a loop until it has an answer—it can accomplish this.
-
-**This reveals latent demand.** Instead of guessing what features users want, you observe what they're asking the agent to do. When patterns emerge, you can optimize them with domain-specific tools or dedicated prompts. But you didn't have to anticipate them—you discovered them.
-
-**The flywheel:**
-1. Build with atomic tools and parity
-2. Users ask for things you didn't anticipate
-3. Agent composes tools to accomplish them (or fails, revealing a gap)
-4. You observe patterns in what's being requested
-5. Add domain tools or prompts to make common patterns efficient
-6. Repeat
-
-This changes how you build products. You're not trying to imagine every feature upfront. You're creating a capable foundation and learning from what emerges.
-
-**The test:** Give the agent an open-ended request relevant to your domain. Can it figure out a reasonable approach, operating in a loop until it succeeds? If it just says "I don't have a feature for that," your architecture is too constrained.
-
----
+**Flywheel:** Atomic tools + parity → users request unexpected things → agent composes solutions → you observe patterns → optimize → repeat.
 
 ### 5. Improvement Over Time
 
-**Agent-native applications get better through accumulated context and prompt refinement.**
+**Agent-native apps get better through accumulated context and prompt refinement.**
 
-Unlike traditional software, agent-native applications can improve without shipping code:
+- **Accumulated context:** Agent maintains state across sessions via `context.md` or structured memory
+- **Prompt refinement:** Developer ships updated prompts; users customize theirs; agents self-modify (advanced)
+- **Self-modification:** Agents editing own prompts/code — add safety rails for production
 
-**Accumulated context:** The agent can maintain state across sessions—what exists, what the user has done, what worked, what didn't. A `context.md` file the agent reads and updates is layer one. More sophisticated approaches involve structured memory and learned preferences.
+> Read [self-modification.md](./references/self-modification.md) for guardrails.
 
-**Prompt refinement at multiple levels:**
-- **Developer level:** You ship updated prompts that change agent behavior for all users
-- **User level:** Users customize prompts for their workflow
-- **Agent level:** The agent modifies its own prompts based on feedback (advanced)
-
-**Self-modification (advanced):** Agents that can edit their own prompts or even their own code. For production use cases, consider adding safety rails—approval gates, automatic checkpoints for rollback, health checks. This is where things are heading.
-
-The improvement mechanisms are still being discovered. Context and prompt refinement are proven. Self-modification is emerging. What's clear: the architecture supports getting better in ways traditional software doesn't.
-
-**The test:** Does the application work better after a month of use than on day one, even without code changes?
+**Test for each principle:**
+1. Parity — Can the agent achieve any UI action?
+2. Granularity — Do you edit prose or refactor code to change behavior?
+3. Composability — Can you add features by writing prompts alone?
+4. Emergent — Can the agent handle open-ended domain requests?
+5. Improvement — Does it work better after a month, without code changes?
 </core_principles>
 
 <intake>
 ## What aspect of agent-native architecture do you need help with?
 
-1. **Design architecture** - Plan a new agent-native system from scratch
-2. **Files & workspace** - Use files as the universal interface, shared workspace patterns
-3. **Tool design** - Build primitive tools, dynamic capability discovery, CRUD completeness
-4. **Domain tools** - Know when to add domain tools vs stay with primitives
-5. **Execution patterns** - Completion signals, partial completion, context limits
-6. **System prompts** - Define agent behavior in prompts, judgment criteria
-7. **Context injection** - Inject runtime app state into agent prompts
-8. **Action parity** - Ensure agents can do everything users can do
-9. **Self-modification** - Enable agents to safely evolve themselves
-10. **Product design** - Progressive disclosure, latent demand, approval patterns
-11. **Mobile patterns** - iOS storage, background execution, checkpoint/resume
-12. **Testing** - Test agent-native apps for capability and parity
-13. **Refactoring** - Make existing code more agent-native
+1. **Design architecture** — Plan a new agent-native system
+2. **Files & workspace** — Files as universal interface, shared workspace
+3. **Tool design** — Primitive tools, dynamic capability discovery, CRUD
+4. **Domain tools** — When to add domain tools vs stay with primitives
+5. **Execution patterns** — Completion signals, partial completion, context limits
+6. **System prompts** — Agent behavior in prompts, judgment criteria
+7. **Context injection** — Inject runtime app state into agent prompts
+8. **Action parity** — Ensure agents can do everything users can
+9. **Self-modification** — Agents safely evolving themselves
+10. **Product design** — Progressive disclosure, latent demand, approval patterns
+11. **Mobile patterns** — iOS storage, background execution, checkpoint/resume
+12. **Testing** — Capability and parity tests for agent-native apps
+13. **Refactoring** — Make existing code more agent-native
 
 **Wait for response before proceeding.**
 </intake>
@@ -196,82 +113,47 @@ The improvement mechanisms are still being discovered. Context and prompt refine
 <architecture_checklist>
 ## Architecture Review Checklist
 
-When designing an agent-native system, verify these **before implementation**:
+Verify these **before implementation**:
 
-### Core Principles
 - [ ] **Parity:** Every UI action has a corresponding agent capability
 - [ ] **Granularity:** Tools are primitives; features are prompt-defined outcomes
-- [ ] **Composability:** New features can be added via prompts alone
-- [ ] **Emergent Capability:** Agent can handle open-ended requests in your domain
-
-### Tool Design
-- [ ] **Dynamic vs Static:** For external APIs where agent should have full access, use Dynamic Capability Discovery
+- [ ] **Composability:** New features via prompts alone
+- [ ] **Emergent Capability:** Agent handles open-ended domain requests
+- [ ] **Dynamic vs Static:** Use Dynamic Capability Discovery for external APIs
 - [ ] **CRUD Completeness:** Every entity has create, read, update, AND delete
 - [ ] **Primitives not Workflows:** Tools enable capability, don't encode business logic
-- [ ] **API as Validator:** Use `z.string()` inputs when the API validates, not `z.enum()`
-
-### Files & Workspace
 - [ ] **Shared Workspace:** Agent and user work in same data space
-- [ ] **context.md Pattern:** Agent reads/updates context file for accumulated knowledge
-- [ ] **File Organization:** Entity-scoped directories with consistent naming
-
-### Agent Execution
-- [ ] **Completion Signals:** Agent has explicit `complete_task` tool (not heuristic detection)
+- [ ] **context.md Pattern:** Agent reads/updates context for accumulated knowledge
+- [ ] **Completion Signals:** Explicit `complete_task` tool (not heuristic detection)
 - [ ] **Partial Completion:** Multi-step tasks track progress for resume
-- [ ] **Context Limits:** Designed for bounded context from the start
+- [ ] **Context Injection:** System prompt includes available resources, capabilities, vocabulary
+- [ ] **Agent → UI:** Agent changes reflect in UI immediately
+- [ ] **Mobile (if applicable):** Checkpoint/resume, iCloud-first, cost-aware model selection
 
-### Context Injection
-- [ ] **Available Resources:** System prompt includes what exists (files, data, types)
-- [ ] **Available Capabilities:** System prompt documents tools with user vocabulary
-- [ ] **Dynamic Context:** Context refreshes for long sessions (or provide `refresh_context` tool)
-
-### UI Integration
-- [ ] **Agent → UI:** Agent changes reflect in UI (shared service, file watching, or event bus)
-- [ ] **No Silent Actions:** Agent writes trigger UI updates immediately
-- [ ] **Capability Discovery:** Users can learn what agent can do
-
-### Mobile (if applicable)
-- [ ] **Checkpoint/Resume:** Handle iOS app suspension gracefully
-- [ ] **iCloud Storage:** iCloud-first with local fallback for multi-device sync
-- [ ] **Cost Awareness:** Model tier selection (Haiku/Sonnet/Opus)
-
-**When designing architecture, explicitly address each checkbox in your plan.**
+**When designing architecture, explicitly address each checkbox.**
 </architecture_checklist>
 
 <quick_start>
-## Quick Start: Build an Agent-Native Feature
+## Quick Start: Agent-Native Feature
 
-**Step 1: Define atomic tools**
 ```typescript
+// Step 1: Atomic tools
 const tools = [
   tool("read_file", "Read any file", { path: z.string() }, ...),
   tool("write_file", "Write any file", { path: z.string(), content: z.string() }, ...),
   tool("list_files", "List directory", { path: z.string() }, ...),
-  tool("complete_task", "Signal task completion", { summary: z.string() }, ...),
+  tool("complete_task", "Signal completion", { summary: z.string() }, ...),
 ];
-```
 
-**Step 2: Write behavior in the system prompt**
-```markdown
-## Your Responsibilities
-When asked to organize content, you should:
-1. Read existing files to understand the structure
+// Step 2: Behavior in system prompt
+const systemPrompt = `When asked to organize content:
+1. Read existing files to understand structure
 2. Analyze what organization makes sense
 3. Create/move files using your tools
-4. Use your judgment about layout and formatting
-5. Call complete_task when you're done
+4. Call complete_task when done. You decide the structure.`;
 
-You decide the structure. Make it good.
-```
-
-**Step 3: Let the agent work in a loop**
-```typescript
-const result = await agent.run({
-  prompt: userMessage,
-  tools: tools,
-  systemPrompt: systemPrompt,
-  // Agent loops until it calls complete_task
-});
+// Step 3: Agent loops until complete_task is called
+const result = await agent.run({ prompt: userMessage, tools, systemPrompt });
 ```
 </quick_start>
 
@@ -304,132 +186,67 @@ All references in `references/`:
 <anti_patterns>
 ## Anti-Patterns
 
-### Common Approaches That Aren't Fully Agent-Native
+### Approaches That Aren't Agent-Native
 
-These aren't necessarily wrong—they may be appropriate for your use case. But they're worth recognizing as different from the architecture this document describes.
+**Agent as router** — Agent figures out intent, calls a function. Uses intelligence to route, not to act. You're using a fraction of agent capability.
 
-**Agent as router** — The agent figures out what the user wants, then calls the right function. The agent's intelligence is used to route, not to act. This can work, but you're using a fraction of what agents can do.
+**Build app, then add agent** — Features built as code, then exposed to agent. No emergent capability possible.
 
-**Build the app, then add agent** — You build features the traditional way (as code), then expose them to an agent. The agent can only do what your features already do. You won't get emergent capability.
+**Request/response thinking** — Agent does one thing and returns. Misses the loop: agent pursues an outcome, handles unexpected situations along the way.
 
-**Request/response thinking** — Agent gets input, does one thing, returns output. This misses the loop: agent gets an outcome to achieve, operates until it's done, handles unexpected situations along the way.
+**Defensive tool design** — Over-constrained inputs (strict enums, excessive validation) prevent unanticipated usage.
 
-**Defensive tool design** — You over-constrain tool inputs because you're used to defensive programming. Strict enums, validation at every layer. This is safe, but it prevents the agent from doing things you didn't anticipate.
-
-**Happy path in code, agent just executes** — Traditional software handles edge cases in code—you write the logic for what happens when X goes wrong. Agent-native lets the agent handle edge cases with judgment. If your code handles all the edge cases, the agent is just a caller.
-
----
+**Happy path in code** — Edge cases handled in code means the agent is just a caller, not using judgment.
 
 ### Specific Anti-Patterns
 
-**THE CARDINAL SIN: Agent executes your code instead of figuring things out**
-
+**Cardinal sin: Agent executes your code instead of figuring things out**
 ```typescript
-// WRONG - You wrote the workflow, agent just executes it
+// WRONG: You wrote the workflow
 tool("process_feedback", async ({ message }) => {
-  const category = categorize(message);      // Your code decides
-  const priority = calculatePriority(message); // Your code decides
-  await store(message, category, priority);   // Your code orchestrates
-  if (priority > 3) await notify();           // Your code decides
+  const cat = categorize(message); const pri = calculatePriority(message);
+  await store(message, cat, pri); if (pri > 3) await notify();
 });
-
-// RIGHT - Agent figures out how to process feedback
-tools: store_item, send_message  // Primitives
-prompt: "Rate importance 1-5 based on actionability, store feedback, notify if >= 4"
+// RIGHT: Agent decides
+tools: store_item, send_message
+prompt: "Rate importance 1-5, store feedback, notify if >= 4"
 ```
 
-**Workflow-shaped tools** — `analyze_and_organize` bundles judgment into the tool. Break it into primitives and let the agent compose them.
+**Workflow-shaped tools** — `analyze_and_organize` bundles judgment. Break into primitives.
 
-**Context starvation** — Agent doesn't know what resources exist in the app.
-```
-User: "Write something about Catherine the Great in my feed"
-Agent: "What feed? I don't understand what system you're referring to."
-```
-Fix: Inject available resources, capabilities, and vocabulary into system prompt.
+**Context starvation** — Agent doesn't know what resources exist. Fix: inject available resources and vocabulary into system prompt.
 
-**Orphan UI actions** — User can do something through the UI that the agent can't achieve. Fix: maintain parity.
+**Orphan UI actions** — User can do something the agent can't. Fix: maintain parity.
 
-**Silent actions** — Agent changes state but UI doesn't update. Fix: Use shared data stores with reactive binding, or file system observation.
+**Silent actions** — Agent changes state, UI doesn't update. Fix: shared data stores with reactive binding.
 
-**Heuristic completion detection** — Detecting agent completion through heuristics (consecutive iterations without tool calls, checking for expected output files). This is fragile. Fix: Require agents to explicitly signal completion through a `complete_task` tool.
+**Heuristic completion** — Detecting completion through heuristics is fragile. Fix: explicit `complete_task` tool.
 
-**Static tool mapping for dynamic APIs** — Building 50 tools for 50 API endpoints when a `discover` + `access` pattern would give more flexibility.
-```typescript
-// WRONG - Every API type needs a hardcoded tool
-tool("read_steps", ...)
-tool("read_heart_rate", ...)
-tool("read_sleep", ...)
-// When glucose tracking is added... code change required
+**Static tool mapping** — 50 tools for 50 API endpoints. Fix: `discover` + `access` pattern for dynamic APIs.
 
-// RIGHT - Dynamic capability discovery
-tool("list_available_types", ...)  // Discover what's available
-tool("read_health_data", { dataType: z.string() }, ...)  // Access any type
-```
+**Incomplete CRUD** — Agent can create but not update or delete. Fix: every entity needs full CRUD.
 
-**Incomplete CRUD** — Agent can create but not update or delete.
-```typescript
-// User: "Delete that journal entry"
-// Agent: "I don't have a tool for that"
-tool("create_journal_entry", ...)  // Missing: update, delete
-```
-Fix: Every entity needs full CRUD.
+**Sandbox isolation** — Agent works in separate data space. Fix: shared workspace.
 
-**Sandbox isolation** — Agent works in separate data space from user.
-```
-Documents/
-├── user_files/        ← User's space
-└── agent_output/      ← Agent's space (isolated)
-```
-Fix: Use shared workspace where both operate on same files.
-
-**Gates without reason** — Domain tool is the only way to do something, and you didn't intend to restrict access. The default is open. Keep primitives available unless there's a specific reason to gate.
-
-**Artificial capability limits** — Restricting what the agent can do out of vague safety concerns rather than specific risks. Be thoughtful about restricting capabilities. The agent should generally be able to do what users can do.
+**Gates without reason** — Domain tool is the only path, restricting access unintentionally. Keep primitives available.
 </anti_patterns>
 
 <success_criteria>
 ## Success Criteria
 
-You've built an agent-native application when:
+**Architecture:**
+- [ ] Agent achieves anything users can (parity)
+- [ ] Tools are atomic; domain tools are shortcuts, not gates (granularity)
+- [ ] New features via prompts alone (composability)
+- [ ] Agent handles unanticipated domain tasks (emergent capability)
+- [ ] Behavior changes via prompt edits, not code refactoring
 
-### Architecture
-- [ ] The agent can achieve anything users can achieve through the UI (parity)
-- [ ] Tools are atomic primitives; domain tools are shortcuts, not gates (granularity)
-- [ ] New features can be added by writing new prompts (composability)
-- [ ] The agent can accomplish tasks you didn't explicitly design for (emergent capability)
-- [ ] Changing behavior means editing prompts, not refactoring code
-
-### Implementation
+**Implementation:**
 - [ ] System prompt includes dynamic context about app state
-- [ ] Every UI action has a corresponding agent tool (action parity)
-- [ ] Agent tools are documented in system prompt with user vocabulary
-- [ ] Agent and user work in the same data space (shared workspace)
-- [ ] Agent actions are immediately reflected in the UI
-- [ ] Every entity has full CRUD (Create, Read, Update, Delete)
-- [ ] Agents explicitly signal completion (no heuristic detection)
+- [ ] Every UI action has a corresponding agent tool
+- [ ] Agent and user share data space; agent actions reflect in UI immediately
+- [ ] Every entity has full CRUD; agents signal completion explicitly
 - [ ] context.md or equivalent for accumulated knowledge
 
-### Product
-- [ ] Simple requests work immediately with no learning curve
-- [ ] Power users can push the system in unexpected directions
-- [ ] You're learning what users want by observing what they ask the agent to do
-- [ ] Approval requirements match stakes and reversibility
-
-### Mobile (if applicable)
-- [ ] Checkpoint/resume handles app interruption
-- [ ] iCloud-first storage with local fallback
-- [ ] Background execution uses available time wisely
-- [ ] Model tier matched to task complexity
-
----
-
-### The Ultimate Test
-
-**Describe an outcome to the agent that's within your application's domain but that you didn't build a specific feature for.**
-
-Can it figure out how to accomplish it, operating in a loop until it succeeds?
-
-If yes, you've built something agent-native.
-
-If it says "I don't have a feature for that"—your architecture is still too constrained.
+**The Ultimate Test:** Describe an outcome within your domain that you didn't build a feature for. Can the agent figure it out, looping until it succeeds? If yes — agent-native. If "I don't have a feature for that" — too constrained.
 </success_criteria>

--- a/plugins/aimi-engineering/skills/dspy-ruby/SKILL.md
+++ b/plugins/aimi-engineering/skills/dspy-ruby/SKILL.md
@@ -9,18 +9,9 @@ description: Build type-safe LLM applications with DSPy.rb — Ruby's programmat
 
 DSPy.rb brings software engineering best practices to LLM development. Instead of tweaking prompts, define what you want with Ruby types and let DSPy handle the rest.
 
-## Overview
-
-DSPy.rb is a Ruby framework for building language model applications with programmatic prompts. It provides:
-
-- **Type-safe signatures** — Define inputs/outputs with Sorbet types
-- **Modular components** — Compose and reuse LLM logic
-- **Automatic optimization** — Use data to improve prompts, not guesswork
-- **Production-ready** — Built-in observability, testing, and error handling
-
 ## Core Concepts
 
-### 1. Signatures
+### Signatures
 
 Define interfaces between your app and LLMs using Ruby types:
 
@@ -44,96 +35,108 @@ class EmailClassifier < DSPy::Signature
 
   output do
     const :category, String
-    const :priority, Priority  # Type-safe enum with defined values
+    const :priority, Priority
     const :confidence, Float
   end
 end
 ```
 
-### 2. Modules
+> For detailed signature syntax, supported types, defaults, field descriptions, recursive types, union types, and schema formats, use the Read tool on `references/core-concepts.md`
 
-Build complex workflows from simple building blocks:
+### Modules
 
-- **Predict** — Basic LLM calls with signatures
-- **ChainOfThought** — Step-by-step reasoning
-- **ReAct** — Tool-using agents
-- **CodeAct** — Dynamic code generation agents (install the `dspy-code_act` gem)
+Composable building blocks that wrap predictors. Define a `forward` method; invoke with `.call()`.
 
-### 3. Tools & Toolsets
-
-Create type-safe tools for agents with comprehensive Sorbet support:
+- **Predict** -- Basic LLM calls with signatures. Fastest, lowest token usage.
+- **ChainOfThought** -- Step-by-step reasoning. Adds `reasoning` field automatically. Do not define `:reasoning` in output.
+- **ReAct** -- Tool-using agents with iterative reasoning + action loops.
+- **CodeAct** -- Dynamic code generation agents (separate gem: `dspy-code_act`).
 
 ```ruby
-# Enum-based tool with automatic type conversion
-class CalculatorTool < DSPy::Tools::Base
-  tool_name 'calculator'
-  tool_description 'Performs arithmetic operations with type-safe enum inputs'
-
-  class Operation < T::Enum
-    enums do
-      Add = new('add')
-      Subtract = new('subtract')
-      Multiply = new('multiply')
-      Divide = new('divide')
-    end
+class SentimentAnalyzer < DSPy::Module
+  def initialize
+    super
+    @predictor = DSPy::Predict.new(SentimentSignature)
   end
 
-  sig { params(operation: Operation, num1: Float, num2: Float).returns(T.any(Float, String)) }
+  def forward(text:)
+    @predictor.call(text: text)
+  end
+end
+
+analyzer = SentimentAnalyzer.new
+result = analyzer.call(text: "I love this product!")
+result.sentiment  # => "positive"
+```
+
+**API rules:**
+- Invoke modules and predictors with `.call()`, not `.forward()`.
+- Access result fields with `result.field`, not `result[:field]`.
+
+> For module composition, lifecycle callbacks, instruction update contract, predictor comparison, concurrent predictions, and few-shot examples, use the Read tool on `references/core-concepts.md`
+
+### Tools & Toolsets
+
+Create type-safe tools for agents with Sorbet signatures:
+
+```ruby
+class CalculatorTool < DSPy::Tools::Base
+  tool_name 'calculator'
+  tool_description 'Performs arithmetic operations'
+
+  sig { params(operation: String, num1: Float, num2: Float).returns(T.any(Float, String)) }
   def call(operation:, num1:, num2:)
     case operation
-    when Operation::Add then num1 + num2
-    when Operation::Subtract then num1 - num2
-    when Operation::Multiply then num1 * num2
-    when Operation::Divide
+    when 'add' then num1 + num2
+    when 'subtract' then num1 - num2
+    when 'multiply' then num1 * num2
+    when 'divide'
       return "Error: Division by zero" if num2 == 0
       num1 / num2
     end
   end
 end
+```
 
-# Multi-tool toolset with rich types
+Group related tools with `DSPy::Tools::Toolset`:
+
+```ruby
 class DataToolset < DSPy::Tools::Toolset
   toolset_name "data_processing"
-
-  class Format < T::Enum
-    enums do
-      JSON = new('json')
-      CSV = new('csv')
-      XML = new('xml')
-    end
-  end
-
   tool :convert, description: "Convert data between formats"
   tool :validate, description: "Validate data structure"
 
-  sig { params(data: String, from: Format, to: Format).returns(String) }
-  def convert(data:, from:, to:)
-    "Converted from #{from.serialize} to #{to.serialize}"
+  sig { params(data: String, format: String).returns(String) }
+  def convert(data:, format:)
+    # ...
   end
 
-  sig { params(data: String, format: Format).returns(T::Hash[String, T.any(String, Integer, T::Boolean)]) }
+  sig { params(data: String, format: String).returns(T::Hash[String, T.untyped]) }
   def validate(data:, format:)
-    { valid: true, format: format.serialize, row_count: 42, message: "Data validation passed" }
+    # ...
   end
 end
 ```
 
-### 4. Type System & Discriminators
+> For toolset DSL details, type safety, built-in toolsets (TextProcessing, GitHubCLI), enum parameters, and testing tools, use the Read tool on `references/toolsets.md`
 
-DSPy.rb uses sophisticated type discrimination for complex data structures:
+### Type System & Discriminators
 
-- **Automatic `_type` field injection** — DSPy adds discriminator fields to structs for type safety
-- **Union type support** — `T.any()` types automatically disambiguated by `_type`
-- **Reserved field name** — Avoid defining your own `_type` fields in structs
-- **Recursive filtering** — `_type` fields filtered during deserialization at all nesting levels
+- **Automatic `_type` field injection** for union types (`T.any()`) with structs
+- **Case-insensitive enum matching** -- LLM returning `"HIGH"` matches `new('high')`
+- **Recursive type support** via JSON Schema `$defs` and `$ref` pointers
+- Prefer `T::Array[X], default: []` over `T.nilable(T::Array[X])`
+- Limit union types to 2-4 members for reliable model comprehension
 
-### 5. Optimization
+### Optimization
 
 Improve accuracy with real data:
 
-- **MIPROv2** — Advanced multi-prompt optimization with bootstrap sampling and Bayesian optimization
-- **GEPA** — Genetic-Pareto Reflective Prompt Evolution with feedback maps, experiment tracking, and telemetry
-- **Evaluation** — Comprehensive framework with built-in and custom metrics, error handling, and batch processing
+- **MIPROv2** -- Multi-prompt instruction optimization with bootstrap sampling and Bayesian optimization. Install: `gem 'dspy-miprov2'`
+- **GEPA** -- Genetic-Pareto Reflective Prompt Evolution with feedback maps and experiment tracking. Install: `gem 'dspy-gepa'`
+- **Evaluation** -- `DSPy::Evals` with built-in metrics (`exact_match`, `contains`, `numeric_difference`, `composite_and`)
+
+> For optimization configuration, metrics, GEPA feedback maps, evaluation framework, and storage system, use the Read tool on `references/optimization.md`
 
 ## Quick Start
 
@@ -155,8 +158,8 @@ class SentimentAnalysis < DSPy::Signature
   end
 
   output do
-    const :sentiment, String  # positive, negative, neutral
-    const :score, Float       # 0.0 to 1.0
+    const :sentiment, String
+    const :score, Float
   end
 end
 
@@ -167,32 +170,24 @@ puts result.sentiment  # => "positive"
 puts result.score      # => 0.92
 ```
 
-## Provider Adapter Gems
+## Provider Adapters
 
 Two strategies for connecting to LLM providers:
 
 ### Per-provider adapters (direct SDK access)
 
 ```ruby
-# Gemfile
-gem 'dspy'
 gem 'dspy-openai'    # OpenAI, OpenRouter, Ollama
 gem 'dspy-anthropic' # Claude
 gem 'dspy-gemini'    # Gemini
 ```
 
-Each adapter gem pulls in the official SDK (`openai`, `anthropic`, `gemini-ai`).
-
 ### Unified adapter via RubyLLM (recommended for multi-provider)
 
 ```ruby
-# Gemfile
-gem 'dspy'
-gem 'dspy-ruby_llm'  # Routes to any provider via ruby_llm
+gem 'dspy-ruby_llm'
 gem 'ruby_llm'
 ```
-
-RubyLLM handles provider routing based on the model name. Use the `ruby_llm/` prefix:
 
 ```ruby
 DSPy.configure do |c|
@@ -202,78 +197,9 @@ DSPy.configure do |c|
 end
 ```
 
-## Events System
+### Fiber-Local LM Context
 
-DSPy.rb ships with a structured event bus for observing runtime behavior.
-
-### Module-Scoped Subscriptions (preferred for agents)
-
-```ruby
-class MyAgent < DSPy::Module
-  subscribe 'lm.tokens', :track_tokens, scope: :descendants
-
-  def track_tokens(_event, attrs)
-    @total_tokens += attrs.fetch(:total_tokens, 0)
-  end
-end
-```
-
-### Global Subscriptions (for observability/integrations)
-
-```ruby
-subscription_id = DSPy.events.subscribe('score.create') do |event, attrs|
-  Langfuse.export_score(attrs)
-end
-
-# Wildcards supported
-DSPy.events.subscribe('llm.*') { |name, attrs| puts "[#{name}] tokens=#{attrs[:total_tokens]}" }
-```
-
-Event names use dot-separated namespaces (`llm.generate`, `react.iteration_complete`). Every event includes module metadata (`module_path`, `module_leaf`, `module_scope.ancestry_token`) for filtering.
-
-## Lifecycle Callbacks
-
-Rails-style lifecycle hooks ship with every `DSPy::Module`:
-
-- **`before`** — Runs ahead of `forward` for setup (metrics, context loading)
-- **`around`** — Wraps `forward`, calls `yield`, and lets you pair setup/teardown logic
-- **`after`** — Fires after `forward` returns for cleanup or persistence
-
-```ruby
-class InstrumentedModule < DSPy::Module
-  before :setup_metrics
-  around :manage_context
-  after :log_metrics
-
-  def forward(question:)
-    @predictor.call(question: question)
-  end
-
-  private
-
-  def setup_metrics
-    @start_time = Time.now
-  end
-
-  def manage_context
-    load_context
-    result = yield
-    save_context
-    result
-  end
-
-  def log_metrics
-    duration = Time.now - @start_time
-    Rails.logger.info "Prediction completed in #{duration}s"
-  end
-end
-```
-
-Execution order: before → around (before yield) → forward → around (after yield) → after. Callbacks are inherited from parent classes and execute in registration order.
-
-## Fiber-Local LM Context
-
-Override the language model temporarily using fiber-local storage:
+Override the language model temporarily:
 
 ```ruby
 fast_model = DSPy::LM.new("openai/gpt-4o-mini", api_key: ENV['OPENAI_API_KEY'])
@@ -281,10 +207,9 @@ fast_model = DSPy::LM.new("openai/gpt-4o-mini", api_key: ENV['OPENAI_API_KEY'])
 DSPy.with_lm(fast_model) do
   result = classifier.call(text: "test")  # Uses fast_model inside this block
 end
-# Back to global LM outside the block
 ```
 
-**LM resolution hierarchy**: Instance-level LM → Fiber-local LM (`DSPy.with_lm`) → Global LM (`DSPy.configure`).
+**LM resolution hierarchy**: Instance-level LM -> Fiber-local LM (`DSPy.with_lm`) -> Global LM (`DSPy.configure`).
 
 Use `configure_predictor` for fine-grained control over agent internals:
 
@@ -294,367 +219,21 @@ agent.configure { |c| c.lm = default_model }
 agent.configure_predictor('thought_generator') { |c| c.lm = powerful_model }
 ```
 
-## Evaluation Framework
-
-Systematically test LLM application performance with `DSPy::Evals`:
-
-```ruby
-metric = DSPy::Metrics.exact_match(field: :answer, case_sensitive: false)
-evaluator = DSPy::Evals.new(predictor, metric: metric)
-result = evaluator.evaluate(test_examples, display_table: true)
-puts "Pass Rate: #{(result.pass_rate * 100).round(1)}%"
-```
-
-Built-in metrics: `exact_match`, `contains`, `numeric_difference`, `composite_and`. Custom metrics return `true`/`false` or a `DSPy::Prediction` with `score:` and `feedback:` fields.
-
-Use `DSPy::Example` for typed test data and `export_scores: true` to push results to Langfuse.
-
-## GEPA Optimization
-
-GEPA (Genetic-Pareto Reflective Prompt Evolution) uses reflection-driven instruction rewrites:
-
-```ruby
-gem 'dspy-gepa'
-
-teleprompter = DSPy::Teleprompt::GEPA.new(
-  metric: metric,
-  reflection_lm: DSPy::ReflectionLM.new('openai/gpt-4o-mini', api_key: ENV['OPENAI_API_KEY']),
-  feedback_map: feedback_map,
-  config: { max_metric_calls: 600, minibatch_size: 6 }
-)
-
-result = teleprompter.compile(program, trainset: train, valset: val)
-optimized_program = result.optimized_program
-```
-
-The metric must return `DSPy::Prediction.new(score:, feedback:)` so the reflection model can reason about failures. Use `feedback_map` to target individual predictors in composite modules.
-
-## Typed Context Pattern
-
-Replace opaque string context blobs with `T::Struct` inputs. Each field gets its own `description:` annotation in the JSON schema the LLM sees:
-
-```ruby
-class NavigationContext < T::Struct
-  const :workflow_hint, T.nilable(String),
-        description: "Current workflow phase guidance for the agent"
-  const :action_log, T::Array[String], default: [],
-        description: "Compact one-line-per-action history of research steps taken"
-  const :iterations_remaining, Integer,
-        description: "Budget remaining. Each tool call costs 1 iteration."
-end
-
-class ToolSelectionSignature < DSPy::Signature
-  input do
-    const :query, String
-    const :context, NavigationContext  # Structured, not an opaque string
-  end
-
-  output do
-    const :tool_name, String
-    const :tool_args, String, description: "JSON-encoded arguments"
-  end
-end
-```
-
-Benefits: type safety at compile time, per-field descriptions in the LLM schema, easy to test as value objects, extensible by adding `const` declarations.
-
-## Schema Formats (BAML / TOON)
-
-Control how DSPy describes signature structure to the LLM:
-
-- **JSON Schema** (default) — Standard format, works with `structured_outputs: true`
-- **BAML** (`schema_format: :baml`) — 84% token reduction for Enhanced Prompting mode. Requires `sorbet-baml` gem.
-- **TOON** (`schema_format: :toon, data_format: :toon`) — Table-oriented format for both schemas and data. Enhanced Prompting mode only.
-
-BAML and TOON apply only when `structured_outputs: false`. With `structured_outputs: true`, the provider receives JSON Schema directly.
-
-## Storage System
-
-Persist and reload optimized programs with `DSPy::Storage::ProgramStorage`:
-
-```ruby
-storage = DSPy::Storage::ProgramStorage.new(storage_path: "./dspy_storage")
-storage.save_program(result.optimized_program, result, metadata: { optimizer: 'MIPROv2' })
-```
-
-Supports checkpoint management, optimization history tracking, and import/export between environments.
-
-## Rails Integration
-
-### Directory Structure
-
-Organize DSPy components using Rails conventions:
-
-```
-app/
-  entities/          # T::Struct types shared across signatures
-  signatures/        # DSPy::Signature definitions
-  tools/             # DSPy::Tools::Base implementations
-    concerns/        # Shared tool behaviors (error handling, etc.)
-  modules/           # DSPy::Module orchestrators
-  services/          # Plain Ruby services that compose DSPy modules
-config/
-  initializers/
-    dspy.rb          # DSPy + provider configuration
-    feature_flags.rb # Model selection per role
-spec/
-  signatures/        # Schema validation tests
-  tools/             # Tool unit tests
-  modules/           # Integration tests with VCR
-  vcr_cassettes/     # Recorded HTTP interactions
-```
-
-### Initializer
-
-```ruby
-# config/initializers/dspy.rb
-Rails.application.config.after_initialize do
-  next if Rails.env.test? && ENV["DSPY_ENABLE_IN_TEST"].blank?
-
-  RubyLLM.configure do |config|
-    config.gemini_api_key = ENV["GEMINI_API_KEY"] if ENV["GEMINI_API_KEY"].present?
-    config.anthropic_api_key = ENV["ANTHROPIC_API_KEY"] if ENV["ANTHROPIC_API_KEY"].present?
-    config.openai_api_key = ENV["OPENAI_API_KEY"] if ENV["OPENAI_API_KEY"].present?
-  end
-
-  model = ENV.fetch("DSPY_MODEL", "ruby_llm/gemini-2.5-flash")
-  DSPy.configure do |config|
-    config.lm = DSPy::LM.new(model, structured_outputs: true)
-    config.logger = Rails.logger
-  end
-
-  # Langfuse observability (optional)
-  if ENV["LANGFUSE_PUBLIC_KEY"].present? && ENV["LANGFUSE_SECRET_KEY"].present?
-    DSPy::Observability.configure!
-  end
-end
-```
-
-### Feature-Flagged Model Selection
-
-Use different models for different roles (fast/cheap for classification, powerful for synthesis):
-
-```ruby
-# config/initializers/feature_flags.rb
-module FeatureFlags
-  SELECTOR_MODEL = ENV.fetch("DSPY_SELECTOR_MODEL", "ruby_llm/gemini-2.5-flash-lite")
-  SYNTHESIZER_MODEL = ENV.fetch("DSPY_SYNTHESIZER_MODEL", "ruby_llm/gemini-2.5-flash")
-end
-```
-
-Then override per-tool or per-predictor:
-
-```ruby
-class ClassifyTool < DSPy::Tools::Base
-  def call(query:)
-    predictor = DSPy::Predict.new(ClassifyQuery)
-    predictor.configure { |c| c.lm = DSPy::LM.new(FeatureFlags::SELECTOR_MODEL, structured_outputs: true) }
-    predictor.call(query: query)
-  end
-end
-```
-
-## Schema-Driven Signatures
-
-**Prefer typed schemas over string descriptions.** Let the type system communicate structure to the LLM rather than prose in the signature description.
-
-### Entities as Shared Types
-
-Define reusable `T::Struct` and `T::Enum` types in `app/entities/` and reference them across signatures:
-
-```ruby
-# app/entities/search_strategy.rb
-class SearchStrategy < T::Enum
-  enums do
-    SingleSearch = new("single_search")
-    DateDecomposition = new("date_decomposition")
-  end
-end
-
-# app/entities/scored_item.rb
-class ScoredItem < T::Struct
-  const :id, String
-  const :score, Float, description: "Relevance score 0.0-1.0"
-  const :verdict, String, description: "relevant, maybe, or irrelevant"
-  const :reason, String, default: ""
-end
-```
-
-### Schema vs Description: When to Use Each
-
-**Use schemas (T::Struct/T::Enum)** for:
-- Multi-field outputs with specific types
-- Enums with defined values the LLM must pick from
-- Nested structures, arrays of typed objects
-- Outputs consumed by code (not displayed to users)
-
-**Use string descriptions** for:
-- Simple single-field outputs where the type is `String`
-- Natural language generation (summaries, answers)
-- Fields where constraint guidance helps (e.g., `description: "YYYY-MM-DD format"`)
-
-**Rule of thumb**: If you'd write a `case` statement on the output, it should be a `T::Enum`. If you'd call `.each` on it, it should be `T::Array[SomeStruct]`.
-
-## Tool Patterns
-
-### Tools That Wrap Predictions
-
-A common pattern: tools encapsulate a DSPy prediction, adding error handling, model selection, and serialization:
-
-```ruby
-class RerankTool < DSPy::Tools::Base
-  tool_name "rerank"
-  tool_description "Score and rank search results by relevance"
-
-  MAX_ITEMS = 200
-  MIN_ITEMS_FOR_LLM = 5
-
-  sig { params(query: String, items: T::Array[T::Hash[Symbol, T.untyped]]).returns(T::Hash[Symbol, T.untyped]) }
-  def call(query:, items: [])
-    return { scored_items: items, reranked: false } if items.size < MIN_ITEMS_FOR_LLM
-
-    capped_items = items.first(MAX_ITEMS)
-    predictor = DSPy::Predict.new(RerankSignature)
-    predictor.configure { |c| c.lm = DSPy::LM.new(FeatureFlags::SYNTHESIZER_MODEL, structured_outputs: true) }
-
-    result = predictor.call(query: query, items: capped_items)
-    { scored_items: result.scored_items, reranked: true }
-  rescue => e
-    Rails.logger.warn "[RerankTool] LLM rerank failed: #{e.message}"
-    { error: "Rerank failed: #{e.message}", scored_items: items, reranked: false }
-  end
-end
-```
-
-**Key patterns:**
-- Short-circuit LLM calls when unnecessary (small data, trivial cases)
-- Cap input size to prevent token overflow
-- Per-tool model selection via `configure`
-- Graceful error handling with fallback data
-
-### Error Handling Concern
-
-```ruby
-module ErrorHandling
-  extend ActiveSupport::Concern
-
-  private
-
-  def safe_predict(signature_class, **inputs)
-    predictor = DSPy::Predict.new(signature_class)
-    yield predictor if block_given?
-    predictor.call(**inputs)
-  rescue Faraday::Error, Net::HTTPError => e
-    Rails.logger.error "[#{self.class.name}] API error: #{e.message}"
-    nil
-  rescue JSON::ParserError => e
-    Rails.logger.error "[#{self.class.name}] Invalid LLM output: #{e.message}"
-    nil
-  end
-end
-```
-
-## Observability
-
-### Tracing with DSPy::Context
-
-Wrap operations in spans for Langfuse/OpenTelemetry visibility:
-
-```ruby
-result = DSPy::Context.with_span(
-  operation: "tool_selector.select",
-  "dspy.module" => "ToolSelector",
-  "tool_selector.tools" => tool_names.join(",")
-) do
-  @predictor.call(query: query, context: context, available_tools: schemas)
-end
-```
-
-### Setup for Langfuse
-
-```ruby
-# Gemfile
-gem 'dspy-o11y'
-gem 'dspy-o11y-langfuse'
-
-# .env
-LANGFUSE_PUBLIC_KEY=pk-...
-LANGFUSE_SECRET_KEY=sk-...
-DSPY_TELEMETRY_BATCH_SIZE=5
-```
-
-Every `DSPy::Predict`, `DSPy::ReAct`, and tool call is automatically traced when observability is configured.
-
-### Score Reporting
-
-Report evaluation scores to Langfuse:
-
-```ruby
-DSPy.score(name: "relevance", value: 0.85, trace_id: current_trace_id)
-```
-
-## Testing
-
-### VCR Setup for Rails
-
-```ruby
-VCR.configure do |config|
-  config.cassette_library_dir = "spec/vcr_cassettes"
-  config.hook_into :webmock
-  config.configure_rspec_metadata!
-  config.filter_sensitive_data('<GEMINI_API_KEY>') { ENV['GEMINI_API_KEY'] }
-  config.filter_sensitive_data('<OPENAI_API_KEY>') { ENV['OPENAI_API_KEY'] }
-end
-```
-
-### Signature Schema Tests
-
-Test that signatures produce valid schemas without calling any LLM:
-
-```ruby
-RSpec.describe ClassifyResearchQuery do
-  it "has required input fields" do
-    schema = described_class.input_json_schema
-    expect(schema[:required]).to include("query")
-  end
-
-  it "has typed output fields" do
-    schema = described_class.output_json_schema
-    expect(schema[:properties]).to have_key(:search_strategy)
-  end
-end
-```
-
-### Tool Tests with Mocked Predictions
-
-```ruby
-RSpec.describe RerankTool do
-  let(:tool) { described_class.new }
-
-  it "skips LLM for small result sets" do
-    expect(DSPy::Predict).not_to receive(:new)
-    result = tool.call(query: "test", items: [{ id: "1" }])
-    expect(result[:reranked]).to be false
-  end
-
-  it "calls LLM for large result sets", :vcr do
-    items = 10.times.map { |i| { id: i.to_s, title: "Item #{i}" } }
-    result = tool.call(query: "relevant items", items: items)
-    expect(result[:reranked]).to be true
-  end
-end
-```
+> For full provider configuration, Bedrock/VertexAI setup, compatibility matrix, and feature-flagged model selection, use the Read tool on `references/providers.md`
 
 ## Resources
 
-- [core-concepts.md](./references/core-concepts.md) — Signatures, modules, predictors, type system deep-dive
-- [toolsets.md](./references/toolsets.md) — Tools::Base, Tools::Toolset DSL, type safety, testing
-- [providers.md](./references/providers.md) — Provider adapters, RubyLLM, fiber-local LM context, compatibility matrix
-- [optimization.md](./references/optimization.md) — MIPROv2, GEPA, evaluation framework, storage system
-- [observability.md](./references/observability.md) — Event system, dspy-o11y gems, Langfuse, score reporting
-- [signature-template.rb](./assets/signature-template.rb) — Signature scaffold with T::Enum, Date/Time, defaults, union types
-- [module-template.rb](./assets/module-template.rb) — Module scaffold with .call(), lifecycle callbacks, fiber-local LM
-- [config-template.rb](./assets/config-template.rb) — Rails initializer with RubyLLM, observability, feature flags
+- [core-concepts.md](./references/core-concepts.md) -- Signatures, modules, predictors, type system deep-dive
+- [toolsets.md](./references/toolsets.md) -- Tools::Base, Tools::Toolset DSL, type safety, testing
+- [providers.md](./references/providers.md) -- Provider adapters, RubyLLM, fiber-local LM context, compatibility matrix
+- [optimization.md](./references/optimization.md) -- MIPROv2, GEPA, evaluation framework, storage system
+- [observability.md](./references/observability.md) -- Event system, dspy-o11y gems, Langfuse, score reporting
+- [patterns.md](./references/patterns.md) -- Typed context, schema-driven signatures, tool patterns, best practices
+- [rails-integration.md](./references/rails-integration.md) -- Directory structure, initializer, feature flags, observability
+- [testing.md](./references/testing.md) -- Schema tests, tool tests, VCR setup, mocking predictions
+- [signature-template.rb](./assets/signature-template.rb) -- Signature scaffold with T::Enum, Date/Time, defaults, union types
+- [module-template.rb](./assets/module-template.rb) -- Module scaffold with .call(), lifecycle callbacks, fiber-local LM
+- [config-template.rb](./assets/config-template.rb) -- Rails initializer with RubyLLM, observability, feature flags
 
 ## Key URLs
 
@@ -666,71 +245,19 @@ end
 
 When helping users with DSPy.rb:
 
-1. **Schema over prose** — Define output structure with `T::Struct` and `T::Enum` types, not string descriptions
-2. **Entities in `app/entities/`** — Extract shared types so signatures stay thin
-3. **Per-tool model selection** — Use `predictor.configure { |c| c.lm = ... }` to pick the right model per task
-4. **Short-circuit LLM calls** — Skip the LLM for trivial cases (small data, cached results)
-5. **Cap input sizes** — Prevent token overflow by limiting array sizes before sending to LLM
-6. **Test schemas without LLM** — Validate `input_json_schema` and `output_json_schema` in unit tests
-7. **VCR for integration tests** — Record real HTTP interactions, never mock LLM responses by hand
-8. **Trace with spans** — Wrap tool calls in `DSPy::Context.with_span` for observability
-9. **Graceful degradation** — Always rescue LLM errors and return fallback data
+1. **Schema over prose** -- Define output structure with `T::Struct` and `T::Enum` types, not string descriptions
+2. **Entities in `app/entities/`** -- Extract shared types so signatures stay thin
+3. **Per-tool model selection** -- Use `predictor.configure { |c| c.lm = ... }` to pick the right model per task
+4. **Short-circuit LLM calls** -- Skip the LLM for trivial cases (small data, cached results)
+5. **Cap input sizes** -- Prevent token overflow by limiting array sizes before sending to LLM
+6. **Test schemas without LLM** -- Validate `input_json_schema` and `output_json_schema` in unit tests
+7. **VCR for integration tests** -- Record real HTTP interactions, never mock LLM responses by hand
+8. **Trace with spans** -- Wrap tool calls in `DSPy::Context.with_span` for observability
+9. **Graceful degradation** -- Always rescue LLM errors and return fallback data
 
-### Signature Best Practices
-
-**Keep description concise** — The signature `description` should state the goal, not the field details:
-
-```ruby
-# Good — concise goal
-class ParseOutline < DSPy::Signature
-  description 'Extract block-level structure from HTML as a flat list of skeleton sections.'
-
-  input do
-    const :html, String, description: 'Raw HTML to parse'
-  end
-
-  output do
-    const :sections, T::Array[Section], description: 'Block elements: headings, paragraphs, code blocks, lists'
-  end
-end
-```
-
-**Use defaults over nilable arrays** — For OpenAI structured outputs compatibility:
-
-```ruby
-# Good — works with OpenAI structured outputs
-class ASTNode < T::Struct
-  const :children, T::Array[ASTNode], default: []
-end
-```
-
-### Recursive Types with `$defs`
-
-DSPy.rb supports recursive types in structured outputs using JSON Schema `$defs`:
-
-```ruby
-class TreeNode < T::Struct
-  const :value, String
-  const :children, T::Array[TreeNode], default: []  # Self-reference
-end
-```
-
-The schema generator automatically creates `#/$defs/TreeNode` references for recursive types, compatible with OpenAI and Gemini structured outputs.
-
-### Field Descriptions for T::Struct
-
-DSPy.rb extends T::Struct to support field-level `description:` kwargs that flow to JSON Schema:
-
-```ruby
-class ASTNode < T::Struct
-  const :node_type, NodeType, description: 'The type of node (heading, paragraph, etc.)'
-  const :text, String, default: "", description: 'Text content of the node'
-  const :level, Integer, default: 0  # No description — field is self-explanatory
-  const :children, T::Array[ASTNode], default: []
-end
-```
-
-**When to use field descriptions**: complex field semantics, enum-like strings, constrained values, nested structs with ambiguous names. **When to skip**: self-explanatory fields like `name`, `id`, `url`, or boolean flags.
+> For detailed signature best practices, typed context patterns, error handling concerns, and advanced tool patterns, use the Read tool on `references/patterns.md`
+> For Rails directory structure, initializers, and feature-flagged model selection, use the Read tool on `references/rails-integration.md`
+> For testing strategies and examples, use the Read tool on `references/testing.md`
 
 ## Version
 

--- a/plugins/aimi-engineering/skills/dspy-ruby/references/patterns.md
+++ b/plugins/aimi-engineering/skills/dspy-ruby/references/patterns.md
@@ -1,0 +1,248 @@
+# DSPy.rb Patterns & Best Practices
+
+## Typed Context Pattern
+
+Replace opaque string context blobs with `T::Struct` inputs. Each field gets its own `description:` annotation in the JSON schema the LLM sees:
+
+```ruby
+class NavigationContext < T::Struct
+  const :workflow_hint, T.nilable(String),
+        description: "Current workflow phase guidance for the agent"
+  const :action_log, T::Array[String], default: [],
+        description: "Compact one-line-per-action history of research steps taken"
+  const :iterations_remaining, Integer,
+        description: "Budget remaining. Each tool call costs 1 iteration."
+end
+
+class ToolSelectionSignature < DSPy::Signature
+  input do
+    const :query, String
+    const :context, NavigationContext  # Structured, not an opaque string
+  end
+
+  output do
+    const :tool_name, String
+    const :tool_args, String, description: "JSON-encoded arguments"
+  end
+end
+```
+
+Benefits: type safety at compile time, per-field descriptions in the LLM schema, easy to test as value objects, extensible by adding `const` declarations.
+
+## Schema-Driven Signatures
+
+**Prefer typed schemas over string descriptions.** Let the type system communicate structure to the LLM rather than prose in the signature description.
+
+### Entities as Shared Types
+
+Define reusable `T::Struct` and `T::Enum` types in `app/entities/` and reference them across signatures:
+
+```ruby
+# app/entities/search_strategy.rb
+class SearchStrategy < T::Enum
+  enums do
+    SingleSearch = new("single_search")
+    DateDecomposition = new("date_decomposition")
+  end
+end
+
+# app/entities/scored_item.rb
+class ScoredItem < T::Struct
+  const :id, String
+  const :score, Float, description: "Relevance score 0.0-1.0"
+  const :verdict, String, description: "relevant, maybe, or irrelevant"
+  const :reason, String, default: ""
+end
+```
+
+### Schema vs Description: When to Use Each
+
+**Use schemas (T::Struct/T::Enum)** for:
+- Multi-field outputs with specific types
+- Enums with defined values the LLM must pick from
+- Nested structures, arrays of typed objects
+- Outputs consumed by code (not displayed to users)
+
+**Use string descriptions** for:
+- Simple single-field outputs where the type is `String`
+- Natural language generation (summaries, answers)
+- Fields where constraint guidance helps (e.g., `description: "YYYY-MM-DD format"`)
+
+**Rule of thumb**: If you'd write a `case` statement on the output, it should be a `T::Enum`. If you'd call `.each` on it, it should be `T::Array[SomeStruct]`.
+
+## Tool Patterns
+
+### Tools That Wrap Predictions
+
+A common pattern: tools encapsulate a DSPy prediction, adding error handling, model selection, and serialization:
+
+```ruby
+class RerankTool < DSPy::Tools::Base
+  tool_name "rerank"
+  tool_description "Score and rank search results by relevance"
+
+  MAX_ITEMS = 200
+  MIN_ITEMS_FOR_LLM = 5
+
+  sig { params(query: String, items: T::Array[T::Hash[Symbol, T.untyped]]).returns(T::Hash[Symbol, T.untyped]) }
+  def call(query:, items: [])
+    return { scored_items: items, reranked: false } if items.size < MIN_ITEMS_FOR_LLM
+
+    capped_items = items.first(MAX_ITEMS)
+    predictor = DSPy::Predict.new(RerankSignature)
+    predictor.configure { |c| c.lm = DSPy::LM.new(FeatureFlags::SYNTHESIZER_MODEL, structured_outputs: true) }
+
+    result = predictor.call(query: query, items: capped_items)
+    { scored_items: result.scored_items, reranked: true }
+  rescue => e
+    Rails.logger.warn "[RerankTool] LLM rerank failed: #{e.message}"
+    { error: "Rerank failed: #{e.message}", scored_items: items, reranked: false }
+  end
+end
+```
+
+**Key patterns:**
+- Short-circuit LLM calls when unnecessary (small data, trivial cases)
+- Cap input size to prevent token overflow
+- Per-tool model selection via `configure`
+- Graceful error handling with fallback data
+
+### Error Handling Concern
+
+```ruby
+module ErrorHandling
+  extend ActiveSupport::Concern
+
+  private
+
+  def safe_predict(signature_class, **inputs)
+    predictor = DSPy::Predict.new(signature_class)
+    yield predictor if block_given?
+    predictor.call(**inputs)
+  rescue Faraday::Error, Net::HTTPError => e
+    Rails.logger.error "[#{self.class.name}] API error: #{e.message}"
+    nil
+  rescue JSON::ParserError => e
+    Rails.logger.error "[#{self.class.name}] Invalid LLM output: #{e.message}"
+    nil
+  end
+end
+```
+
+## Signature Best Practices
+
+**Keep description concise** -- The signature `description` should state the goal, not the field details:
+
+```ruby
+# Good -- concise goal
+class ParseOutline < DSPy::Signature
+  description 'Extract block-level structure from HTML as a flat list of skeleton sections.'
+
+  input do
+    const :html, String, description: 'Raw HTML to parse'
+  end
+
+  output do
+    const :sections, T::Array[Section], description: 'Block elements: headings, paragraphs, code blocks, lists'
+  end
+end
+```
+
+**Use defaults over nilable arrays** -- For OpenAI structured outputs compatibility:
+
+```ruby
+# Good -- works with OpenAI structured outputs
+class ASTNode < T::Struct
+  const :children, T::Array[ASTNode], default: []
+end
+```
+
+### Recursive Types with `$defs`
+
+DSPy.rb supports recursive types in structured outputs using JSON Schema `$defs`:
+
+```ruby
+class TreeNode < T::Struct
+  const :value, String
+  const :children, T::Array[TreeNode], default: []  # Self-reference
+end
+```
+
+The schema generator automatically creates `#/$defs/TreeNode` references for recursive types, compatible with OpenAI and Gemini structured outputs.
+
+### Field Descriptions for T::Struct
+
+DSPy.rb extends T::Struct to support field-level `description:` kwargs that flow to JSON Schema:
+
+```ruby
+class ASTNode < T::Struct
+  const :node_type, NodeType, description: 'The type of node (heading, paragraph, etc.)'
+  const :text, String, default: "", description: 'Text content of the node'
+  const :level, Integer, default: 0  # No description -- field is self-explanatory
+  const :children, T::Array[ASTNode], default: []
+end
+```
+
+**When to use field descriptions**: complex field semantics, enum-like strings, constrained values, nested structs with ambiguous names. **When to skip**: self-explanatory fields like `name`, `id`, `url`, or boolean flags.
+
+## Events System
+
+DSPy.rb ships with a structured event bus for observing runtime behavior.
+
+### Module-Scoped Subscriptions (preferred for agents)
+
+```ruby
+class MyAgent < DSPy::Module
+  subscribe 'lm.tokens', :track_tokens, scope: :descendants
+
+  def track_tokens(_event, attrs)
+    @total_tokens += attrs.fetch(:total_tokens, 0)
+  end
+end
+```
+
+### Global Subscriptions (for observability/integrations)
+
+```ruby
+subscription_id = DSPy.events.subscribe('score.create') do |event, attrs|
+  Langfuse.export_score(attrs)
+end
+
+# Wildcards supported
+DSPy.events.subscribe('llm.*') { |name, attrs| puts "[#{name}] tokens=#{attrs[:total_tokens]}" }
+```
+
+Event names use dot-separated namespaces (`llm.generate`, `react.iteration_complete`). Every event includes module metadata (`module_path`, `module_leaf`, `module_scope.ancestry_token`) for filtering.
+
+## Lifecycle Callbacks
+
+Rails-style lifecycle hooks ship with every `DSPy::Module`:
+
+- **`before`** -- Runs ahead of `forward` for setup (metrics, context loading)
+- **`around`** -- Wraps `forward`, calls `yield`, and lets you pair setup/teardown logic
+- **`after`** -- Fires after `forward` returns for cleanup or persistence
+
+Execution order: before -> around (before yield) -> forward -> around (after yield) -> after. Callbacks are inherited from parent classes and execute in registration order.
+
+## Schema Formats (BAML / TOON)
+
+Control how DSPy describes signature structure to the LLM:
+
+- **JSON Schema** (default) -- Standard format, works with `structured_outputs: true`
+- **BAML** (`schema_format: :baml`) -- 84% token reduction for Enhanced Prompting mode. Requires `sorbet-baml` gem.
+- **TOON** (`schema_format: :toon, data_format: :toon`) -- Table-oriented format for both schemas and data. Enhanced Prompting mode only.
+
+BAML and TOON apply only when `structured_outputs: false`. With `structured_outputs: true`, the provider receives JSON Schema directly.
+
+## Storage System
+
+Persist and reload optimized programs with `DSPy::Storage::ProgramStorage`:
+
+```ruby
+storage = DSPy::Storage::ProgramStorage.new(storage_path: "./dspy_storage")
+storage.save_program(result.optimized_program, result, metadata: { optimizer: 'MIPROv2' })
+```
+
+Supports checkpoint management, optimization history tracking, and import/export between environments.
+
+> For detailed storage API and checkpoint management, use the Read tool on `references/optimization.md`

--- a/plugins/aimi-engineering/skills/dspy-ruby/references/rails-integration.md
+++ b/plugins/aimi-engineering/skills/dspy-ruby/references/rails-integration.md
@@ -1,0 +1,125 @@
+# DSPy.rb Rails Integration
+
+## Directory Structure
+
+Organize DSPy components using Rails conventions:
+
+```
+app/
+  entities/          # T::Struct types shared across signatures
+  signatures/        # DSPy::Signature definitions
+  tools/             # DSPy::Tools::Base implementations
+    concerns/        # Shared tool behaviors (error handling, etc.)
+  modules/           # DSPy::Module orchestrators
+  services/          # Plain Ruby services that compose DSPy modules
+config/
+  initializers/
+    dspy.rb          # DSPy + provider configuration
+    feature_flags.rb # Model selection per role
+spec/
+  signatures/        # Schema validation tests
+  tools/             # Tool unit tests
+  modules/           # Integration tests with VCR
+  vcr_cassettes/     # Recorded HTTP interactions
+```
+
+## Initializer
+
+```ruby
+# config/initializers/dspy.rb
+Rails.application.config.after_initialize do
+  next if Rails.env.test? && ENV["DSPY_ENABLE_IN_TEST"].blank?
+
+  RubyLLM.configure do |config|
+    config.gemini_api_key = ENV["GEMINI_API_KEY"] if ENV["GEMINI_API_KEY"].present?
+    config.anthropic_api_key = ENV["ANTHROPIC_API_KEY"] if ENV["ANTHROPIC_API_KEY"].present?
+    config.openai_api_key = ENV["OPENAI_API_KEY"] if ENV["OPENAI_API_KEY"].present?
+  end
+
+  model = ENV.fetch("DSPY_MODEL", "ruby_llm/gemini-2.5-flash")
+  DSPy.configure do |config|
+    config.lm = DSPy::LM.new(model, structured_outputs: true)
+    config.logger = Rails.logger
+  end
+
+  # Langfuse observability (optional)
+  if ENV["LANGFUSE_PUBLIC_KEY"].present? && ENV["LANGFUSE_SECRET_KEY"].present?
+    DSPy::Observability.configure!
+  end
+end
+```
+
+## Feature-Flagged Model Selection
+
+Use different models for different roles (fast/cheap for classification, powerful for synthesis):
+
+```ruby
+# config/initializers/feature_flags.rb
+module FeatureFlags
+  SELECTOR_MODEL = ENV.fetch("DSPY_SELECTOR_MODEL", "ruby_llm/gemini-2.5-flash-lite")
+  SYNTHESIZER_MODEL = ENV.fetch("DSPY_SYNTHESIZER_MODEL", "ruby_llm/gemini-2.5-flash")
+end
+```
+
+Then override per-tool or per-predictor:
+
+```ruby
+class ClassifyTool < DSPy::Tools::Base
+  def call(query:)
+    predictor = DSPy::Predict.new(ClassifyQuery)
+    predictor.configure { |c| c.lm = DSPy::LM.new(FeatureFlags::SELECTOR_MODEL, structured_outputs: true) }
+    predictor.call(query: query)
+  end
+end
+```
+
+## Observability Setup
+
+### Tracing with DSPy::Context
+
+Wrap operations in spans for Langfuse/OpenTelemetry visibility:
+
+```ruby
+result = DSPy::Context.with_span(
+  operation: "tool_selector.select",
+  "dspy.module" => "ToolSelector",
+  "tool_selector.tools" => tool_names.join(",")
+) do
+  @predictor.call(query: query, context: context, available_tools: schemas)
+end
+```
+
+### Langfuse Gem Setup
+
+```ruby
+# Gemfile
+gem 'dspy-o11y'
+gem 'dspy-o11y-langfuse'
+
+# .env
+LANGFUSE_PUBLIC_KEY=pk-...
+LANGFUSE_SECRET_KEY=sk-...
+DSPY_TELEMETRY_BATCH_SIZE=5
+```
+
+Every `DSPy::Predict`, `DSPy::ReAct`, and tool call is automatically traced when observability is configured.
+
+### Score Reporting
+
+Report evaluation scores to Langfuse:
+
+```ruby
+DSPy.score(name: "relevance", value: 0.85, trace_id: current_trace_id)
+```
+
+## VCR Setup for Testing
+
+```ruby
+VCR.configure do |config|
+  config.cassette_library_dir = "spec/vcr_cassettes"
+  config.hook_into :webmock
+  config.configure_rspec_metadata!
+  config.filter_sensitive_data('<GEMINI_API_KEY>') { ENV['GEMINI_API_KEY'] }
+  config.filter_sensitive_data('<OPENAI_API_KEY>') { ENV['OPENAI_API_KEY'] }
+end
+```

--- a/plugins/aimi-engineering/skills/dspy-ruby/references/testing.md
+++ b/plugins/aimi-engineering/skills/dspy-ruby/references/testing.md
@@ -1,0 +1,171 @@
+# DSPy.rb Testing
+
+## Signature Schema Tests
+
+Test that signatures produce valid schemas without calling any LLM:
+
+```ruby
+RSpec.describe ClassifyResearchQuery do
+  it "has required input fields" do
+    schema = described_class.input_json_schema
+    expect(schema[:required]).to include("query")
+  end
+
+  it "has typed output fields" do
+    schema = described_class.output_json_schema
+    expect(schema[:properties]).to have_key(:search_strategy)
+  end
+end
+```
+
+## Tool Tests with Mocked Predictions
+
+```ruby
+RSpec.describe RerankTool do
+  let(:tool) { described_class.new }
+
+  it "skips LLM for small result sets" do
+    expect(DSPy::Predict).not_to receive(:new)
+    result = tool.call(query: "test", items: [{ id: "1" }])
+    expect(result[:reranked]).to be false
+  end
+
+  it "calls LLM for large result sets", :vcr do
+    items = 10.times.map { |i| { id: i.to_s, title: "Item #{i}" } }
+    result = tool.call(query: "relevant items", items: items)
+    expect(result[:reranked]).to be true
+  end
+end
+```
+
+## VCR Setup for Rails
+
+```ruby
+VCR.configure do |config|
+  config.cassette_library_dir = "spec/vcr_cassettes"
+  config.hook_into :webmock
+  config.configure_rspec_metadata!
+  config.filter_sensitive_data('<GEMINI_API_KEY>') { ENV['GEMINI_API_KEY'] }
+  config.filter_sensitive_data('<OPENAI_API_KEY>') { ENV['OPENAI_API_KEY'] }
+end
+```
+
+## Unit Testing Individual Tools
+
+Test `DSPy::Tools::Base` subclasses by instantiating and calling `call` directly:
+
+```ruby
+RSpec.describe WeatherLookup do
+  subject(:tool) { described_class.new }
+
+  it "returns weather for a city" do
+    result = tool.call(city: "Berlin")
+    expect(result).to include("Berlin")
+  end
+
+  it "exposes the correct tool name" do
+    expect(tool.name).to eq("weather_lookup")
+  end
+
+  it "generates a valid schema" do
+    schema = described_class.call_schema_object
+    expect(schema[:required]).to include("city")
+    expect(schema[:properties]).to have_key(:city)
+  end
+end
+```
+
+## Unit Testing Toolsets
+
+Test toolset methods directly on an instance. Verify tool generation with `to_tools`:
+
+```ruby
+RSpec.describe DatabaseToolset do
+  subject(:toolset) { described_class.new }
+
+  it "executes a query" do
+    result = toolset.query(sql: "SELECT 1")
+    expect(result).to be_a(String)
+  end
+
+  it "generates tools with correct names" do
+    tools = described_class.to_tools
+    names = tools.map(&:name)
+    expect(names).to contain_exactly("db_query", "db_insert", "db_delete")
+  end
+end
+```
+
+## Mocking Predictions Inside Tools
+
+When a tool calls a DSPy predictor internally, stub the predictor to isolate tool logic from LLM calls:
+
+```ruby
+class SmartSearchTool < DSPy::Tools::Base
+  extend T::Sig
+
+  tool_name "smart_search"
+  tool_description "Search with query expansion"
+
+  sig { void }
+  def initialize
+    @expander = DSPy::Predict.new(QueryExpansionSignature)
+  end
+
+  sig { params(query: String).returns(String) }
+  def call(query:)
+    expanded = @expander.call(query: query)
+    perform_search(expanded.expanded_query)
+  end
+
+  private
+
+  def perform_search(query)
+    # actual search logic
+  end
+end
+
+RSpec.describe SmartSearchTool do
+  subject(:tool) { described_class.new }
+
+  before do
+    expansion_result = double("result", expanded_query: "expanded test query")
+    allow_any_instance_of(DSPy::Predict).to receive(:call).and_return(expansion_result)
+  end
+
+  it "expands the query before searching" do
+    allow(tool).to receive(:perform_search).with("expanded test query").and_return("found 3 results")
+    result = tool.call(query: "test")
+    expect(result).to eq("found 3 results")
+  end
+end
+```
+
+## Testing Enum Coercion
+
+Verify that string values from LLM responses deserialize into the correct enum instances:
+
+```ruby
+RSpec.describe "enum coercion" do
+  it "handles case-insensitive enum values" do
+    toolset = GitHubCLIToolset.new
+    result = toolset.list_issues(state: IssueState::Open)
+    expect(result).to be_a(String)
+  end
+end
+```
+
+## Evaluation Framework Testing
+
+Use `DSPy::Evals` to systematically test LLM application performance:
+
+```ruby
+metric = DSPy::Metrics.exact_match(field: :answer, case_sensitive: false)
+evaluator = DSPy::Evals.new(predictor, metric: metric)
+result = evaluator.evaluate(test_examples, display_table: true)
+puts "Pass Rate: #{(result.pass_rate * 100).round(1)}%"
+```
+
+Built-in metrics: `exact_match`, `contains`, `numeric_difference`, `composite_and`. Custom metrics return `true`/`false` or a `DSPy::Prediction` with `score:` and `feedback:` fields.
+
+Use `DSPy::Example` for typed test data and `export_scores: true` to push results to Langfuse.

--- a/plugins/aimi-engineering/skills/orchestrating-swarms/SKILL.md
+++ b/plugins/aimi-engineering/skills/orchestrating-swarms/SKILL.md
@@ -6,7 +6,7 @@ disable-model-invocation: true
 
 # Claude Code Swarm Orchestration
 
-Master multi-agent orchestration using Claude Code's TeammateTool and Task system.
+Multi-agent orchestration using Claude Code's TeammateTool and Task system.
 
 ---
 
@@ -14,1699 +14,237 @@ Master multi-agent orchestration using Claude Code's TeammateTool and Task syste
 
 | Primitive | What It Is | File Location |
 |-----------|-----------|---------------|
-| **Agent** | A Claude instance that can use tools. You are an agent. Subagents are agents you spawn. | N/A (process) |
-| **Team** | A named group of agents working together. One leader, multiple teammates. | `~/.claude/teams/{name}/config.json` |
-| **Teammate** | An agent that joined a team. Has a name, color, inbox. Spawned via Task with `team_name` + `name`. | Listed in team config |
-| **Leader** | The agent that created the team. Receives teammate messages, approves plans/shutdowns. | First member in config |
-| **Task** | A work item with subject, description, status, owner, and dependencies. | `~/.claude/tasks/{team}/N.json` |
-| **Inbox** | JSON file where an agent receives messages from teammates. | `~/.claude/teams/{name}/inboxes/{agent}.json` |
-| **Message** | A JSON object sent between agents. Can be text or structured (shutdown_request, idle_notification, etc). | Stored in inbox files |
-| **Backend** | How teammates run. Auto-detected: `in-process` (same Node.js, invisible), `tmux` (separate panes, visible), `iterm2` (split panes in iTerm2). See [Spawn Backends](#spawn-backends). | Auto-detected based on environment |
+| **Agent** | A Claude instance that can use tools. You are an agent. | N/A (process) |
+| **Team** | A named group of agents. One leader, multiple teammates. | `~/.claude/teams/{name}/config.json` |
+| **Teammate** | An agent in a team. Spawned via Task with `team_name` + `name`. | Listed in team config |
+| **Leader** | The agent that created the team. Receives messages, approves shutdowns. | First member in config |
+| **Task** | A work item with subject, status, owner, and dependencies. | `~/.claude/tasks/{team}/N.json` |
+| **Inbox** | JSON file where an agent receives messages. | `~/.claude/teams/{name}/inboxes/{agent}.json` |
+| **Message** | JSON sent between agents (text, shutdown_request, idle_notification, etc). | Stored in inbox files |
 
 ### How They Connect
 
-```mermaid
-flowchart TB
-    subgraph TEAM[TEAM]
-        Leader[Leader - you]
-        T1[Teammate 1]
-        T2[Teammate 2]
-
-        Leader <-->|messages via inbox| T1
-        Leader <-->|messages via inbox| T2
-        T1 <-.->|can message| T2
-    end
-
-    subgraph TASKS[TASK LIST]
-        Task1["#1 completed: Research<br/>owner: teammate1"]
-        Task2["#2 in_progress: Implement<br/>owner: teammate2"]
-        Task3["#3 pending: Test<br/>blocked by #2"]
-    end
-
-    T1 --> Task1
-    T2 --> Task2
-    Task2 -.->|unblocks| Task3
-```
+Leader communicates with teammates via inbox messages. Teammates can also message each other. All agents share a task list where tasks have statuses (pending, in_progress, completed) and dependency chains that auto-unblock.
 
 ### Lifecycle
 
-```mermaid
-flowchart LR
-    A[1. Create Team] --> B[2. Create Tasks]
-    B --> C[3. Spawn Teammates]
-    C --> D[4. Work]
-    D --> E[5. Coordinate]
-    E --> F[6. Shutdown]
-    F --> G[7. Cleanup]
-```
+Create Team -> Create Tasks -> Spawn Teammates -> Work (claim + execute) -> Coordinate (inbox messages) -> Shutdown (requestShutdown each) -> Cleanup (remove resources)
 
 ### Message Flow
 
-```mermaid
-sequenceDiagram
-    participant L as Leader
-    participant T1 as Teammate 1
-    participant T2 as Teammate 2
-    participant Tasks as Task List
+Leader creates tasks and spawns teammates. Teammates claim tasks, complete them, and send findings to leader. Leader requests shutdown from each teammate, waits for approvals, then calls cleanup.
 
-    L->>Tasks: TaskCreate (3 tasks)
-    L->>T1: spawn with prompt
-    L->>T2: spawn with prompt
-
-    T1->>Tasks: claim task #1
-    T2->>Tasks: claim task #2
-
-    T1->>Tasks: complete #1
-    T1->>L: send findings (inbox)
-
-    Note over Tasks: #3 auto-unblocks
-
-    T2->>Tasks: complete #2
-    T2->>L: send findings (inbox)
-
-    L->>T1: requestShutdown
-    T1->>L: approveShutdown
-    L->>T2: requestShutdown
-    T2->>L: approveShutdown
-
-    L->>L: cleanup
-```
-
----
-
-## Table of Contents
-
-1. [Core Architecture](#core-architecture)
-2. [Two Ways to Spawn Agents](#two-ways-to-spawn-agents)
-3. [Built-in Agent Types](#built-in-agent-types)
-4. [Plugin Agent Types](#plugin-agent-types)
-5. [TeammateTool Operations](#teammatetool-operations)
-6. [Task System Integration](#task-system-integration)
-7. [Message Formats](#message-formats)
-8. [Orchestration Patterns](#orchestration-patterns)
-9. [Environment Variables](#environment-variables)
-10. [Spawn Backends](#spawn-backends)
-11. [Error Handling](#error-handling)
-12. [Complete Workflows](#complete-workflows)
-
----
-
-## Core Architecture
-
-### How Swarms Work
-
-A swarm consists of:
-- **Leader** (you) - Creates team, spawns workers, coordinates work
-- **Teammates** (spawned agents) - Execute tasks, report back
-- **Task List** - Shared work queue with dependencies
-- **Inboxes** - JSON files for inter-agent messaging
-
-### File Structure
-
-```
-~/.claude/teams/{team-name}/
-├── config.json              # Team metadata and member list
-└── inboxes/
-    ├── team-lead.json       # Leader's inbox
-    ├── worker-1.json        # Worker 1's inbox
-    └── worker-2.json        # Worker 2's inbox
-
-~/.claude/tasks/{team-name}/
-├── 1.json                   # Task #1
-├── 2.json                   # Task #2
-└── 3.json                   # Task #3
-```
-
-### Team Config Structure
-
-```json
-{
-  "name": "my-project",
-  "description": "Working on feature X",
-  "leadAgentId": "team-lead@my-project",
-  "createdAt": 1706000000000,
-  "members": [
-    {
-      "agentId": "team-lead@my-project",
-      "name": "team-lead",
-      "agentType": "team-lead",
-      "color": "#4A90D9",
-      "joinedAt": 1706000000000,
-      "backendType": "in-process"
-    },
-    {
-      "agentId": "worker-1@my-project",
-      "name": "worker-1",
-      "agentType": "Explore",
-      "model": "haiku",
-      "prompt": "Analyze the codebase structure...",
-      "color": "#D94A4A",
-      "planModeRequired": false,
-      "joinedAt": 1706000001000,
-      "tmuxPaneId": "in-process",
-      "cwd": "/Users/me/project",
-      "backendType": "in-process"
-    }
-  ]
-}
-```
+> For detailed team config structure, file layout, environment variables, and spawn backends, use the Read tool on `references/team-lifecycle.md`
 
 ---
 
 ## Two Ways to Spawn Agents
 
-### Method 1: Task Tool (Subagents)
+### Subagent (Task tool, no team)
 
-Use Task for **short-lived, focused work** that returns a result:
+Short-lived, focused work that returns a result:
 
 ```javascript
 Task({
   subagent_type: "Explore",
   description: "Find auth files",
   prompt: "Find all authentication-related files in this codebase",
-  model: "haiku"  // Optional: haiku, sonnet, opus
+  model: "haiku"
 })
 ```
 
-**Characteristics:**
-- Runs synchronously (blocks until complete) or async with `run_in_background: true`
-- Returns result directly to you
-- No team membership required
-- Best for: searches, analysis, focused research
+Runs synchronously (or async with `run_in_background: true`), returns result directly. No team membership.
 
-### Method 2: Task Tool + team_name + name (Teammates)
+### Teammate (Task + team_name + name)
 
-Use Task with `team_name` and `name` to **spawn persistent teammates**:
+Persistent agent that joins a team:
 
 ```javascript
-// First create a team
-Teammate({ operation: "spawnTeam", team_name: "my-project" })
-
-// Then spawn a teammate into that team
 Task({
-  team_name: "my-project",        // Required: which team to join
-  name: "security-reviewer",      // Required: teammate's name
-  subagent_type: "security-sentinel",
-  prompt: "Review all authentication code for vulnerabilities. Send findings to team-lead via Teammate write.",
-  run_in_background: true         // Teammates usually run in background
+  team_name: "my-project",
+  name: "security-reviewer",
+  subagent_type: "aimi-engineering:review:aimi-security-sentinel",
+  prompt: "Review all auth code for vulnerabilities. Send findings to team-lead.",
+  run_in_background: true
 })
 ```
 
-**Characteristics:**
-- Joins team, appears in `config.json`
-- Communicates via inbox messages
-- Can claim tasks from shared task list
-- Persists until shutdown
-- Best for: parallel work, ongoing collaboration, pipeline stages
+Joins team, communicates via inbox, can claim tasks from shared list. Persists until shutdown.
 
-### Key Difference
-
-| Aspect | Task (subagent) | Task + team_name + name (teammate) |
-|--------|-----------------|-----------------------------------|
-| Lifespan | Until task complete | Until shutdown requested |
+| Aspect | Subagent | Teammate |
+|--------|----------|----------|
+| Lifespan | Until task complete | Until shutdown |
 | Communication | Return value | Inbox messages |
 | Task access | None | Shared task list |
 | Team membership | No | Yes |
-| Coordination | One-off | Ongoing |
 
 ---
 
-## Built-in Agent Types
+## Agent Types
 
-These are always available without plugins:
+### Built-in
 
-### Bash
-```javascript
-Task({
-  subagent_type: "Bash",
-  description: "Run git commands",
-  prompt: "Check git status and show recent commits"
-})
-```
-- **Tools:** Bash only
-- **Model:** Inherits from parent
-- **Best for:** Git operations, command execution, system tasks
+| Type | Tools | Best For |
+|------|-------|----------|
+| `Bash` | Bash only | Git ops, command execution |
+| `Explore` | Read-only (model: haiku) | Codebase search, file discovery |
+| `Plan` | Read-only | Architecture planning |
+| `general-purpose` | All tools | Multi-step tasks, implementation |
+| `claude-code-guide` | Read-only + Web | Claude Code questions |
 
-### Explore
-```javascript
-Task({
-  subagent_type: "Explore",
-  description: "Find API endpoints",
-  prompt: "Find all API endpoints in this codebase. Be very thorough.",
-  model: "haiku"  // Fast and cheap
-})
-```
-- **Tools:** All read-only tools (no Edit, Write, NotebookEdit, Task)
-- **Model:** Haiku (optimized for speed)
-- **Best for:** Codebase exploration, file searches, code understanding
-- **Thoroughness levels:** "quick", "medium", "very thorough"
+### Plugin (aimi-engineering)
 
-### Plan
-```javascript
-Task({
-  subagent_type: "Plan",
-  description: "Design auth system",
-  prompt: "Create an implementation plan for adding OAuth2 authentication"
-})
-```
-- **Tools:** All read-only tools
-- **Model:** Inherits from parent
-- **Best for:** Architecture planning, implementation strategies
+**Review:** `aimi-engineering:review:aimi-security-sentinel`, `aimi-performance-oracle`, `aimi-architecture-strategist`, `aimi-code-simplicity-reviewer`, `aimi-kieran-rails-reviewer`, `aimi-kieran-typescript-reviewer`, `aimi-kieran-python-reviewer`, `aimi-dhh-rails-reviewer`, and more.
 
-### general-purpose
-```javascript
-Task({
-  subagent_type: "general-purpose",
-  description: "Research and implement",
-  prompt: "Research React Query best practices and implement caching for the user API"
-})
-```
-- **Tools:** All tools (*)
-- **Model:** Inherits from parent
-- **Best for:** Multi-step tasks, research + action combinations
+**Research:** `aimi-engineering:research:aimi-best-practices-researcher`, `aimi-framework-docs-researcher`, `aimi-codebase-researcher`, `aimi-learnings-researcher`
 
-### claude-code-guide
-```javascript
-Task({
-  subagent_type: "claude-code-guide",
-  description: "Help with Claude Code",
-  prompt: "How do I configure MCP servers?"
-})
-```
-- **Tools:** Read-only + WebFetch + WebSearch
-- **Best for:** Questions about Claude Code, Agent SDK, Anthropic API
+**Design:** `aimi-engineering:design:aimi-figma-design-sync`
 
-### statusline-setup
-```javascript
-Task({
-  subagent_type: "statusline-setup",
-  description: "Configure status line",
-  prompt: "Set up a status line showing git branch and node version"
-})
-```
-- **Tools:** Read, Edit only
-- **Model:** Sonnet
-- **Best for:** Configuring Claude Code status line
+**Workflow:** `aimi-engineering:workflow:aimi-bug-reproduction-validator`
+
+> For full agent type details with examples, use the Read tool on `references/agent-types.md`
 
 ---
 
-## Plugin Agent Types
+## Core Operations
 
-From the `aimi-engineering` plugin:
-
-### Review Agents
-```javascript
-// Security review
-Task({
-  subagent_type: "aimi-engineering:review:aimi-security-sentinel",
-  description: "Security audit",
-  prompt: "Audit this PR for security vulnerabilities"
-})
-
-// Performance review
-Task({
-  subagent_type: "aimi-engineering:review:aimi-performance-oracle",
-  description: "Performance check",
-  prompt: "Analyze this code for performance bottlenecks"
-})
-
-// Rails code review
-Task({
-  subagent_type: "aimi-engineering:review:aimi-kieran-rails-reviewer",
-  description: "Rails review",
-  prompt: "Review this Rails code for best practices"
-})
-
-// Architecture review
-Task({
-  subagent_type: "aimi-engineering:review:aimi-architecture-strategist",
-  description: "Architecture review",
-  prompt: "Review the system architecture of the authentication module"
-})
-
-// Code simplicity
-Task({
-  subagent_type: "aimi-engineering:review:aimi-code-simplicity-reviewer",
-  description: "Simplicity check",
-  prompt: "Check if this implementation can be simplified"
-})
-```
-
-**All review agents from aimi-engineering:**
-- `aimi-agent-native-reviewer` - Ensures features work for agents too
-- `aimi-architecture-strategist` - Architectural compliance
-- `aimi-code-simplicity-reviewer` - YAGNI and minimalism
-- `aimi-data-integrity-guardian` - Database and data safety
-- `aimi-data-migration-expert` - Migration validation
-- `aimi-deployment-verification-agent` - Pre-deploy checklists
-- `aimi-dhh-rails-reviewer` - DHH/37signals Rails style
-- `aimi-julik-frontend-races-reviewer` - JavaScript race conditions
-- `aimi-kieran-python-reviewer` - Python best practices
-- `aimi-kieran-rails-reviewer` - Rails best practices
-- `aimi-kieran-typescript-reviewer` - TypeScript best practices
-- `aimi-pattern-recognition-specialist` - Design patterns and anti-patterns
-- `aimi-performance-oracle` - Performance analysis
-- `aimi-security-sentinel` - Security vulnerabilities
-
-### Research Agents
-```javascript
-// Best practices research
-Task({
-  subagent_type: "aimi-engineering:research:aimi-best-practices-researcher",
-  description: "Research auth best practices",
-  prompt: "Research current best practices for JWT authentication in Rails 2024-2026"
-})
-
-// Framework documentation
-Task({
-  subagent_type: "aimi-engineering:research:aimi-framework-docs-researcher",
-  description: "Research Active Storage",
-  prompt: "Gather comprehensive documentation about Active Storage file uploads"
-})
-
-// Learnings research
-Task({
-  subagent_type: "aimi-engineering:research:aimi-learnings-researcher",
-  description: "Search past solutions",
-  prompt: "Search .aimi/solutions/ for relevant past solutions to authentication issues"
-})
-```
-
-**All research agents from aimi-engineering:**
-- `aimi-best-practices-researcher` - External best practices
-- `aimi-framework-docs-researcher` - Framework documentation
-- `aimi-codebase-researcher` - Repository structure and patterns
-- `aimi-learnings-researcher` - Search .aimi/solutions/
-
-### Design Agents
-```javascript
-Task({
-  subagent_type: "aimi-engineering:design:aimi-figma-design-sync",
-  description: "Sync with Figma",
-  prompt: "Compare implementation with Figma design at [URL]"
-})
-```
-
-### Workflow Agents
-```javascript
-Task({
-  subagent_type: "aimi-engineering:workflow:aimi-bug-reproduction-validator",
-  description: "Validate bug",
-  prompt: "Reproduce and validate this reported bug: [description]"
-})
-```
-
----
-
-## TeammateTool Operations
-
-### 1. spawnTeam - Create a Team
+### Team Setup
 
 ```javascript
-Teammate({
-  operation: "spawnTeam",
-  team_name: "feature-auth",
-  description: "Implementing OAuth2 authentication"
-})
+// Create team (you become leader)
+Teammate({ operation: "spawnTeam", team_name: "feature-auth" })
 ```
 
-**Creates:**
-- `~/.claude/teams/feature-auth/config.json`
-- `~/.claude/tasks/feature-auth/` directory
-- You become the team leader
-
-### 2. discoverTeams - List Available Teams
+### Messaging
 
 ```javascript
-Teammate({ operation: "discoverTeams" })
+// Message one teammate
+Teammate({ operation: "write", target_agent_id: "worker-1", value: "Prioritize auth module" })
+
+// Broadcast to all (expensive -- prefer write)
+Teammate({ operation: "broadcast", name: "team-lead", value: "Status check" })
 ```
 
-**Returns:** List of teams you can join (not already a member of)
-
-### 3. requestJoin - Request to Join Team
+### Task Management
 
 ```javascript
-Teammate({
-  operation: "requestJoin",
-  team_name: "feature-auth",
-  proposed_name: "helper",
-  capabilities: "I can help with code review and testing"
-})
+// Create task
+TaskCreate({ subject: "Review auth", description: "...", activeForm: "Reviewing..." })
+
+// Set dependencies (auto-unblock when blocking task completes)
+TaskUpdate({ taskId: "2", addBlockedBy: ["1"] })
+
+// Claim and work
+TaskUpdate({ taskId: "1", owner: "worker-1", status: "in_progress" })
+TaskUpdate({ taskId: "1", status: "completed" })
 ```
 
-### 4. approveJoin - Accept Join Request (Leader Only)
-
-When you receive a `join_request` message:
-```json
-{"type": "join_request", "proposedName": "helper", "requestId": "join-123", ...}
-```
-
-Approve it:
-```javascript
-Teammate({
-  operation: "approveJoin",
-  target_agent_id: "helper",
-  request_id: "join-123"
-})
-```
-
-### 5. rejectJoin - Decline Join Request (Leader Only)
+### Shutdown
 
 ```javascript
-Teammate({
-  operation: "rejectJoin",
-  target_agent_id: "helper",
-  request_id: "join-123",
-  reason: "Team is at capacity"
-})
-```
-
-### 6. write - Message One Teammate
-
-```javascript
-Teammate({
-  operation: "write",
-  target_agent_id: "security-reviewer",
-  value: "Please prioritize the authentication module. The deadline is tomorrow."
-})
-```
-
-**Important for teammates:** Your text output is NOT visible to the team. You MUST use `write` to communicate.
-
-### 7. broadcast - Message ALL Teammates
-
-```javascript
-Teammate({
-  operation: "broadcast",
-  name: "team-lead",  // Your name
-  value: "Status check: Please report your progress"
-})
-```
-
-**WARNING:** Broadcasting is expensive - sends N separate messages for N teammates. Prefer `write` to specific teammates.
-
-**When to broadcast:**
-- Critical issues requiring immediate attention
-- Major announcements affecting everyone
-
-**When NOT to broadcast:**
-- Responding to one teammate
-- Normal back-and-forth
-- Information relevant to only some teammates
-
-### 8. requestShutdown - Ask Teammate to Exit (Leader Only)
-
-```javascript
-Teammate({
-  operation: "requestShutdown",
-  target_agent_id: "security-reviewer",
-  reason: "All tasks complete, wrapping up"
-})
-```
-
-### 9. approveShutdown - Accept Shutdown (Teammate Only)
-
-When you receive a `shutdown_request` message:
-```json
-{"type": "shutdown_request", "requestId": "shutdown-123", "from": "team-lead", "reason": "Done"}
-```
-
-**MUST** call:
-```javascript
-Teammate({
-  operation: "approveShutdown",
-  request_id: "shutdown-123"
-})
-```
-
-This sends confirmation and terminates your process.
-
-### 10. rejectShutdown - Decline Shutdown (Teammate Only)
-
-```javascript
-Teammate({
-  operation: "rejectShutdown",
-  request_id: "shutdown-123",
-  reason: "Still working on task #3, need 5 more minutes"
-})
-```
-
-### 11. approvePlan - Approve Teammate's Plan (Leader Only)
-
-When teammate with `plan_mode_required` sends a plan:
-```json
-{"type": "plan_approval_request", "from": "architect", "requestId": "plan-456", ...}
-```
-
-Approve:
-```javascript
-Teammate({
-  operation: "approvePlan",
-  target_agent_id: "architect",
-  request_id: "plan-456"
-})
-```
-
-### 12. rejectPlan - Reject Plan with Feedback (Leader Only)
-
-```javascript
-Teammate({
-  operation: "rejectPlan",
-  target_agent_id: "architect",
-  request_id: "plan-456",
-  feedback: "Please add error handling for the API calls and consider rate limiting"
-})
-```
-
-### 13. cleanup - Remove Team Resources
-
-```javascript
+// Request shutdown for each teammate, wait for approvals, then cleanup
+Teammate({ operation: "requestShutdown", target_agent_id: "worker-1" })
+// Wait for {"type": "shutdown_approved"} ...
 Teammate({ operation: "cleanup" })
 ```
 
-**Removes:**
-- `~/.claude/teams/{team-name}/` directory
-- `~/.claude/tasks/{team-name}/` directory
+> For all 13 TeammateTool operations and message format schemas, use the Read tool on `references/message-protocols.md`
 
-**IMPORTANT:** Will fail if teammates are still active. Use `requestShutdown` first.
-
----
-
-## Task System Integration
-
-### TaskCreate - Create Work Items
-
-```javascript
-TaskCreate({
-  subject: "Review authentication module",
-  description: "Review all files in app/services/auth/ for security vulnerabilities",
-  activeForm: "Reviewing auth module..."  // Shown in spinner when in_progress
-})
-```
-
-### TaskList - See All Tasks
-
-```javascript
-TaskList()
-```
-
-Returns:
-```
-#1 [completed] Analyze codebase structure
-#2 [in_progress] Review authentication module (owner: security-reviewer)
-#3 [pending] Generate summary report [blocked by #2]
-```
-
-### TaskGet - Get Task Details
-
-```javascript
-TaskGet({ taskId: "2" })
-```
-
-Returns full task with description, status, blockedBy, etc.
-
-### TaskUpdate - Update Task Status
-
-```javascript
-// Claim a task
-TaskUpdate({ taskId: "2", owner: "security-reviewer" })
-
-// Start working
-TaskUpdate({ taskId: "2", status: "in_progress" })
-
-// Mark complete
-TaskUpdate({ taskId: "2", status: "completed" })
-
-// Set up dependencies
-TaskUpdate({ taskId: "3", addBlockedBy: ["1", "2"] })
-```
-
-### Task Dependencies
-
-When a blocking task is completed, blocked tasks are automatically unblocked:
-
-```javascript
-// Create pipeline
-TaskCreate({ subject: "Step 1: Research" })        // #1
-TaskCreate({ subject: "Step 2: Implement" })       // #2
-TaskCreate({ subject: "Step 3: Test" })            // #3
-TaskCreate({ subject: "Step 4: Deploy" })          // #4
-
-// Set up dependencies
-TaskUpdate({ taskId: "2", addBlockedBy: ["1"] })   // #2 waits for #1
-TaskUpdate({ taskId: "3", addBlockedBy: ["2"] })   // #3 waits for #2
-TaskUpdate({ taskId: "4", addBlockedBy: ["3"] })   // #4 waits for #3
-
-// When #1 completes, #2 auto-unblocks
-// When #2 completes, #3 auto-unblocks
-// etc.
-```
-
-### Task File Structure
-
-`~/.claude/tasks/{team-name}/1.json`:
-```json
-{
-  "id": "1",
-  "subject": "Review authentication module",
-  "description": "Review all files in app/services/auth/...",
-  "status": "in_progress",
-  "owner": "security-reviewer",
-  "activeForm": "Reviewing auth module...",
-  "blockedBy": [],
-  "blocks": ["3"],
-  "createdAt": 1706000000000,
-  "updatedAt": 1706000001000
-}
-```
-
----
-
-## Message Formats
-
-### Regular Message
-
-```json
-{
-  "from": "team-lead",
-  "text": "Please prioritize the auth module",
-  "timestamp": "2026-01-25T23:38:32.588Z",
-  "read": false
-}
-```
-
-### Structured Messages (JSON in text field)
-
-#### Shutdown Request
-```json
-{
-  "type": "shutdown_request",
-  "requestId": "shutdown-abc123@worker-1",
-  "from": "team-lead",
-  "reason": "All tasks complete",
-  "timestamp": "2026-01-25T23:38:32.588Z"
-}
-```
-
-#### Shutdown Approved
-```json
-{
-  "type": "shutdown_approved",
-  "requestId": "shutdown-abc123@worker-1",
-  "from": "worker-1",
-  "paneId": "%5",
-  "backendType": "in-process",
-  "timestamp": "2026-01-25T23:39:00.000Z"
-}
-```
-
-#### Idle Notification (auto-sent when teammate stops)
-```json
-{
-  "type": "idle_notification",
-  "from": "worker-1",
-  "timestamp": "2026-01-25T23:40:00.000Z",
-  "completedTaskId": "2",
-  "completedStatus": "completed"
-}
-```
-
-#### Task Completed
-```json
-{
-  "type": "task_completed",
-  "from": "worker-1",
-  "taskId": "2",
-  "taskSubject": "Review authentication module",
-  "timestamp": "2026-01-25T23:40:00.000Z"
-}
-```
-
-#### Plan Approval Request
-```json
-{
-  "type": "plan_approval_request",
-  "from": "architect",
-  "requestId": "plan-xyz789",
-  "planContent": "# Implementation Plan\n\n1. ...",
-  "timestamp": "2026-01-25T23:41:00.000Z"
-}
-```
-
-#### Join Request
-```json
-{
-  "type": "join_request",
-  "proposedName": "helper",
-  "requestId": "join-abc123",
-  "capabilities": "Code review and testing",
-  "timestamp": "2026-01-25T23:42:00.000Z"
-}
-```
-
-#### Permission Request (for sandbox/tool permissions)
-```json
-{
-  "type": "permission_request",
-  "requestId": "perm-123",
-  "workerId": "worker-1@my-project",
-  "workerName": "worker-1",
-  "workerColor": "#4A90D9",
-  "toolName": "Bash",
-  "toolUseId": "toolu_abc123",
-  "description": "Run npm install",
-  "input": {"command": "npm install"},
-  "permissionSuggestions": ["Bash(npm *)"],
-  "createdAt": 1706000000000
-}
-```
+> For detailed TaskCreate/TaskList/TaskGet/TaskUpdate usage and task file structure, use the Read tool on `references/task-coordination.md`
 
 ---
 
 ## Orchestration Patterns
 
-### Pattern 1: Parallel Specialists (Leader Pattern)
+### Parallel Specialists
 
-Multiple specialists review code simultaneously:
+Spawn multiple reviewers simultaneously, collect results, synthesize:
 
 ```javascript
-// 1. Create team
 Teammate({ operation: "spawnTeam", team_name: "code-review" })
 
-// 2. Spawn specialists in parallel (single message, multiple Task calls)
-Task({
-  team_name: "code-review",
-  name: "security",
+Task({ team_name: "code-review", name: "security",
   subagent_type: "aimi-engineering:review:aimi-security-sentinel",
-  prompt: "Review the PR for security vulnerabilities. Focus on: SQL injection, XSS, auth bypass. Send findings to team-lead.",
-  run_in_background: true
-})
+  prompt: "Review PR for security issues. Send findings to team-lead.",
+  run_in_background: true })
 
-Task({
-  team_name: "code-review",
-  name: "performance",
+Task({ team_name: "code-review", name: "performance",
   subagent_type: "aimi-engineering:review:aimi-performance-oracle",
-  prompt: "Review the PR for performance issues. Focus on: N+1 queries, memory leaks, slow algorithms. Send findings to team-lead.",
-  run_in_background: true
-})
+  prompt: "Review PR for performance issues. Send findings to team-lead.",
+  run_in_background: true })
 
-Task({
-  team_name: "code-review",
-  name: "simplicity",
-  subagent_type: "aimi-engineering:review:aimi-code-simplicity-reviewer",
-  prompt: "Review the PR for unnecessary complexity. Focus on: over-engineering, premature abstraction, YAGNI violations. Send findings to team-lead.",
-  run_in_background: true
-})
-
-// 3. Wait for results (check inbox)
-// cat ~/.claude/teams/code-review/inboxes/team-lead.json
-
-// 4. Synthesize findings and cleanup
-Teammate({ operation: "requestShutdown", target_agent_id: "security" })
-Teammate({ operation: "requestShutdown", target_agent_id: "performance" })
-Teammate({ operation: "requestShutdown", target_agent_id: "simplicity" })
-// Wait for approvals...
-Teammate({ operation: "cleanup" })
+// Collect from inbox, synthesize, shutdown + cleanup
 ```
 
-### Pattern 2: Pipeline (Sequential Dependencies)
+### Pipeline (Sequential)
 
-Each stage depends on the previous:
+Tasks auto-unblock as dependencies complete:
 
 ```javascript
-// 1. Create team and task pipeline
-Teammate({ operation: "spawnTeam", team_name: "feature-pipeline" })
-
-TaskCreate({ subject: "Research", description: "Research best practices for the feature", activeForm: "Researching..." })
-TaskCreate({ subject: "Plan", description: "Create implementation plan based on research", activeForm: "Planning..." })
-TaskCreate({ subject: "Implement", description: "Implement the feature according to plan", activeForm: "Implementing..." })
-TaskCreate({ subject: "Test", description: "Write and run tests for the implementation", activeForm: "Testing..." })
-TaskCreate({ subject: "Review", description: "Final code review before merge", activeForm: "Reviewing..." })
-
-// Set up sequential dependencies
+TaskCreate({ subject: "Research" })   // #1
+TaskCreate({ subject: "Implement" })  // #2
+TaskCreate({ subject: "Test" })       // #3
 TaskUpdate({ taskId: "2", addBlockedBy: ["1"] })
 TaskUpdate({ taskId: "3", addBlockedBy: ["2"] })
-TaskUpdate({ taskId: "4", addBlockedBy: ["3"] })
-TaskUpdate({ taskId: "5", addBlockedBy: ["4"] })
-
-// 2. Spawn workers that claim and complete tasks
-Task({
-  team_name: "feature-pipeline",
-  name: "researcher",
-  subagent_type: "aimi-engineering:research:aimi-best-practices-researcher",
-  prompt: "Claim task #1, research best practices, complete it, send findings to team-lead. Then check for more work.",
-  run_in_background: true
-})
-
-Task({
-  team_name: "feature-pipeline",
-  name: "implementer",
-  subagent_type: "general-purpose",
-  prompt: "Poll TaskList every 30 seconds. When task #3 unblocks, claim it and implement. Then complete and notify team-lead.",
-  run_in_background: true
-})
-
-// Tasks auto-unblock as dependencies complete
+// Spawn workers -- tasks unblock automatically
 ```
 
-### Pattern 3: Swarm (Self-Organizing)
+### Swarm (Self-Organizing)
 
-Workers grab available tasks from a pool:
+Workers race to claim from a pool of independent tasks:
 
 ```javascript
-// 1. Create team and task pool
-Teammate({ operation: "spawnTeam", team_name: "file-review-swarm" })
-
-// Create many independent tasks (no dependencies)
-for (const file of ["auth.rb", "user.rb", "api_controller.rb", "payment.rb"]) {
-  TaskCreate({
-    subject: `Review ${file}`,
-    description: `Review ${file} for security and code quality issues`,
-    activeForm: `Reviewing ${file}...`
-  })
-}
-
-// 2. Spawn worker swarm
-Task({
-  team_name: "file-review-swarm",
-  name: "worker-1",
-  subagent_type: "general-purpose",
-  prompt: `
-    You are a swarm worker. Your job:
-    1. Call TaskList to see available tasks
-    2. Find a task with status 'pending' and no owner
-    3. Claim it with TaskUpdate (set owner to your name)
-    4. Do the work
-    5. Mark it completed with TaskUpdate
-    6. Send findings to team-lead via Teammate write
-    7. Repeat until no tasks remain
-  `,
-  run_in_background: true
-})
-
-Task({
-  team_name: "file-review-swarm",
-  name: "worker-2",
-  subagent_type: "general-purpose",
-  prompt: `[Same prompt as worker-1]`,
-  run_in_background: true
-})
-
-Task({
-  team_name: "file-review-swarm",
-  name: "worker-3",
-  subagent_type: "general-purpose",
-  prompt: `[Same prompt as worker-1]`,
-  run_in_background: true
-})
-
-// Workers race to claim tasks, naturally load-balance
+// Create many independent tasks, spawn N workers with prompt:
+// "1. TaskList  2. Find pending task  3. Claim  4. Work  5. Complete  6. Repeat"
 ```
 
-### Pattern 4: Research + Implementation
+### Research + Implementation
 
-Research first, then implement:
+Synchronous research, then pass results to implementer:
 
 ```javascript
-// 1. Research phase (synchronous, returns results)
-const research = await Task({
-  subagent_type: "aimi-engineering:research:aimi-best-practices-researcher",
-  description: "Research caching patterns",
-  prompt: "Research best practices for implementing caching in Rails APIs. Include: cache invalidation strategies, Redis vs Memcached, cache key design."
-})
-
-// 2. Use research to guide implementation
-Task({
-  subagent_type: "general-purpose",
-  description: "Implement caching",
-  prompt: `
-    Implement API caching based on this research:
-
-    ${research.content}
-
-    Focus on the user_controller.rb endpoints.
-  `
-})
+const research = await Task({ subagent_type: "...", prompt: "Research caching..." })
+Task({ subagent_type: "general-purpose", prompt: `Implement based on: ${research.content}` })
 ```
 
-### Pattern 5: Plan Approval Workflow
-
-Require plan approval before implementation:
-
-```javascript
-// 1. Create team
-Teammate({ operation: "spawnTeam", team_name: "careful-work" })
-
-// 2. Spawn architect with plan_mode_required
-Task({
-  team_name: "careful-work",
-  name: "architect",
-  subagent_type: "Plan",
-  prompt: "Design an implementation plan for adding OAuth2 authentication",
-  mode: "plan",  // Requires plan approval
-  run_in_background: true
-})
-
-// 3. Wait for plan approval request
-// You'll receive: {"type": "plan_approval_request", "from": "architect", "requestId": "plan-xxx", ...}
-
-// 4. Review and approve/reject
-Teammate({
-  operation: "approvePlan",
-  target_agent_id: "architect",
-  request_id: "plan-xxx"
-})
-// OR
-Teammate({
-  operation: "rejectPlan",
-  target_agent_id: "architect",
-  request_id: "plan-xxx",
-  feedback: "Please add rate limiting considerations"
-})
-```
-
-### Pattern 6: Coordinated Multi-File Refactoring
-
-```javascript
-// 1. Create team for coordinated refactoring
-Teammate({ operation: "spawnTeam", team_name: "refactor-auth" })
-
-// 2. Create tasks with clear file boundaries
-TaskCreate({
-  subject: "Refactor User model",
-  description: "Extract authentication methods to AuthenticatableUser concern",
-  activeForm: "Refactoring User model..."
-})
-
-TaskCreate({
-  subject: "Refactor Session controller",
-  description: "Update to use new AuthenticatableUser concern",
-  activeForm: "Refactoring Sessions..."
-})
-
-TaskCreate({
-  subject: "Update specs",
-  description: "Update all authentication specs for new structure",
-  activeForm: "Updating specs..."
-})
-
-// Dependencies: specs depend on both refactors completing
-TaskUpdate({ taskId: "3", addBlockedBy: ["1", "2"] })
-
-// 3. Spawn workers for each task
-Task({
-  team_name: "refactor-auth",
-  name: "model-worker",
-  subagent_type: "general-purpose",
-  prompt: "Claim task #1, refactor the User model, complete when done",
-  run_in_background: true
-})
-
-Task({
-  team_name: "refactor-auth",
-  name: "controller-worker",
-  subagent_type: "general-purpose",
-  prompt: "Claim task #2, refactor the Session controller, complete when done",
-  run_in_background: true
-})
-
-Task({
-  team_name: "refactor-auth",
-  name: "spec-worker",
-  subagent_type: "general-purpose",
-  prompt: "Wait for task #3 to unblock (when #1 and #2 complete), then update specs",
-  run_in_background: true
-})
-```
-
----
-
-## Environment Variables
-
-Spawned teammates automatically receive these:
-
-```bash
-CLAUDE_CODE_TEAM_NAME="my-project"
-CLAUDE_CODE_AGENT_ID="worker-1@my-project"
-CLAUDE_CODE_AGENT_NAME="worker-1"
-CLAUDE_CODE_AGENT_TYPE="Explore"
-CLAUDE_CODE_AGENT_COLOR="#4A90D9"
-CLAUDE_CODE_PLAN_MODE_REQUIRED="false"
-CLAUDE_CODE_PARENT_SESSION_ID="session-xyz"
-```
-
-**Using in prompts:**
-```javascript
-Task({
-  team_name: "my-project",
-  name: "worker",
-  subagent_type: "general-purpose",
-  prompt: "Your name is $CLAUDE_CODE_AGENT_NAME. Use it when sending messages to team-lead."
-})
-```
-
----
-
-## Spawn Backends
-
-A **backend** determines how teammate Claude instances actually run. Claude Code supports three backends, and **auto-detects** the best one based on your environment.
-
-### Backend Comparison
-
-| Backend | How It Works | Visibility | Persistence | Speed |
-|---------|-------------|------------|-------------|-------|
-| **in-process** | Same Node.js process as leader | Hidden (background) | Dies with leader | Fastest |
-| **tmux** | Separate terminal in tmux session | Visible in tmux | Survives leader exit | Medium |
-| **iterm2** | Split panes in iTerm2 window | Visible side-by-side | Dies with window | Medium |
-
-### Auto-Detection Logic
-
-Claude Code automatically selects a backend using this decision tree:
-
-```mermaid
-flowchart TD
-    A[Start] --> B{Running inside tmux?}
-    B -->|Yes| C[Use tmux backend]
-    B -->|No| D{Running in iTerm2?}
-    D -->|No| E{tmux available?}
-    E -->|Yes| F[Use tmux - external session]
-    E -->|No| G[Use in-process]
-    D -->|Yes| H{it2 CLI installed?}
-    H -->|Yes| I[Use iterm2 backend]
-    H -->|No| J{tmux available?}
-    J -->|Yes| K[Use tmux - prompt to install it2]
-    J -->|No| L[Error: Install tmux or it2]
-```
-
-**Detection checks:**
-1. `$TMUX` environment variable → inside tmux
-2. `$TERM_PROGRAM === "iTerm.app"` or `$ITERM_SESSION_ID` → in iTerm2
-3. `which tmux` → tmux available
-4. `which it2` → it2 CLI installed
-
-### in-process (Default for non-tmux)
-
-Teammates run as async tasks within the same Node.js process.
-
-**How it works:**
-- No new process spawned
-- Teammates share the same Node.js event loop
-- Communication via in-memory queues (fast)
-- You don't see teammate output directly
-
-**When it's used:**
-- Not running inside tmux session
-- Non-interactive mode (CI, scripts)
-- Explicitly set via `CLAUDE_CODE_SPAWN_BACKEND=in-process`
-
-**Characteristics:**
-```
-┌─────────────────────────────────────────┐
-│           Node.js Process               │
-│  ┌─────────┐  ┌─────────┐  ┌─────────┐ │
-│  │ Leader  │  │Worker 1 │  │Worker 2 │ │
-│  │ (main)  │  │ (async) │  │ (async) │ │
-│  └─────────┘  └─────────┘  └─────────┘ │
-└─────────────────────────────────────────┘
-```
-
-**Pros:**
-- Fastest startup (no process spawn)
-- Lowest overhead
-- Works everywhere
-
-**Cons:**
-- Can't see teammate output in real-time
-- All die if leader dies
-- Harder to debug
-
-```javascript
-// in-process is automatic when not in tmux
-Task({
-  team_name: "my-project",
-  name: "worker",
-  subagent_type: "general-purpose",
-  prompt: "...",
-  run_in_background: true
-})
-
-// Force in-process explicitly
-// export CLAUDE_CODE_SPAWN_BACKEND=in-process
-```
-
-### tmux
-
-Teammates run as separate Claude instances in tmux panes/windows.
-
-**How it works:**
-- Each teammate gets its own tmux pane
-- Separate process per teammate
-- You can switch panes to see teammate output
-- Communication via inbox files
-
-**When it's used:**
-- Running inside a tmux session (`$TMUX` is set)
-- tmux available and not in iTerm2
-- Explicitly set via `CLAUDE_CODE_SPAWN_BACKEND=tmux`
-
-**Layout modes:**
-
-1. **Inside tmux (native):** Splits your current window
-```
-┌─────────────────┬─────────────────┐
-│                 │    Worker 1     │
-│     Leader      ├─────────────────┤
-│   (your pane)   │    Worker 2     │
-│                 ├─────────────────┤
-│                 │    Worker 3     │
-└─────────────────┴─────────────────┘
-```
-
-2. **Outside tmux (external session):** Creates a new tmux session called `claude-swarm`
-```bash
-# Your terminal stays as-is
-# Workers run in separate tmux session
-
-# View workers:
-tmux attach -t claude-swarm
-```
-
-**Pros:**
-- See teammate output in real-time
-- Teammates survive leader exit
-- Can attach/detach sessions
-- Works in CI/headless environments
-
-**Cons:**
-- Slower startup (process spawn)
-- Requires tmux installed
-- More resource usage
-
-```bash
-# Start tmux session first
-tmux new-session -s claude
-
-# Or force tmux backend
-export CLAUDE_CODE_SPAWN_BACKEND=tmux
-```
-
-**Useful tmux commands:**
-```bash
-# List all panes in current window
-tmux list-panes
-
-# Switch to pane by number
-tmux select-pane -t 1
-
-# Kill a specific pane
-tmux kill-pane -t %5
-
-# View swarm session (if external)
-tmux attach -t claude-swarm
-
-# Rebalance pane layout
-tmux select-layout tiled
-```
-
-### iterm2 (macOS only)
-
-Teammates run as split panes within your iTerm2 window.
-
-**How it works:**
-- Uses iTerm2's Python API via `it2` CLI
-- Splits your current window into panes
-- Each teammate visible side-by-side
-- Communication via inbox files
-
-**When it's used:**
-- Running in iTerm2 (`$TERM_PROGRAM === "iTerm.app"`)
-- `it2` CLI is installed and working
-- Python API enabled in iTerm2 preferences
-
-**Layout:**
-```
-┌─────────────────┬─────────────────┐
-│                 │    Worker 1     │
-│     Leader      ├─────────────────┤
-│   (your pane)   │    Worker 2     │
-│                 ├─────────────────┤
-│                 │    Worker 3     │
-└─────────────────┴─────────────────┘
-```
-
-**Pros:**
-- Visual debugging - see all teammates
-- Native macOS experience
-- No tmux needed
-- Automatic pane management
-
-**Cons:**
-- macOS + iTerm2 only
-- Requires setup (it2 CLI + Python API)
-- Panes die with window
-
-**Setup:**
-```bash
-# 1. Install it2 CLI
-uv tool install it2
-# OR
-pipx install it2
-# OR
-pip install --user it2
-
-# 2. Enable Python API in iTerm2
-# iTerm2 → Settings → General → Magic → Enable Python API
-
-# 3. Restart iTerm2
-
-# 4. Verify
-it2 --version
-it2 session list
-```
-
-**If setup fails:**
-Claude Code will prompt you to set up it2 when you first spawn a teammate. You can choose to:
-1. Install it2 now (guided setup)
-2. Use tmux instead
-3. Cancel
-
-### Forcing a Backend
-
-```bash
-# Force in-process (fastest, no visibility)
-export CLAUDE_CODE_SPAWN_BACKEND=in-process
-
-# Force tmux (visible panes, persistent)
-export CLAUDE_CODE_SPAWN_BACKEND=tmux
-
-# Auto-detect (default)
-unset CLAUDE_CODE_SPAWN_BACKEND
-```
-
-### Backend in Team Config
-
-The backend type is recorded per-teammate in `config.json`:
-
-```json
-{
-  "members": [
-    {
-      "name": "worker-1",
-      "backendType": "in-process",
-      "tmuxPaneId": "in-process"
-    },
-    {
-      "name": "worker-2",
-      "backendType": "tmux",
-      "tmuxPaneId": "%5"
-    }
-  ]
-}
-```
-
-### Troubleshooting Backends
-
-| Issue | Cause | Solution |
-|-------|-------|----------|
-| "No pane backend available" | Neither tmux nor iTerm2 available | Install tmux: `brew install tmux` |
-| "it2 CLI not installed" | In iTerm2 but missing it2 | Run `uv tool install it2` |
-| "Python API not enabled" | it2 can't communicate with iTerm2 | Enable in iTerm2 Settings → General → Magic |
-| Workers not visible | Using in-process backend | Start inside tmux or iTerm2 |
-| Workers dying unexpectedly | Outside tmux, leader exited | Use tmux for persistence |
-
-### Checking Current Backend
-
-```bash
-# See what backend was detected
-cat ~/.claude/teams/{team}/config.json | jq '.members[].backendType'
-
-# Check if inside tmux
-echo $TMUX
-
-# Check if in iTerm2
-echo $TERM_PROGRAM
-
-# Check tmux availability
-which tmux
-
-# Check it2 availability
-which it2
-```
+> For complete pattern examples, plan approval workflow, multi-file refactoring, and full end-to-end workflows, use the Read tool on `references/orchestration-patterns.md`
 
 ---
 
 ## Error Handling
 
-### Common Errors
-
-| Error | Cause | Solution |
-|-------|-------|----------|
-| "Cannot cleanup with active members" | Teammates still running | `requestShutdown` all teammates first, wait for approval |
-| "Already leading a team" | Team already exists | `cleanup` first, or use different team name |
-| "Agent not found" | Wrong teammate name | Check `config.json` for actual names |
-| "Team does not exist" | No team created | Call `spawnTeam` first |
-| "team_name is required" | Missing team context | Provide `team_name` parameter |
-| "Agent type not found" | Invalid subagent_type | Check available agents with proper prefix |
-
-### Graceful Shutdown Sequence
-
-**Always follow this sequence:**
-
-```javascript
-// 1. Request shutdown for all teammates
-Teammate({ operation: "requestShutdown", target_agent_id: "worker-1" })
-Teammate({ operation: "requestShutdown", target_agent_id: "worker-2" })
-
-// 2. Wait for shutdown approvals
-// Check for {"type": "shutdown_approved", ...} messages
-
-// 3. Verify no active members
-// Read ~/.claude/teams/{team}/config.json
-
-// 4. Only then cleanup
-Teammate({ operation: "cleanup" })
-```
-
-### Handling Crashed Teammates
-
-Teammates have a 5-minute heartbeat timeout. If a teammate crashes:
-
-1. They'll be automatically marked as inactive after timeout
-2. Their tasks remain in the task list
-3. Another teammate can claim their tasks
-4. Cleanup will work after timeout expires
-
-### Debugging
-
-```bash
-# Check team config
-cat ~/.claude/teams/{team}/config.json | jq '.members[] | {name, agentType, backendType}'
-
-# Check teammate inboxes
-cat ~/.claude/teams/{team}/inboxes/{agent}.json | jq '.'
-
-# List all teams
-ls ~/.claude/teams/
-
-# Check task states
-cat ~/.claude/tasks/{team}/*.json | jq '{id, subject, status, owner, blockedBy}'
-
-# Watch for new messages
-tail -f ~/.claude/teams/{team}/inboxes/team-lead.json
-```
-
----
-
-## Complete Workflows
-
-### Workflow 1: Full Code Review with Parallel Specialists
-
-```javascript
-// === STEP 1: Setup ===
-Teammate({ operation: "spawnTeam", team_name: "pr-review-123", description: "Reviewing PR #123" })
-
-// === STEP 2: Spawn reviewers in parallel ===
-// (Send all these in a single message for parallel execution)
-Task({
-  team_name: "pr-review-123",
-  name: "security",
-  subagent_type: "aimi-engineering:review:aimi-security-sentinel",
-  prompt: `Review PR #123 for security vulnerabilities.
-
-  Focus on:
-  - SQL injection
-  - XSS vulnerabilities
-  - Authentication/authorization bypass
-  - Sensitive data exposure
-
-  When done, send your findings to team-lead using:
-  Teammate({ operation: "write", target_agent_id: "team-lead", value: "Your findings here" })`,
-  run_in_background: true
-})
-
-Task({
-  team_name: "pr-review-123",
-  name: "perf",
-  subagent_type: "aimi-engineering:review:aimi-performance-oracle",
-  prompt: `Review PR #123 for performance issues.
-
-  Focus on:
-  - N+1 queries
-  - Missing indexes
-  - Memory leaks
-  - Inefficient algorithms
-
-  Send findings to team-lead when done.`,
-  run_in_background: true
-})
-
-Task({
-  team_name: "pr-review-123",
-  name: "arch",
-  subagent_type: "aimi-engineering:review:aimi-architecture-strategist",
-  prompt: `Review PR #123 for architectural concerns.
-
-  Focus on:
-  - Design pattern adherence
-  - SOLID principles
-  - Separation of concerns
-  - Testability
-
-  Send findings to team-lead when done.`,
-  run_in_background: true
-})
-
-// === STEP 3: Monitor and collect results ===
-// Poll inbox or wait for idle notifications
-// cat ~/.claude/teams/pr-review-123/inboxes/team-lead.json
-
-// === STEP 4: Synthesize findings ===
-// Combine all reviewer findings into a cohesive report
-
-// === STEP 5: Cleanup ===
-Teammate({ operation: "requestShutdown", target_agent_id: "security" })
-Teammate({ operation: "requestShutdown", target_agent_id: "perf" })
-Teammate({ operation: "requestShutdown", target_agent_id: "arch" })
-// Wait for approvals...
-Teammate({ operation: "cleanup" })
-```
-
-### Workflow 2: Research → Plan → Implement → Test Pipeline
-
-```javascript
-// === SETUP ===
-Teammate({ operation: "spawnTeam", team_name: "feature-oauth" })
-
-// === CREATE PIPELINE ===
-TaskCreate({ subject: "Research OAuth providers", description: "Research OAuth2 best practices and compare providers (Google, GitHub, Auth0)", activeForm: "Researching OAuth..." })
-TaskCreate({ subject: "Create implementation plan", description: "Design OAuth implementation based on research findings", activeForm: "Planning..." })
-TaskCreate({ subject: "Implement OAuth", description: "Implement OAuth2 authentication according to plan", activeForm: "Implementing OAuth..." })
-TaskCreate({ subject: "Write tests", description: "Write comprehensive tests for OAuth implementation", activeForm: "Writing tests..." })
-TaskCreate({ subject: "Final review", description: "Review complete implementation for security and quality", activeForm: "Final review..." })
-
-// Set dependencies
-TaskUpdate({ taskId: "2", addBlockedBy: ["1"] })
-TaskUpdate({ taskId: "3", addBlockedBy: ["2"] })
-TaskUpdate({ taskId: "4", addBlockedBy: ["3"] })
-TaskUpdate({ taskId: "5", addBlockedBy: ["4"] })
-
-// === SPAWN SPECIALIZED WORKERS ===
-Task({
-  team_name: "feature-oauth",
-  name: "researcher",
-  subagent_type: "aimi-engineering:research:aimi-best-practices-researcher",
-  prompt: "Claim task #1. Research OAuth2 best practices, compare providers, document findings. Mark task complete and send summary to team-lead.",
-  run_in_background: true
-})
-
-Task({
-  team_name: "feature-oauth",
-  name: "planner",
-  subagent_type: "Plan",
-  prompt: "Wait for task #2 to unblock. Read research from task #1. Create detailed implementation plan. Mark complete and send plan to team-lead.",
-  run_in_background: true
-})
-
-Task({
-  team_name: "feature-oauth",
-  name: "implementer",
-  subagent_type: "general-purpose",
-  prompt: "Wait for task #3 to unblock. Read plan from task #2. Implement OAuth2 authentication. Mark complete when done.",
-  run_in_background: true
-})
-
-Task({
-  team_name: "feature-oauth",
-  name: "tester",
-  subagent_type: "general-purpose",
-  prompt: "Wait for task #4 to unblock. Write comprehensive tests for the OAuth implementation. Run tests. Mark complete with results.",
-  run_in_background: true
-})
-
-Task({
-  team_name: "feature-oauth",
-  name: "reviewer",
-  subagent_type: "aimi-engineering:review:aimi-security-sentinel",
-  prompt: "Wait for task #5 to unblock. Review the complete OAuth implementation for security. Send final assessment to team-lead.",
-  run_in_background: true
-})
-
-// Pipeline auto-progresses as each stage completes
-```
-
-### Workflow 3: Self-Organizing Code Review Swarm
-
-```javascript
-// === SETUP ===
-Teammate({ operation: "spawnTeam", team_name: "codebase-review" })
-
-// === CREATE TASK POOL (all independent, no dependencies) ===
-const filesToReview = [
-  "app/models/user.rb",
-  "app/models/payment.rb",
-  "app/controllers/api/v1/users_controller.rb",
-  "app/controllers/api/v1/payments_controller.rb",
-  "app/services/payment_processor.rb",
-  "app/services/notification_service.rb",
-  "lib/encryption_helper.rb"
-]
-
-for (const file of filesToReview) {
-  TaskCreate({
-    subject: `Review ${file}`,
-    description: `Review ${file} for security vulnerabilities, code quality, and performance issues`,
-    activeForm: `Reviewing ${file}...`
-  })
-}
-
-// === SPAWN WORKER SWARM ===
-const swarmPrompt = `
-You are a swarm worker. Your job is to continuously process available tasks.
-
-LOOP:
-1. Call TaskList() to see available tasks
-2. Find a task that is:
-   - status: 'pending'
-   - no owner
-   - not blocked
-3. If found:
-   - Claim it: TaskUpdate({ taskId: "X", owner: "YOUR_NAME" })
-   - Start it: TaskUpdate({ taskId: "X", status: "in_progress" })
-   - Do the review work
-   - Complete it: TaskUpdate({ taskId: "X", status: "completed" })
-   - Send findings to team-lead via Teammate write
-   - Go back to step 1
-4. If no tasks available:
-   - Send idle notification to team-lead
-   - Wait 30 seconds
-   - Try again (up to 3 times)
-   - If still no tasks, exit
-
-Replace YOUR_NAME with your actual agent name from $CLAUDE_CODE_AGENT_NAME.
-`
-
-// Spawn 3 workers
-Task({ team_name: "codebase-review", name: "worker-1", subagent_type: "general-purpose", prompt: swarmPrompt, run_in_background: true })
-Task({ team_name: "codebase-review", name: "worker-2", subagent_type: "general-purpose", prompt: swarmPrompt, run_in_background: true })
-Task({ team_name: "codebase-review", name: "worker-3", subagent_type: "general-purpose", prompt: swarmPrompt, run_in_background: true })
-
-// Workers self-organize: race to claim tasks, naturally load-balance
-// Monitor progress with TaskList() or by reading inbox
-```
-
----
-
-## Best Practices
-
-### 1. Always Cleanup
-Don't leave orphaned teams. Always call `cleanup` when done.
-
-### 2. Use Meaningful Names
-```javascript
-// Good
-name: "security-reviewer"
-name: "oauth-implementer"
-name: "test-writer"
-
-// Bad
-name: "worker-1"
-name: "agent-2"
-```
-
-### 3. Write Clear Prompts
-Tell workers exactly what to do:
-```javascript
-// Good
-prompt: `
-  1. Review app/models/user.rb for N+1 queries
-  2. Check all ActiveRecord associations have proper includes
-  3. Document any issues found
-  4. Send findings to team-lead via Teammate write
-`
-
-// Bad
-prompt: "Review the code"
-```
-
-### 4. Use Task Dependencies
-Let the system manage unblocking:
-```javascript
-// Good: Auto-unblocking
-TaskUpdate({ taskId: "2", addBlockedBy: ["1"] })
-
-// Bad: Manual polling
-"Wait until task #1 is done, check every 30 seconds..."
-```
-
-### 5. Check Inboxes for Results
-Workers send results to your inbox. Check it:
-```bash
-cat ~/.claude/teams/{team}/inboxes/team-lead.json | jq '.'
-```
-
-### 6. Handle Worker Failures
-- Workers have 5-minute heartbeat timeout
-- Tasks of crashed workers can be reclaimed
-- Build retry logic into worker prompts
-
-### 7. Prefer write Over broadcast
-`broadcast` sends N messages for N teammates. Use `write` for targeted communication.
-
-### 8. Match Agent Type to Task
-- **Explore** for searching/reading
-- **Plan** for architecture design
-- **general-purpose** for implementation
-- **Specialized reviewers** for specific review types
+| Error | Solution |
+|-------|----------|
+| "Cannot cleanup with active members" | `requestShutdown` all teammates first |
+| "Already leading a team" | `cleanup` first, or use different name |
+| "Agent not found" | Check `config.json` for actual names |
+| "Team does not exist" | Call `spawnTeam` first |
+
+Crashed teammates auto-deactivate after 5-minute heartbeat timeout. Their tasks can be reclaimed.
+
+> For graceful shutdown sequence, debugging commands, and detailed error reference, use the Read tool on `references/error-handling.md`
 
 ---
 
 ## Quick Reference
 
-### Spawn Subagent (No Team)
 ```javascript
+// Spawn subagent (no team)
 Task({ subagent_type: "Explore", description: "Find files", prompt: "..." })
-```
 
-### Spawn Teammate (With Team)
-```javascript
+// Spawn teammate (with team)
 Teammate({ operation: "spawnTeam", team_name: "my-team" })
 Task({ team_name: "my-team", name: "worker", subagent_type: "general-purpose", prompt: "...", run_in_background: true })
-```
 
-### Message Teammate
-```javascript
+// Message teammate
 Teammate({ operation: "write", target_agent_id: "worker-1", value: "..." })
-```
 
-### Create Task Pipeline
-```javascript
+// Create task pipeline
 TaskCreate({ subject: "Step 1", description: "..." })
 TaskCreate({ subject: "Step 2", description: "..." })
 TaskUpdate({ taskId: "2", addBlockedBy: ["1"] })
-```
 
-### Shutdown Team
-```javascript
+// Shutdown team
 Teammate({ operation: "requestShutdown", target_agent_id: "worker-1" })
 // Wait for approval...
 Teammate({ operation: "cleanup" })

--- a/plugins/aimi-engineering/skills/orchestrating-swarms/references/agent-types.md
+++ b/plugins/aimi-engineering/skills/orchestrating-swarms/references/agent-types.md
@@ -1,0 +1,190 @@
+# Agent Types Reference
+
+---
+
+## Built-in Agent Types
+
+These are always available without plugins.
+
+### Bash
+```javascript
+Task({
+  subagent_type: "Bash",
+  description: "Run git commands",
+  prompt: "Check git status and show recent commits"
+})
+```
+- **Tools:** Bash only
+- **Model:** Inherits from parent
+- **Best for:** Git operations, command execution, system tasks
+
+### Explore
+```javascript
+Task({
+  subagent_type: "Explore",
+  description: "Find API endpoints",
+  prompt: "Find all API endpoints in this codebase. Be very thorough.",
+  model: "haiku"  // Fast and cheap
+})
+```
+- **Tools:** All read-only tools (no Edit, Write, NotebookEdit, Task)
+- **Model:** Haiku (optimized for speed)
+- **Best for:** Codebase exploration, file searches, code understanding
+- **Thoroughness levels:** "quick", "medium", "very thorough"
+
+### Plan
+```javascript
+Task({
+  subagent_type: "Plan",
+  description: "Design auth system",
+  prompt: "Create an implementation plan for adding OAuth2 authentication"
+})
+```
+- **Tools:** All read-only tools
+- **Model:** Inherits from parent
+- **Best for:** Architecture planning, implementation strategies
+
+### general-purpose
+```javascript
+Task({
+  subagent_type: "general-purpose",
+  description: "Research and implement",
+  prompt: "Research React Query best practices and implement caching for the user API"
+})
+```
+- **Tools:** All tools (*)
+- **Model:** Inherits from parent
+- **Best for:** Multi-step tasks, research + action combinations
+
+### claude-code-guide
+```javascript
+Task({
+  subagent_type: "claude-code-guide",
+  description: "Help with Claude Code",
+  prompt: "How do I configure MCP servers?"
+})
+```
+- **Tools:** Read-only + WebFetch + WebSearch
+- **Best for:** Questions about Claude Code, Agent SDK, Anthropic API
+
+### statusline-setup
+```javascript
+Task({
+  subagent_type: "statusline-setup",
+  description: "Configure status line",
+  prompt: "Set up a status line showing git branch and node version"
+})
+```
+- **Tools:** Read, Edit only
+- **Model:** Sonnet
+- **Best for:** Configuring Claude Code status line
+
+---
+
+## Plugin Agent Types (aimi-engineering)
+
+### Review Agents
+
+```javascript
+// Security review
+Task({
+  subagent_type: "aimi-engineering:review:aimi-security-sentinel",
+  description: "Security audit",
+  prompt: "Audit this PR for security vulnerabilities"
+})
+
+// Performance review
+Task({
+  subagent_type: "aimi-engineering:review:aimi-performance-oracle",
+  description: "Performance check",
+  prompt: "Analyze this code for performance bottlenecks"
+})
+
+// Rails code review
+Task({
+  subagent_type: "aimi-engineering:review:aimi-kieran-rails-reviewer",
+  description: "Rails review",
+  prompt: "Review this Rails code for best practices"
+})
+
+// Architecture review
+Task({
+  subagent_type: "aimi-engineering:review:aimi-architecture-strategist",
+  description: "Architecture review",
+  prompt: "Review the system architecture of the authentication module"
+})
+
+// Code simplicity
+Task({
+  subagent_type: "aimi-engineering:review:aimi-code-simplicity-reviewer",
+  description: "Simplicity check",
+  prompt: "Check if this implementation can be simplified"
+})
+```
+
+**All review agents from aimi-engineering:**
+- `aimi-agent-native-reviewer` - Ensures features work for agents too
+- `aimi-architecture-strategist` - Architectural compliance
+- `aimi-code-simplicity-reviewer` - YAGNI and minimalism
+- `aimi-data-integrity-guardian` - Database and data safety
+- `aimi-data-migration-expert` - Migration validation
+- `aimi-deployment-verification-agent` - Pre-deploy checklists
+- `aimi-dhh-rails-reviewer` - DHH/37signals Rails style
+- `aimi-julik-frontend-races-reviewer` - JavaScript race conditions
+- `aimi-kieran-python-reviewer` - Python best practices
+- `aimi-kieran-rails-reviewer` - Rails best practices
+- `aimi-kieran-typescript-reviewer` - TypeScript best practices
+- `aimi-pattern-recognition-specialist` - Design patterns and anti-patterns
+- `aimi-performance-oracle` - Performance analysis
+- `aimi-security-sentinel` - Security vulnerabilities
+
+### Research Agents
+
+```javascript
+// Best practices research
+Task({
+  subagent_type: "aimi-engineering:research:aimi-best-practices-researcher",
+  description: "Research auth best practices",
+  prompt: "Research current best practices for JWT authentication in Rails 2024-2026"
+})
+
+// Framework documentation
+Task({
+  subagent_type: "aimi-engineering:research:aimi-framework-docs-researcher",
+  description: "Research Active Storage",
+  prompt: "Gather comprehensive documentation about Active Storage file uploads"
+})
+
+// Learnings research
+Task({
+  subagent_type: "aimi-engineering:research:aimi-learnings-researcher",
+  description: "Search past solutions",
+  prompt: "Search .aimi/solutions/ for relevant past solutions to authentication issues"
+})
+```
+
+**All research agents from aimi-engineering:**
+- `aimi-best-practices-researcher` - External best practices
+- `aimi-framework-docs-researcher` - Framework documentation
+- `aimi-codebase-researcher` - Repository structure and patterns
+- `aimi-learnings-researcher` - Search .aimi/solutions/
+
+### Design Agents
+
+```javascript
+Task({
+  subagent_type: "aimi-engineering:design:aimi-figma-design-sync",
+  description: "Sync with Figma",
+  prompt: "Compare implementation with Figma design at [URL]"
+})
+```
+
+### Workflow Agents
+
+```javascript
+Task({
+  subagent_type: "aimi-engineering:workflow:aimi-bug-reproduction-validator",
+  description: "Validate bug",
+  prompt: "Reproduce and validate this reported bug: [description]"
+})
+```

--- a/plugins/aimi-engineering/skills/orchestrating-swarms/references/error-handling.md
+++ b/plugins/aimi-engineering/skills/orchestrating-swarms/references/error-handling.md
@@ -1,0 +1,61 @@
+# Error Handling & Debugging
+
+---
+
+## Common Errors
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| "Cannot cleanup with active members" | Teammates still running | `requestShutdown` all teammates first, wait for approval |
+| "Already leading a team" | Team already exists | `cleanup` first, or use different team name |
+| "Agent not found" | Wrong teammate name | Check `config.json` for actual names |
+| "Team does not exist" | No team created | Call `spawnTeam` first |
+| "team_name is required" | Missing team context | Provide `team_name` parameter |
+| "Agent type not found" | Invalid subagent_type | Check available agents with proper prefix |
+
+## Graceful Shutdown Sequence
+
+**Always follow this sequence:**
+
+```javascript
+// 1. Request shutdown for all teammates
+Teammate({ operation: "requestShutdown", target_agent_id: "worker-1" })
+Teammate({ operation: "requestShutdown", target_agent_id: "worker-2" })
+
+// 2. Wait for shutdown approvals
+// Check for {"type": "shutdown_approved", ...} messages
+
+// 3. Verify no active members
+// Read ~/.claude/teams/{team}/config.json
+
+// 4. Only then cleanup
+Teammate({ operation: "cleanup" })
+```
+
+## Handling Crashed Teammates
+
+Teammates have a 5-minute heartbeat timeout. If a teammate crashes:
+
+1. They'll be automatically marked as inactive after timeout
+2. Their tasks remain in the task list
+3. Another teammate can claim their tasks
+4. Cleanup will work after timeout expires
+
+## Debugging
+
+```bash
+# Check team config
+cat ~/.claude/teams/{team}/config.json | jq '.members[] | {name, agentType, backendType}'
+
+# Check teammate inboxes
+cat ~/.claude/teams/{team}/inboxes/{agent}.json | jq '.'
+
+# List all teams
+ls ~/.claude/teams/
+
+# Check task states
+cat ~/.claude/tasks/{team}/*.json | jq '{id, subject, status, owner, blockedBy}'
+
+# Watch for new messages
+tail -f ~/.claude/teams/{team}/inboxes/team-lead.json
+```

--- a/plugins/aimi-engineering/skills/orchestrating-swarms/references/message-protocols.md
+++ b/plugins/aimi-engineering/skills/orchestrating-swarms/references/message-protocols.md
@@ -1,0 +1,276 @@
+# Message Protocols
+
+All inter-agent communication happens via inbox JSON files at `~/.claude/teams/{team}/inboxes/{agent}.json`.
+
+---
+
+## Regular Message
+
+```json
+{
+  "from": "team-lead",
+  "text": "Please prioritize the auth module",
+  "timestamp": "2026-01-25T23:38:32.588Z",
+  "read": false
+}
+```
+
+## Structured Messages (JSON in text field)
+
+### Shutdown Request
+```json
+{
+  "type": "shutdown_request",
+  "requestId": "shutdown-abc123@worker-1",
+  "from": "team-lead",
+  "reason": "All tasks complete",
+  "timestamp": "2026-01-25T23:38:32.588Z"
+}
+```
+
+### Shutdown Approved
+```json
+{
+  "type": "shutdown_approved",
+  "requestId": "shutdown-abc123@worker-1",
+  "from": "worker-1",
+  "paneId": "%5",
+  "backendType": "in-process",
+  "timestamp": "2026-01-25T23:39:00.000Z"
+}
+```
+
+### Idle Notification (auto-sent when teammate stops)
+```json
+{
+  "type": "idle_notification",
+  "from": "worker-1",
+  "timestamp": "2026-01-25T23:40:00.000Z",
+  "completedTaskId": "2",
+  "completedStatus": "completed"
+}
+```
+
+### Task Completed
+```json
+{
+  "type": "task_completed",
+  "from": "worker-1",
+  "taskId": "2",
+  "taskSubject": "Review authentication module",
+  "timestamp": "2026-01-25T23:40:00.000Z"
+}
+```
+
+### Plan Approval Request
+```json
+{
+  "type": "plan_approval_request",
+  "from": "architect",
+  "requestId": "plan-xyz789",
+  "planContent": "# Implementation Plan\n\n1. ...",
+  "timestamp": "2026-01-25T23:41:00.000Z"
+}
+```
+
+### Join Request
+```json
+{
+  "type": "join_request",
+  "proposedName": "helper",
+  "requestId": "join-abc123",
+  "capabilities": "Code review and testing",
+  "timestamp": "2026-01-25T23:42:00.000Z"
+}
+```
+
+### Permission Request (for sandbox/tool permissions)
+```json
+{
+  "type": "permission_request",
+  "requestId": "perm-123",
+  "workerId": "worker-1@my-project",
+  "workerName": "worker-1",
+  "workerColor": "#4A90D9",
+  "toolName": "Bash",
+  "toolUseId": "toolu_abc123",
+  "description": "Run npm install",
+  "input": {"command": "npm install"},
+  "permissionSuggestions": ["Bash(npm *)"],
+  "createdAt": 1706000000000
+}
+```
+
+---
+
+## TeammateTool Operations Reference
+
+### 1. spawnTeam - Create a Team
+
+```javascript
+Teammate({
+  operation: "spawnTeam",
+  team_name: "feature-auth",
+  description: "Implementing OAuth2 authentication"
+})
+```
+
+**Creates:**
+- `~/.claude/teams/feature-auth/config.json`
+- `~/.claude/tasks/feature-auth/` directory
+- You become the team leader
+
+### 2. discoverTeams - List Available Teams
+
+```javascript
+Teammate({ operation: "discoverTeams" })
+```
+
+**Returns:** List of teams you can join (not already a member of)
+
+### 3. requestJoin - Request to Join Team
+
+```javascript
+Teammate({
+  operation: "requestJoin",
+  team_name: "feature-auth",
+  proposed_name: "helper",
+  capabilities: "I can help with code review and testing"
+})
+```
+
+### 4. approveJoin - Accept Join Request (Leader Only)
+
+When you receive a `join_request` message:
+```json
+{"type": "join_request", "proposedName": "helper", "requestId": "join-123", ...}
+```
+
+Approve it:
+```javascript
+Teammate({
+  operation: "approveJoin",
+  target_agent_id: "helper",
+  request_id: "join-123"
+})
+```
+
+### 5. rejectJoin - Decline Join Request (Leader Only)
+
+```javascript
+Teammate({
+  operation: "rejectJoin",
+  target_agent_id: "helper",
+  request_id: "join-123",
+  reason: "Team is at capacity"
+})
+```
+
+### 6. write - Message One Teammate
+
+```javascript
+Teammate({
+  operation: "write",
+  target_agent_id: "security-reviewer",
+  value: "Please prioritize the authentication module. The deadline is tomorrow."
+})
+```
+
+**Important for teammates:** Your text output is NOT visible to the team. You MUST use `write` to communicate.
+
+### 7. broadcast - Message ALL Teammates
+
+```javascript
+Teammate({
+  operation: "broadcast",
+  name: "team-lead",  // Your name
+  value: "Status check: Please report your progress"
+})
+```
+
+**WARNING:** Broadcasting is expensive - sends N separate messages for N teammates. Prefer `write` to specific teammates.
+
+**When to broadcast:**
+- Critical issues requiring immediate attention
+- Major announcements affecting everyone
+
+**When NOT to broadcast:**
+- Responding to one teammate
+- Normal back-and-forth
+- Information relevant to only some teammates
+
+### 8. requestShutdown - Ask Teammate to Exit (Leader Only)
+
+```javascript
+Teammate({
+  operation: "requestShutdown",
+  target_agent_id: "security-reviewer",
+  reason: "All tasks complete, wrapping up"
+})
+```
+
+### 9. approveShutdown - Accept Shutdown (Teammate Only)
+
+When you receive a `shutdown_request` message:
+```json
+{"type": "shutdown_request", "requestId": "shutdown-123", "from": "team-lead", "reason": "Done"}
+```
+
+**MUST** call:
+```javascript
+Teammate({
+  operation: "approveShutdown",
+  request_id: "shutdown-123"
+})
+```
+
+This sends confirmation and terminates your process.
+
+### 10. rejectShutdown - Decline Shutdown (Teammate Only)
+
+```javascript
+Teammate({
+  operation: "rejectShutdown",
+  request_id: "shutdown-123",
+  reason: "Still working on task #3, need 5 more minutes"
+})
+```
+
+### 11. approvePlan - Approve Teammate's Plan (Leader Only)
+
+When teammate with `plan_mode_required` sends a plan:
+```json
+{"type": "plan_approval_request", "from": "architect", "requestId": "plan-456", ...}
+```
+
+Approve:
+```javascript
+Teammate({
+  operation: "approvePlan",
+  target_agent_id: "architect",
+  request_id: "plan-456"
+})
+```
+
+### 12. rejectPlan - Reject Plan with Feedback (Leader Only)
+
+```javascript
+Teammate({
+  operation: "rejectPlan",
+  target_agent_id: "architect",
+  request_id: "plan-456",
+  feedback: "Please add error handling for the API calls and consider rate limiting"
+})
+```
+
+### 13. cleanup - Remove Team Resources
+
+```javascript
+Teammate({ operation: "cleanup" })
+```
+
+**Removes:**
+- `~/.claude/teams/{team-name}/` directory
+- `~/.claude/tasks/{team-name}/` directory
+
+**IMPORTANT:** Will fail if teammates are still active. Use `requestShutdown` first.

--- a/plugins/aimi-engineering/skills/orchestrating-swarms/references/orchestration-patterns.md
+++ b/plugins/aimi-engineering/skills/orchestrating-swarms/references/orchestration-patterns.md
@@ -1,0 +1,520 @@
+# Orchestration Patterns & Complete Workflows
+
+---
+
+## Pattern 1: Parallel Specialists (Leader Pattern)
+
+Multiple specialists review code simultaneously:
+
+```javascript
+// 1. Create team
+Teammate({ operation: "spawnTeam", team_name: "code-review" })
+
+// 2. Spawn specialists in parallel (single message, multiple Task calls)
+Task({
+  team_name: "code-review",
+  name: "security",
+  subagent_type: "aimi-engineering:review:aimi-security-sentinel",
+  prompt: "Review the PR for security vulnerabilities. Focus on: SQL injection, XSS, auth bypass. Send findings to team-lead.",
+  run_in_background: true
+})
+
+Task({
+  team_name: "code-review",
+  name: "performance",
+  subagent_type: "aimi-engineering:review:aimi-performance-oracle",
+  prompt: "Review the PR for performance issues. Focus on: N+1 queries, memory leaks, slow algorithms. Send findings to team-lead.",
+  run_in_background: true
+})
+
+Task({
+  team_name: "code-review",
+  name: "simplicity",
+  subagent_type: "aimi-engineering:review:aimi-code-simplicity-reviewer",
+  prompt: "Review the PR for unnecessary complexity. Focus on: over-engineering, premature abstraction, YAGNI violations. Send findings to team-lead.",
+  run_in_background: true
+})
+
+// 3. Wait for results (check inbox)
+// cat ~/.claude/teams/code-review/inboxes/team-lead.json
+
+// 4. Synthesize findings and cleanup
+Teammate({ operation: "requestShutdown", target_agent_id: "security" })
+Teammate({ operation: "requestShutdown", target_agent_id: "performance" })
+Teammate({ operation: "requestShutdown", target_agent_id: "simplicity" })
+// Wait for approvals...
+Teammate({ operation: "cleanup" })
+```
+
+## Pattern 2: Pipeline (Sequential Dependencies)
+
+Each stage depends on the previous:
+
+```javascript
+// 1. Create team and task pipeline
+Teammate({ operation: "spawnTeam", team_name: "feature-pipeline" })
+
+TaskCreate({ subject: "Research", description: "Research best practices for the feature", activeForm: "Researching..." })
+TaskCreate({ subject: "Plan", description: "Create implementation plan based on research", activeForm: "Planning..." })
+TaskCreate({ subject: "Implement", description: "Implement the feature according to plan", activeForm: "Implementing..." })
+TaskCreate({ subject: "Test", description: "Write and run tests for the implementation", activeForm: "Testing..." })
+TaskCreate({ subject: "Review", description: "Final code review before merge", activeForm: "Reviewing..." })
+
+// Set up sequential dependencies
+TaskUpdate({ taskId: "2", addBlockedBy: ["1"] })
+TaskUpdate({ taskId: "3", addBlockedBy: ["2"] })
+TaskUpdate({ taskId: "4", addBlockedBy: ["3"] })
+TaskUpdate({ taskId: "5", addBlockedBy: ["4"] })
+
+// 2. Spawn workers that claim and complete tasks
+Task({
+  team_name: "feature-pipeline",
+  name: "researcher",
+  subagent_type: "aimi-engineering:research:aimi-best-practices-researcher",
+  prompt: "Claim task #1, research best practices, complete it, send findings to team-lead. Then check for more work.",
+  run_in_background: true
+})
+
+Task({
+  team_name: "feature-pipeline",
+  name: "implementer",
+  subagent_type: "general-purpose",
+  prompt: "Poll TaskList every 30 seconds. When task #3 unblocks, claim it and implement. Then complete and notify team-lead.",
+  run_in_background: true
+})
+
+// Tasks auto-unblock as dependencies complete
+```
+
+## Pattern 3: Swarm (Self-Organizing)
+
+Workers grab available tasks from a pool:
+
+```javascript
+// 1. Create team and task pool
+Teammate({ operation: "spawnTeam", team_name: "file-review-swarm" })
+
+// Create many independent tasks (no dependencies)
+for (const file of ["auth.rb", "user.rb", "api_controller.rb", "payment.rb"]) {
+  TaskCreate({
+    subject: `Review ${file}`,
+    description: `Review ${file} for security and code quality issues`,
+    activeForm: `Reviewing ${file}...`
+  })
+}
+
+// 2. Spawn worker swarm
+Task({
+  team_name: "file-review-swarm",
+  name: "worker-1",
+  subagent_type: "general-purpose",
+  prompt: `
+    You are a swarm worker. Your job:
+    1. Call TaskList to see available tasks
+    2. Find a task with status 'pending' and no owner
+    3. Claim it with TaskUpdate (set owner to your name)
+    4. Do the work
+    5. Mark it completed with TaskUpdate
+    6. Send findings to team-lead via Teammate write
+    7. Repeat until no tasks remain
+  `,
+  run_in_background: true
+})
+
+Task({
+  team_name: "file-review-swarm",
+  name: "worker-2",
+  subagent_type: "general-purpose",
+  prompt: `[Same prompt as worker-1]`,
+  run_in_background: true
+})
+
+Task({
+  team_name: "file-review-swarm",
+  name: "worker-3",
+  subagent_type: "general-purpose",
+  prompt: `[Same prompt as worker-1]`,
+  run_in_background: true
+})
+
+// Workers race to claim tasks, naturally load-balance
+```
+
+## Pattern 4: Research + Implementation
+
+Research first, then implement:
+
+```javascript
+// 1. Research phase (synchronous, returns results)
+const research = await Task({
+  subagent_type: "aimi-engineering:research:aimi-best-practices-researcher",
+  description: "Research caching patterns",
+  prompt: "Research best practices for implementing caching in Rails APIs. Include: cache invalidation strategies, Redis vs Memcached, cache key design."
+})
+
+// 2. Use research to guide implementation
+Task({
+  subagent_type: "general-purpose",
+  description: "Implement caching",
+  prompt: `
+    Implement API caching based on this research:
+
+    ${research.content}
+
+    Focus on the user_controller.rb endpoints.
+  `
+})
+```
+
+## Pattern 5: Plan Approval Workflow
+
+Require plan approval before implementation:
+
+```javascript
+// 1. Create team
+Teammate({ operation: "spawnTeam", team_name: "careful-work" })
+
+// 2. Spawn architect with plan_mode_required
+Task({
+  team_name: "careful-work",
+  name: "architect",
+  subagent_type: "Plan",
+  prompt: "Design an implementation plan for adding OAuth2 authentication",
+  mode: "plan",  // Requires plan approval
+  run_in_background: true
+})
+
+// 3. Wait for plan approval request
+// You'll receive: {"type": "plan_approval_request", "from": "architect", "requestId": "plan-xxx", ...}
+
+// 4. Review and approve/reject
+Teammate({
+  operation: "approvePlan",
+  target_agent_id: "architect",
+  request_id: "plan-xxx"
+})
+// OR
+Teammate({
+  operation: "rejectPlan",
+  target_agent_id: "architect",
+  request_id: "plan-xxx",
+  feedback: "Please add rate limiting considerations"
+})
+```
+
+## Pattern 6: Coordinated Multi-File Refactoring
+
+```javascript
+// 1. Create team for coordinated refactoring
+Teammate({ operation: "spawnTeam", team_name: "refactor-auth" })
+
+// 2. Create tasks with clear file boundaries
+TaskCreate({
+  subject: "Refactor User model",
+  description: "Extract authentication methods to AuthenticatableUser concern",
+  activeForm: "Refactoring User model..."
+})
+
+TaskCreate({
+  subject: "Refactor Session controller",
+  description: "Update to use new AuthenticatableUser concern",
+  activeForm: "Refactoring Sessions..."
+})
+
+TaskCreate({
+  subject: "Update specs",
+  description: "Update all authentication specs for new structure",
+  activeForm: "Updating specs..."
+})
+
+// Dependencies: specs depend on both refactors completing
+TaskUpdate({ taskId: "3", addBlockedBy: ["1", "2"] })
+
+// 3. Spawn workers for each task
+Task({
+  team_name: "refactor-auth",
+  name: "model-worker",
+  subagent_type: "general-purpose",
+  prompt: "Claim task #1, refactor the User model, complete when done",
+  run_in_background: true
+})
+
+Task({
+  team_name: "refactor-auth",
+  name: "controller-worker",
+  subagent_type: "general-purpose",
+  prompt: "Claim task #2, refactor the Session controller, complete when done",
+  run_in_background: true
+})
+
+Task({
+  team_name: "refactor-auth",
+  name: "spec-worker",
+  subagent_type: "general-purpose",
+  prompt: "Wait for task #3 to unblock (when #1 and #2 complete), then update specs",
+  run_in_background: true
+})
+```
+
+---
+
+## Complete Workflows
+
+### Workflow 1: Full Code Review with Parallel Specialists
+
+```javascript
+// === STEP 1: Setup ===
+Teammate({ operation: "spawnTeam", team_name: "pr-review-123", description: "Reviewing PR #123" })
+
+// === STEP 2: Spawn reviewers in parallel ===
+// (Send all these in a single message for parallel execution)
+Task({
+  team_name: "pr-review-123",
+  name: "security",
+  subagent_type: "aimi-engineering:review:aimi-security-sentinel",
+  prompt: `Review PR #123 for security vulnerabilities.
+
+  Focus on:
+  - SQL injection
+  - XSS vulnerabilities
+  - Authentication/authorization bypass
+  - Sensitive data exposure
+
+  When done, send your findings to team-lead using:
+  Teammate({ operation: "write", target_agent_id: "team-lead", value: "Your findings here" })`,
+  run_in_background: true
+})
+
+Task({
+  team_name: "pr-review-123",
+  name: "perf",
+  subagent_type: "aimi-engineering:review:aimi-performance-oracle",
+  prompt: `Review PR #123 for performance issues.
+
+  Focus on:
+  - N+1 queries
+  - Missing indexes
+  - Memory leaks
+  - Inefficient algorithms
+
+  Send findings to team-lead when done.`,
+  run_in_background: true
+})
+
+Task({
+  team_name: "pr-review-123",
+  name: "arch",
+  subagent_type: "aimi-engineering:review:aimi-architecture-strategist",
+  prompt: `Review PR #123 for architectural concerns.
+
+  Focus on:
+  - Design pattern adherence
+  - SOLID principles
+  - Separation of concerns
+  - Testability
+
+  Send findings to team-lead when done.`,
+  run_in_background: true
+})
+
+// === STEP 3: Monitor and collect results ===
+// Poll inbox or wait for idle notifications
+// cat ~/.claude/teams/pr-review-123/inboxes/team-lead.json
+
+// === STEP 4: Synthesize findings ===
+// Combine all reviewer findings into a cohesive report
+
+// === STEP 5: Cleanup ===
+Teammate({ operation: "requestShutdown", target_agent_id: "security" })
+Teammate({ operation: "requestShutdown", target_agent_id: "perf" })
+Teammate({ operation: "requestShutdown", target_agent_id: "arch" })
+// Wait for approvals...
+Teammate({ operation: "cleanup" })
+```
+
+### Workflow 2: Research -> Plan -> Implement -> Test Pipeline
+
+```javascript
+// === SETUP ===
+Teammate({ operation: "spawnTeam", team_name: "feature-oauth" })
+
+// === CREATE PIPELINE ===
+TaskCreate({ subject: "Research OAuth providers", description: "Research OAuth2 best practices and compare providers (Google, GitHub, Auth0)", activeForm: "Researching OAuth..." })
+TaskCreate({ subject: "Create implementation plan", description: "Design OAuth implementation based on research findings", activeForm: "Planning..." })
+TaskCreate({ subject: "Implement OAuth", description: "Implement OAuth2 authentication according to plan", activeForm: "Implementing OAuth..." })
+TaskCreate({ subject: "Write tests", description: "Write comprehensive tests for OAuth implementation", activeForm: "Writing tests..." })
+TaskCreate({ subject: "Final review", description: "Review complete implementation for security and quality", activeForm: "Final review..." })
+
+// Set dependencies
+TaskUpdate({ taskId: "2", addBlockedBy: ["1"] })
+TaskUpdate({ taskId: "3", addBlockedBy: ["2"] })
+TaskUpdate({ taskId: "4", addBlockedBy: ["3"] })
+TaskUpdate({ taskId: "5", addBlockedBy: ["4"] })
+
+// === SPAWN SPECIALIZED WORKERS ===
+Task({
+  team_name: "feature-oauth",
+  name: "researcher",
+  subagent_type: "aimi-engineering:research:aimi-best-practices-researcher",
+  prompt: "Claim task #1. Research OAuth2 best practices, compare providers, document findings. Mark task complete and send summary to team-lead.",
+  run_in_background: true
+})
+
+Task({
+  team_name: "feature-oauth",
+  name: "planner",
+  subagent_type: "Plan",
+  prompt: "Wait for task #2 to unblock. Read research from task #1. Create detailed implementation plan. Mark complete and send plan to team-lead.",
+  run_in_background: true
+})
+
+Task({
+  team_name: "feature-oauth",
+  name: "implementer",
+  subagent_type: "general-purpose",
+  prompt: "Wait for task #3 to unblock. Read plan from task #2. Implement OAuth2 authentication. Mark complete when done.",
+  run_in_background: true
+})
+
+Task({
+  team_name: "feature-oauth",
+  name: "tester",
+  subagent_type: "general-purpose",
+  prompt: "Wait for task #4 to unblock. Write comprehensive tests for the OAuth implementation. Run tests. Mark complete with results.",
+  run_in_background: true
+})
+
+Task({
+  team_name: "feature-oauth",
+  name: "reviewer",
+  subagent_type: "aimi-engineering:review:aimi-security-sentinel",
+  prompt: "Wait for task #5 to unblock. Review the complete OAuth implementation for security. Send final assessment to team-lead.",
+  run_in_background: true
+})
+
+// Pipeline auto-progresses as each stage completes
+```
+
+### Workflow 3: Self-Organizing Code Review Swarm
+
+```javascript
+// === SETUP ===
+Teammate({ operation: "spawnTeam", team_name: "codebase-review" })
+
+// === CREATE TASK POOL (all independent, no dependencies) ===
+const filesToReview = [
+  "app/models/user.rb",
+  "app/models/payment.rb",
+  "app/controllers/api/v1/users_controller.rb",
+  "app/controllers/api/v1/payments_controller.rb",
+  "app/services/payment_processor.rb",
+  "app/services/notification_service.rb",
+  "lib/encryption_helper.rb"
+]
+
+for (const file of filesToReview) {
+  TaskCreate({
+    subject: `Review ${file}`,
+    description: `Review ${file} for security vulnerabilities, code quality, and performance issues`,
+    activeForm: `Reviewing ${file}...`
+  })
+}
+
+// === SPAWN WORKER SWARM ===
+const swarmPrompt = `
+You are a swarm worker. Your job is to continuously process available tasks.
+
+LOOP:
+1. Call TaskList() to see available tasks
+2. Find a task that is:
+   - status: 'pending'
+   - no owner
+   - not blocked
+3. If found:
+   - Claim it: TaskUpdate({ taskId: "X", owner: "YOUR_NAME" })
+   - Start it: TaskUpdate({ taskId: "X", status: "in_progress" })
+   - Do the review work
+   - Complete it: TaskUpdate({ taskId: "X", status: "completed" })
+   - Send findings to team-lead via Teammate write
+   - Go back to step 1
+4. If no tasks available:
+   - Send idle notification to team-lead
+   - Wait 30 seconds
+   - Try again (up to 3 times)
+   - If still no tasks, exit
+
+Replace YOUR_NAME with your actual agent name from $CLAUDE_CODE_AGENT_NAME.
+`
+
+// Spawn 3 workers
+Task({ team_name: "codebase-review", name: "worker-1", subagent_type: "general-purpose", prompt: swarmPrompt, run_in_background: true })
+Task({ team_name: "codebase-review", name: "worker-2", subagent_type: "general-purpose", prompt: swarmPrompt, run_in_background: true })
+Task({ team_name: "codebase-review", name: "worker-3", subagent_type: "general-purpose", prompt: swarmPrompt, run_in_background: true })
+
+// Workers self-organize: race to claim tasks, naturally load-balance
+// Monitor progress with TaskList() or by reading inbox
+```
+
+---
+
+## Best Practices
+
+### 1. Always Cleanup
+Don't leave orphaned teams. Always call `cleanup` when done.
+
+### 2. Use Meaningful Names
+```javascript
+// Good
+name: "security-reviewer"
+name: "oauth-implementer"
+name: "test-writer"
+
+// Bad
+name: "worker-1"
+name: "agent-2"
+```
+
+### 3. Write Clear Prompts
+Tell workers exactly what to do:
+```javascript
+// Good
+prompt: `
+  1. Review app/models/user.rb for N+1 queries
+  2. Check all ActiveRecord associations have proper includes
+  3. Document any issues found
+  4. Send findings to team-lead via Teammate write
+`
+
+// Bad
+prompt: "Review the code"
+```
+
+### 4. Use Task Dependencies
+Let the system manage unblocking:
+```javascript
+// Good: Auto-unblocking
+TaskUpdate({ taskId: "2", addBlockedBy: ["1"] })
+
+// Bad: Manual polling
+"Wait until task #1 is done, check every 30 seconds..."
+```
+
+### 5. Check Inboxes for Results
+Workers send results to your inbox. Check it:
+```bash
+cat ~/.claude/teams/{team}/inboxes/team-lead.json | jq '.'
+```
+
+### 6. Handle Worker Failures
+- Workers have 5-minute heartbeat timeout
+- Tasks of crashed workers can be reclaimed
+- Build retry logic into worker prompts
+
+### 7. Prefer write Over broadcast
+`broadcast` sends N messages for N teammates. Use `write` for targeted communication.
+
+### 8. Match Agent Type to Task
+- **Explore** for searching/reading
+- **Plan** for architecture design
+- **general-purpose** for implementation
+- **Specialized reviewers** for specific review types

--- a/plugins/aimi-engineering/skills/orchestrating-swarms/references/task-coordination.md
+++ b/plugins/aimi-engineering/skills/orchestrating-swarms/references/task-coordination.md
@@ -1,0 +1,91 @@
+# Task Coordination
+
+The task system provides shared work queues with status tracking and automatic dependency resolution.
+
+---
+
+## TaskCreate - Create Work Items
+
+```javascript
+TaskCreate({
+  subject: "Review authentication module",
+  description: "Review all files in app/services/auth/ for security vulnerabilities",
+  activeForm: "Reviewing auth module..."  // Shown in spinner when in_progress
+})
+```
+
+## TaskList - See All Tasks
+
+```javascript
+TaskList()
+```
+
+Returns:
+```
+#1 [completed] Analyze codebase structure
+#2 [in_progress] Review authentication module (owner: security-reviewer)
+#3 [pending] Generate summary report [blocked by #2]
+```
+
+## TaskGet - Get Task Details
+
+```javascript
+TaskGet({ taskId: "2" })
+```
+
+Returns full task with description, status, blockedBy, etc.
+
+## TaskUpdate - Update Task Status
+
+```javascript
+// Claim a task
+TaskUpdate({ taskId: "2", owner: "security-reviewer" })
+
+// Start working
+TaskUpdate({ taskId: "2", status: "in_progress" })
+
+// Mark complete
+TaskUpdate({ taskId: "2", status: "completed" })
+
+// Set up dependencies
+TaskUpdate({ taskId: "3", addBlockedBy: ["1", "2"] })
+```
+
+## Task Dependencies
+
+When a blocking task is completed, blocked tasks are automatically unblocked:
+
+```javascript
+// Create pipeline
+TaskCreate({ subject: "Step 1: Research" })        // #1
+TaskCreate({ subject: "Step 2: Implement" })       // #2
+TaskCreate({ subject: "Step 3: Test" })            // #3
+TaskCreate({ subject: "Step 4: Deploy" })          // #4
+
+// Set up dependencies
+TaskUpdate({ taskId: "2", addBlockedBy: ["1"] })   // #2 waits for #1
+TaskUpdate({ taskId: "3", addBlockedBy: ["2"] })   // #3 waits for #2
+TaskUpdate({ taskId: "4", addBlockedBy: ["3"] })   // #4 waits for #3
+
+// When #1 completes, #2 auto-unblocks
+// When #2 completes, #3 auto-unblocks
+// etc.
+```
+
+## Task File Structure
+
+`~/.claude/tasks/{team-name}/1.json`:
+```json
+{
+  "id": "1",
+  "subject": "Review authentication module",
+  "description": "Review all files in app/services/auth/...",
+  "status": "in_progress",
+  "owner": "security-reviewer",
+  "activeForm": "Reviewing auth module...",
+  "blockedBy": [],
+  "blocks": ["3"],
+  "createdAt": 1706000000000,
+  "updatedAt": 1706000001000
+}
+```

--- a/plugins/aimi-engineering/skills/orchestrating-swarms/references/team-lifecycle.md
+++ b/plugins/aimi-engineering/skills/orchestrating-swarms/references/team-lifecycle.md
@@ -1,0 +1,364 @@
+# Team Lifecycle & Infrastructure
+
+## How Primitives Connect
+
+Leader communicates with teammates via inbox messages. Teammates can also message each other directly. All agents share a task list where tasks have statuses (pending, in_progress, completed) and dependency chains that auto-unblock.
+
+## Lifecycle Steps
+
+1. Create Team (spawnTeam) -- 2. Create Tasks (TaskCreate) -- 3. Spawn Teammates (Task + team_name + name) -- 4. Work (claim + execute tasks) -- 5. Coordinate (messages via inboxes) -- 6. Shutdown (requestShutdown for each teammate) -- 7. Cleanup (remove team resources)
+
+## Message Flow Summary
+
+Leader creates tasks and spawns teammates. Teammates claim tasks, complete them, and send findings to leader via inbox. When all work is done, leader requests shutdown from each teammate, waits for approvals, then calls cleanup.
+
+---
+
+## File Structure
+
+```
+~/.claude/teams/{team-name}/
+├── config.json              # Team metadata and member list
+└── inboxes/
+    ├── team-lead.json       # Leader's inbox
+    ├── worker-1.json        # Worker 1's inbox
+    └── worker-2.json        # Worker 2's inbox
+
+~/.claude/tasks/{team-name}/
+├── 1.json                   # Task #1
+├── 2.json                   # Task #2
+└── 3.json                   # Task #3
+```
+
+## Team Config Structure
+
+```json
+{
+  "name": "my-project",
+  "description": "Working on feature X",
+  "leadAgentId": "team-lead@my-project",
+  "createdAt": 1706000000000,
+  "members": [
+    {
+      "agentId": "team-lead@my-project",
+      "name": "team-lead",
+      "agentType": "team-lead",
+      "color": "#4A90D9",
+      "joinedAt": 1706000000000,
+      "backendType": "in-process"
+    },
+    {
+      "agentId": "worker-1@my-project",
+      "name": "worker-1",
+      "agentType": "Explore",
+      "model": "haiku",
+      "prompt": "Analyze the codebase structure...",
+      "color": "#D94A4A",
+      "planModeRequired": false,
+      "joinedAt": 1706000001000,
+      "tmuxPaneId": "in-process",
+      "cwd": "/Users/me/project",
+      "backendType": "in-process"
+    }
+  ]
+}
+```
+
+---
+
+## Environment Variables
+
+Spawned teammates automatically receive these:
+
+```bash
+CLAUDE_CODE_TEAM_NAME="my-project"
+CLAUDE_CODE_AGENT_ID="worker-1@my-project"
+CLAUDE_CODE_AGENT_NAME="worker-1"
+CLAUDE_CODE_AGENT_TYPE="Explore"
+CLAUDE_CODE_AGENT_COLOR="#4A90D9"
+CLAUDE_CODE_PLAN_MODE_REQUIRED="false"
+CLAUDE_CODE_PARENT_SESSION_ID="session-xyz"
+```
+
+**Using in prompts:**
+```javascript
+Task({
+  team_name: "my-project",
+  name: "worker",
+  subagent_type: "general-purpose",
+  prompt: "Your name is $CLAUDE_CODE_AGENT_NAME. Use it when sending messages to team-lead."
+})
+```
+
+---
+
+## Spawn Backends
+
+A **backend** determines how teammate Claude instances actually run. Claude Code supports three backends, and **auto-detects** the best one based on your environment.
+
+### Backend Comparison
+
+| Backend | How It Works | Visibility | Persistence | Speed |
+|---------|-------------|------------|-------------|-------|
+| **in-process** | Same Node.js process as leader | Hidden (background) | Dies with leader | Fastest |
+| **tmux** | Separate terminal in tmux session | Visible in tmux | Survives leader exit | Medium |
+| **iterm2** | Split panes in iTerm2 window | Visible side-by-side | Dies with window | Medium |
+
+### Auto-Detection Logic
+
+Decision tree: Running inside tmux? -> Use tmux backend. Running in iTerm2 with it2 CLI? -> Use iterm2 backend. tmux available? -> Use tmux (external session). Otherwise -> Use in-process.
+
+**Detection checks:**
+1. `$TMUX` environment variable -> inside tmux
+2. `$TERM_PROGRAM === "iTerm.app"` or `$ITERM_SESSION_ID` -> in iTerm2
+3. `which tmux` -> tmux available
+4. `which it2` -> it2 CLI installed
+
+### in-process (Default for non-tmux)
+
+Teammates run as async tasks within the same Node.js process.
+
+**How it works:**
+- No new process spawned
+- Teammates share the same Node.js event loop
+- Communication via in-memory queues (fast)
+- You don't see teammate output directly
+
+**When it's used:**
+- Not running inside tmux session
+- Non-interactive mode (CI, scripts)
+- Explicitly set via `CLAUDE_CODE_SPAWN_BACKEND=in-process`
+
+**Characteristics:**
+```
++-----------------------------------------+
+|           Node.js Process               |
+|  +---------+  +---------+  +---------+  |
+|  | Leader  |  |Worker 1 |  |Worker 2 |  |
+|  | (main)  |  | (async) |  | (async) |  |
+|  +---------+  +---------+  +---------+  |
++-----------------------------------------+
+```
+
+**Pros:**
+- Fastest startup (no process spawn)
+- Lowest overhead
+- Works everywhere
+
+**Cons:**
+- Can't see teammate output in real-time
+- All die if leader dies
+- Harder to debug
+
+```javascript
+// in-process is automatic when not in tmux
+Task({
+  team_name: "my-project",
+  name: "worker",
+  subagent_type: "general-purpose",
+  prompt: "...",
+  run_in_background: true
+})
+
+// Force in-process explicitly
+// export CLAUDE_CODE_SPAWN_BACKEND=in-process
+```
+
+### tmux
+
+Teammates run as separate Claude instances in tmux panes/windows.
+
+**How it works:**
+- Each teammate gets its own tmux pane
+- Separate process per teammate
+- You can switch panes to see teammate output
+- Communication via inbox files
+
+**When it's used:**
+- Running inside a tmux session (`$TMUX` is set)
+- tmux available and not in iTerm2
+- Explicitly set via `CLAUDE_CODE_SPAWN_BACKEND=tmux`
+
+**Layout modes:**
+
+1. **Inside tmux (native):** Splits your current window
+```
++-----------------+-----------------+
+|                 |    Worker 1     |
+|     Leader      +-----------------+
+|   (your pane)   |    Worker 2     |
+|                 +-----------------+
+|                 |    Worker 3     |
++-----------------+-----------------+
+```
+
+2. **Outside tmux (external session):** Creates a new tmux session called `claude-swarm`
+```bash
+# Your terminal stays as-is
+# Workers run in separate tmux session
+
+# View workers:
+tmux attach -t claude-swarm
+```
+
+**Pros:**
+- See teammate output in real-time
+- Teammates survive leader exit
+- Can attach/detach sessions
+- Works in CI/headless environments
+
+**Cons:**
+- Slower startup (process spawn)
+- Requires tmux installed
+- More resource usage
+
+```bash
+# Start tmux session first
+tmux new-session -s claude
+
+# Or force tmux backend
+export CLAUDE_CODE_SPAWN_BACKEND=tmux
+```
+
+**Useful tmux commands:**
+```bash
+# List all panes in current window
+tmux list-panes
+
+# Switch to pane by number
+tmux select-pane -t 1
+
+# Kill a specific pane
+tmux kill-pane -t %5
+
+# View swarm session (if external)
+tmux attach -t claude-swarm
+
+# Rebalance pane layout
+tmux select-layout tiled
+```
+
+### iterm2 (macOS only)
+
+Teammates run as split panes within your iTerm2 window.
+
+**How it works:**
+- Uses iTerm2's Python API via `it2` CLI
+- Splits your current window into panes
+- Each teammate visible side-by-side
+- Communication via inbox files
+
+**When it's used:**
+- Running in iTerm2 (`$TERM_PROGRAM === "iTerm.app"`)
+- `it2` CLI is installed and working
+- Python API enabled in iTerm2 preferences
+
+**Layout:**
+```
++-----------------+-----------------+
+|                 |    Worker 1     |
+|     Leader      +-----------------+
+|   (your pane)   |    Worker 2     |
+|                 +-----------------+
+|                 |    Worker 3     |
++-----------------+-----------------+
+```
+
+**Pros:**
+- Visual debugging - see all teammates
+- Native macOS experience
+- No tmux needed
+- Automatic pane management
+
+**Cons:**
+- macOS + iTerm2 only
+- Requires setup (it2 CLI + Python API)
+- Panes die with window
+
+**Setup:**
+```bash
+# 1. Install it2 CLI
+uv tool install it2
+# OR
+pipx install it2
+# OR
+pip install --user it2
+
+# 2. Enable Python API in iTerm2
+# iTerm2 -> Settings -> General -> Magic -> Enable Python API
+
+# 3. Restart iTerm2
+
+# 4. Verify
+it2 --version
+it2 session list
+```
+
+**If setup fails:**
+Claude Code will prompt you to set up it2 when you first spawn a teammate. You can choose to:
+1. Install it2 now (guided setup)
+2. Use tmux instead
+3. Cancel
+
+### Forcing a Backend
+
+```bash
+# Force in-process (fastest, no visibility)
+export CLAUDE_CODE_SPAWN_BACKEND=in-process
+
+# Force tmux (visible panes, persistent)
+export CLAUDE_CODE_SPAWN_BACKEND=tmux
+
+# Auto-detect (default)
+unset CLAUDE_CODE_SPAWN_BACKEND
+```
+
+### Backend in Team Config
+
+The backend type is recorded per-teammate in `config.json`:
+
+```json
+{
+  "members": [
+    {
+      "name": "worker-1",
+      "backendType": "in-process",
+      "tmuxPaneId": "in-process"
+    },
+    {
+      "name": "worker-2",
+      "backendType": "tmux",
+      "tmuxPaneId": "%5"
+    }
+  ]
+}
+```
+
+### Troubleshooting Backends
+
+| Issue | Cause | Solution |
+|-------|-------|----------|
+| "No pane backend available" | Neither tmux nor iTerm2 available | Install tmux: `brew install tmux` |
+| "it2 CLI not installed" | In iTerm2 but missing it2 | Run `uv tool install it2` |
+| "Python API not enabled" | it2 can't communicate with iTerm2 | Enable in iTerm2 Settings -> General -> Magic |
+| Workers not visible | Using in-process backend | Start inside tmux or iTerm2 |
+| Workers dying unexpectedly | Outside tmux, leader exited | Use tmux for persistence |
+
+### Checking Current Backend
+
+```bash
+# See what backend was detected
+cat ~/.claude/teams/{team}/config.json | jq '.members[].backendType'
+
+# Check if inside tmux
+echo $TMUX
+
+# Check if in iTerm2
+echo $TERM_PROGRAM
+
+# Check tmux availability
+which tmux
+
+# Check it2 availability
+which it2
+```

--- a/plugins/aimi-engineering/skills/story-executor/SKILL.md
+++ b/plugins/aimi-engineering/skills/story-executor/SKILL.md
@@ -26,22 +26,8 @@ Execute ONE story from the tasks file:
 
 ## Story Format
 
-```json
-{
-  "id": "US-001",
-  "title": "Add status field to tasks table",
-  "description": "As a developer, I need to store task status in the database.",
-  "acceptanceCriteria": [
-    "Add status column: 'pending' | 'in_progress' | 'done' (default 'pending')",
-    "Generate and run migration successfully",
-    "Typecheck passes"
-  ],
-  "priority": 1,
-  "status": "pending",
-  "dependsOn": [],
-  "notes": ""
-}
-```
+> **Schema:** See `task-format-v3.md` in `../task-planner/references/`. Each story is one atomic unit of work completable in a single agent iteration.
+> Key fields: `id`, `title`, `description`, `acceptanceCriteria`, `priority`, `status`, `dependsOn`, `notes`
 
 ---
 

--- a/plugins/aimi-engineering/skills/task-planner/SKILL.md
+++ b/plugins/aimi-engineering/skills/task-planner/SKILL.md
@@ -20,50 +20,10 @@ Take a feature description through research, spec analysis, and story decomposit
 
 **Filename:** `.aimi/tasks/YYYY-MM-DD-[feature-name]-tasks.json`
 
-**Schema:** v3 — see `references/task-format-v3.md` for the full specification.
+> **Schema:** See `references/task-format-v3.md` for the full v3 specification with status state machine, dependency system, and validation rules.
+> Key fields: `schemaVersion`, `metadata{title,type,branchName,createdAt,planPath,maxConcurrency}`, `userStories[]{id,title,description,acceptanceCriteria,priority,status,dependsOn,notes}`
 
-```json
-{
-  "schemaVersion": "3.0",
-  "metadata": {
-    "title": "feat: Feature name",
-    "type": "feat",
-    "branchName": "feat/feature-name",
-    "createdAt": "YYYY-MM-DD",
-    "planPath": null,
-    "brainstormPath": ".aimi/brainstorms/... (optional)",
-    "maxConcurrency": 4
-  },
-  "userStories": [
-    {
-      "id": "US-001",
-      "title": "Add schema migration",
-      "description": "As a [user], I want [feature] so that [benefit]",
-      "acceptanceCriteria": ["Criterion 1", "Typecheck passes"],
-      "priority": 1,
-      "status": "pending",
-      "dependsOn": [],
-      "notes": ""
-    },
-    {
-      "id": "US-002",
-      "title": "Add server action",
-      "description": "As a [user], I want [feature] so that [benefit]",
-      "acceptanceCriteria": ["Criterion 1", "Typecheck passes"],
-      "priority": 2,
-      "status": "pending",
-      "dependsOn": ["US-001"],
-      "notes": ""
-    }
-  ]
-}
-```
-
-**Key fields:**
-- `planPath` is always `null` — this skill generates tasks.json directly, no intermediate plan.
-- `status` tracks story lifecycle. All stories initialize as `"pending"`.
-- `dependsOn` is a string array of story IDs that must complete before this story can start.
-- `maxConcurrency` (optional) controls how many stories execute in parallel (default: `4`).
+**Notes:** `planPath` is always `null` (this skill generates tasks.json directly). All stories initialize with `status: "pending"`. `dependsOn` is a string array of story IDs. `maxConcurrency` defaults to `4`.
 
 ### Type Values
 


### PR DESCRIPTION
Summary

  - Trim agent examples: Reduce all agent .md files from multiple examples down to 1 example
  each, cutting token overhead across 28 agent files (research, docs, review, design, workflow
  categories)
  - Split large skills into core + references: Break orchestrating-swarms (1666 line reduction),
  dspy-ruby, and agent-native-architecture SKILLs into lean core files with on-demand references/
   subdirectories
  - Extract shared command boilerplate: Deduplicate CLI path resolution logic from 4 commands
  (execute, status, next, swarm) into a single commands/references/cli-path-resolution.md
  - Consolidate schema references: Point all task format references to canonical
  task-format-v3.md

  Impact

  - 50 files changed — net reduction of ~514 lines (-2908 / +2394)
  - Agents, skills, and commands all load fewer tokens per invocation
  - No behavioral changes — all functionality preserved, just reorganized for efficiency

  Test plan

  - Verify all agent definitions still load correctly in Claude Code
  - Confirm skills (orchestrating-swarms, dspy-ruby, agent-native-architecture) resolve
  references at runtime
  - Run /aimi:execute, /aimi:status, /aimi:plan to validate CLI path resolution from shared
  reference
  - Check plugin.json and marketplace.json version bumps are consistent