### PR TITLE
Add two-phase story loading and reduce CLI token consumption

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and worktree+team orchestration.",
-      "version": "1.26.2",
+      "version": "1.26.3",
       "author": {
         "name": "Stanley Takamatsu",
         "url": "https://github.com/aimi-so"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and worktree+team orchestration.",
-      "version": "1.26.0",
+      "version": "1.26.2",
       "author": {
         "name": "Stanley Takamatsu",
         "url": "https://github.com/aimi-so"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and worktree+team orchestration.",
-      "version": "1.25.0",
+      "version": "1.26.0",
       "author": {
         "name": "Stanley Takamatsu",
         "url": "https://github.com/aimi-so"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and worktree+team orchestration.",
-      "version": "1.26.3",
+      "version": "1.27.0",
       "author": {
         "name": "Stanley Takamatsu",
         "url": "https://github.com/aimi-so"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **aimi-cli.sh**: `--brief` flag on `list-ready` command — outputs a summary line (count + story IDs) instead of full JSON story objects, reducing output for wave orchestration
 - **aimi-cli.sh**: `--counts-only` flag on `status` command — returns aggregate counts (`pending`, `in_progress`, `completed`, `failed`, `skipped`, `total`) without the `userStories` array, enabling lightweight progress checks in wave loops
 - **aimi-cli.sh**: `status` dispatch updated to `shift; cmd_status "$@"` pattern for flag forwarding
+
+### Changed
+
+- **aimi-cli.sh**: `mark-in-progress`, `mark-completed`, `mark-failed`, `mark-skipped` commands now return minimal `{id, status}` JSON confirmation instead of the full story object, reducing output noise in agent loops
 
 ## [1.25.0] - 2026-03-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.26.3] - 2026-03-02
+
+### Changed
+
+- **execute.md**: Two-phase story loading — wave selection uses `list-ready --brief` (returns `{id, title, priority, dependsOn}` stubs), full story data fetched via `get-story <id>` per story after `mark-in-progress` (claim-then-fetch pattern)
+- **execute.md**: Single-story wave path now follows: `list-ready --brief` -> `mark-in-progress` -> `get-story` -> build prompt -> Task
+- **execute.md**: Multi-story wave path now follows: `list-ready --brief` -> select -> `mark-in-progress` all -> `get-story` each -> create worktrees -> spawn Tasks
+- **execute.md**: Error handling for `get-story` failures: marks story failed, cascade-skips dependents, continues with remaining stories in wave
+- **execute.md**: Multi-story wave gracefully degrades — if fetch failures reduce to 1 story, falls back to single-story path (no worktree overhead)
+
 ## [1.26.2] - 2026-03-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.26.1] - 2026-03-02
+
+### Changed
+
+- **Acceptance criterion limit increased from 300 to 600 chars** across CLI validation, schema docs, skill references, and command checklists (aimi-cli.sh, task-format-v3.md, story-decomposition.md, SKILL.md, plan.md, CLAUDE.md, README.md)
+
 ## [1.26.0] - 2026-03-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.26.3] - 2026-03-02
+## [1.27.0] - 2026-03-02
+
+### Added
+
+- **aimi-cli.sh**: `get-story <id>` command for on-demand story fetching — returns full story JSON for a single story by ID, enabling lazy loading instead of bulk extraction
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.26.0] - 2026-03-02
+
+### Added
+
+- **aimi-cli.sh**: `--counts-only` flag on `status` command — returns aggregate counts (`pending`, `in_progress`, `completed`, `failed`, `skipped`, `total`) without the `userStories` array, enabling lightweight progress checks in wave loops
+- **aimi-cli.sh**: `status` dispatch updated to `shift; cmd_status "$@"` pattern for flag forwarding
+
 ## [1.25.0] - 2026-03-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **next.md**: Added `subagent_type` guard comments to both Task spawn locations (line 86 and retry at line 122), matching the pattern already applied in execute.md — prevents agents from substituting `story-executor` as an agent type
+- **execute.md**: Added `subagent_type` guard (`IMPORTANT: Do NOT change subagent_type`) to Task spawn ensuring agents never substitute `story-executor` as an agent type
+- **next.md**: Added `subagent_type` guard comments to both Task spawn locations (line 86 and retry at line 122), matching the pattern in execute.md — prevents agents from substituting `story-executor` as an agent type
+
+### Added
+
+- **story-executor SKILL.md**: Added Tools section documenting available capabilities (Read, Edit, Write, Bash, Glob, Grep, WebSearch, WebFetch, Task) for agents spawned within story execution
 
 ## [1.26.1] - 2026-03-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.26.2] - 2026-03-02
+
+### Fixed
+
+- **next.md**: Added `subagent_type` guard comments to both Task spawn locations (line 86 and retry at line 122), matching the pattern already applied in execute.md — prevents agents from substituting `story-executor` as an agent type
+
 ## [1.26.1] - 2026-03-02
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ Invalid characters (spaces, semicolons, quotes) trigger validation errors.
 |-------|------------|
 | `title` | 200 chars |
 | `description` | 500 chars |
-| Each acceptance criterion | 300 chars |
+| Each acceptance criterion | 600 chars |
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -536,9 +536,13 @@ Invalid characters (spaces, semicolons, quotes) trigger validation errors.
 
 ## Version History
 
-**Current Version:** 1.24.1
+**Current Version:** 1.27.0
 
 ### Recent Changes
+
+**v1.27.0** - Lazy Story Loading
+- Added `get-story <id>` CLI command for on-demand story fetching
+- Updated execute.md to use two-phase loading (`list-ready --brief` + `get-story`) for reduced orchestrator context consumption
 
 **v1.24.1** - Auto-approve patterns for swarm Docker commands
 

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi"

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.25.0",
+  "version": "1.26.0",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi"

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.26.2",
+  "version": "1.26.3",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi"

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.26.1",
+  "version": "1.26.2",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi"

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.26.3",
+  "version": "1.27.0",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi"

--- a/plugins/aimi-engineering/CLAUDE.md
+++ b/plugins/aimi-engineering/CLAUDE.md
@@ -46,7 +46,7 @@ aimi-engineering-plugin/
 
 2. **Story content sanitization** - Before prompt interpolation:
    - Strip newlines, markdown headers, code fences
-   - Validate field lengths (title: 200, description: 500, criterion: 300)
+   - Validate field lengths (title: 200, description: 500, criterion: 600)
    - Reject suspicious content ("ignore previous instructions", shell syntax)
 
 3. **Bash permissions** - Use specific prefixes in allowed-tools:

--- a/plugins/aimi-engineering/commands/execute.md
+++ b/plugins/aimi-engineering/commands/execute.md
@@ -210,6 +210,7 @@ while true:
 
         # Spawn a single foreground Task — same pattern as next.md
         # No worktree, worker operates in current directory
+        # IMPORTANT: subagent_type MUST be "general-purpose" — story-executor is a skill, NOT an agent.
         Task(
             subagent_type: "general-purpose",
             description: "Execute [story.id]: [story.title]",
@@ -257,6 +258,7 @@ while true:
     # Claude Code runs multiple foreground Tasks concurrently and returns
     # all results before the agent's turn ends.
     #
+    # IMPORTANT: subagent_type MUST be "general-purpose" — story-executor is a skill, NOT an agent.
     # In one tool-call turn, emit N Task calls:
     for story in selected_stories:
         worktree_name = "aimi-[story.id]"

--- a/plugins/aimi-engineering/commands/execute.md
+++ b/plugins/aimi-engineering/commands/execute.md
@@ -9,7 +9,11 @@ allowed-tools: Read, Write, Edit, Bash(git:*), Bash(AIMI_CLI=*), Bash($AIMI_CLI:
 
 Execute all pending stories autonomously using wave-based fan-out.
 
-Each wave collects all ready stories. Single-story waves run inline (no worktree overhead). Multi-story waves spawn N foreground Tasks in one tool-call turn with worktrees, wait for all results, then merge.
+Each wave uses two-phase story loading to conserve context:
+- **Phase 1 (wave selection):** `list-ready --brief` returns lightweight story stubs `{id, title, priority, dependsOn}` for scheduling decisions.
+- **Phase 2 (prompt construction):** `get-story <id>` fetches full story data `{description, acceptanceCriteria, notes}` only for selected stories, after they are claimed with `mark-in-progress`.
+
+Single-story waves run inline (no worktree overhead). Multi-story waves spawn N foreground Tasks in one tool-call turn with worktrees, wait for all results, then merge.
 
 ## Step 0: Resolve CLI Path
 
@@ -179,8 +183,8 @@ while true:
     pending = $AIMI_CLI count-pending
     if pending == 0: break
 
-    # Get ready stories
-    ready_stories = $AIMI_CLI list-ready
+    # Get ready stories (brief mode — returns {id, title, priority, dependsOn} only)
+    ready_stories = $AIMI_CLI list-ready --brief
     if ready_stories is empty:
         if pending > 0:
             Report: "Deadlock detected: [pending] stories pending but none are ready."
@@ -208,19 +212,29 @@ while true:
     if len(selected_stories) == 1:
         story = selected_stories[0]
 
+        # Fetch full story data (description, acceptanceCriteria, notes)
+        full_story = $AIMI_CLI get-story [story.id]
+        if get-story failed:
+            $AIMI_CLI mark-failed [story.id] "get-story failed"
+            $AIMI_CLI cascade-skip [story.id]
+            Report: "[story.id] failed (could not fetch story data). Dependent stories cascade-skipped."
+            Report: "Wave [wave] complete."
+            wave += 1
+            continue
+
         # Spawn a single foreground Task — same pattern as next.md
         # No worktree, worker operates in current directory
         # IMPORTANT: subagent_type MUST be "general-purpose" — story-executor is a skill, NOT an agent.
         Task(
             subagent_type: "general-purpose",
-            description: "Execute [story.id]: [story.title]",
+            description: "Execute [full_story.id]: [full_story.title]",
             prompt: [story-executor SKILL.md prompt template with:
                 - PROJECT_GUIDELINES = PROJECT_GUIDELINES
-                - STORY_ID = story.id
-                - STORY_TITLE = story.title
-                - STORY_DESCRIPTION = story.description
-                - ACCEPTANCE_CRITERIA = story.acceptanceCriteria (bulleted)
-                - story.notes = story.notes (include PREVIOUS NOTES section only if non-empty)
+                - STORY_ID = full_story.id
+                - STORY_TITLE = full_story.title
+                - STORY_DESCRIPTION = full_story.description
+                - ACCEPTANCE_CRITERIA = full_story.acceptanceCriteria (bulleted)
+                - full_story.notes = full_story.notes (include PREVIOUS NOTES section only if non-empty)
                 - No WORKTREE_PATH (sequential — worker operates in current directory)
             ]
         )
@@ -242,10 +256,59 @@ while true:
     # MULTI-STORY WAVE (parallel with worktrees)
     # ========================================
 
+    # Fetch full story data for all selected stories (claim-then-fetch)
+    full_stories = []
+    fetch_failed = []
+    for story in selected_stories:
+        full_story = $AIMI_CLI get-story [story.id]
+        if get-story failed:
+            fetch_failed.append(story)
+            $AIMI_CLI mark-failed [story.id] "get-story failed"
+            $AIMI_CLI cascade-skip [story.id]
+            Report: "[story.id] failed (could not fetch story data). Dependent stories cascade-skipped."
+        else:
+            full_stories.append(full_story)
+
+    # If all fetches failed, skip worktree creation entirely
+    if len(full_stories) == 0:
+        Report: "Wave [wave] complete: 0 succeeded, [len(fetch_failed)] failed (all get-story calls failed)"
+        wave += 1
+        continue
+
+    # If only one story remains after fetch failures, use single-story path (no worktree)
+    if len(full_stories) == 1:
+        full_story = full_stories[0]
+        Task(
+            subagent_type: "general-purpose",
+            description: "Execute [full_story.id]: [full_story.title]",
+            prompt: [story-executor SKILL.md prompt template with:
+                - PROJECT_GUIDELINES = PROJECT_GUIDELINES
+                - STORY_ID = full_story.id
+                - STORY_TITLE = full_story.title
+                - STORY_DESCRIPTION = full_story.description
+                - ACCEPTANCE_CRITERIA = full_story.acceptanceCriteria (bulleted)
+                - full_story.notes = full_story.notes (include PREVIOUS NOTES section only if non-empty)
+                - No WORKTREE_PATH (single remaining story — no worktree overhead)
+            ]
+        )
+
+        if Task succeeded:
+            $AIMI_CLI mark-complete [full_story.id]
+            Report: "[full_story.id] completed."
+        else:
+            $AIMI_CLI mark-failed [full_story.id] "Failed during wave [wave]"
+            $AIMI_CLI cascade-skip [full_story.id]
+            Report: "[full_story.id] failed. Dependent stories cascade-skipped."
+
+        Report: "Wave [wave] complete."
+        wave += 1
+        continue
+
+    # Multiple stories remain — proceed with worktree parallelism
     worktree_names = []
 
-    for story in selected_stories:
-        worktree_name = "aimi-[story.id]"
+    for full_story in full_stories:
+        worktree_name = "aimi-[full_story.id]"
         worktree_names.append(worktree_name)
 
         # Create worktree from current feature branch
@@ -260,21 +323,21 @@ while true:
     #
     # IMPORTANT: subagent_type MUST be "general-purpose" — story-executor is a skill, NOT an agent.
     # In one tool-call turn, emit N Task calls:
-    for story in selected_stories:
-        worktree_name = "aimi-[story.id]"
+    for full_story in full_stories:
+        worktree_name = "aimi-[full_story.id]"
         worktree_path = [worktree path for this story]
 
         Task(
             subagent_type: "general-purpose",
-            description: "Execute [story.id]: [story.title]",
+            description: "Execute [full_story.id]: [full_story.title]",
             prompt: [story-executor SKILL.md prompt template with:
                 - WORKTREE_PATH = worktree_path
                 - PROJECT_GUIDELINES = PROJECT_GUIDELINES
-                - STORY_ID = story.id
-                - STORY_TITLE = story.title
-                - STORY_DESCRIPTION = story.description
-                - ACCEPTANCE_CRITERIA = story.acceptanceCriteria (bulleted)
-                - story.notes = story.notes (include PREVIOUS NOTES section only if non-empty)
+                - STORY_ID = full_story.id
+                - STORY_TITLE = full_story.title
+                - STORY_DESCRIPTION = full_story.description
+                - ACCEPTANCE_CRITERIA = full_story.acceptanceCriteria (bulleted)
+                - full_story.notes = full_story.notes (include PREVIOUS NOTES section only if non-empty)
                 - Do NOT modify the tasks.json file — report result (success/failure + details)
             ]
         )
@@ -285,21 +348,21 @@ while true:
 
     for each Task result:
         if Task succeeded:
-            succeeded_stories.append(story)
+            succeeded_stories.append(full_story)
         else:
-            failed_stories.append(story)
+            failed_stories.append(full_story)
 
     # --- Post-Wave Processing ---
 
     # Handle failures first
-    for story in failed_stories:
-        $AIMI_CLI mark-failed [story.id] "Failed during parallel wave [wave]"
-        $AIMI_CLI cascade-skip [story.id]
-        Report: "[story.id] failed. Dependent stories cascade-skipped."
+    for full_story in failed_stories:
+        $AIMI_CLI mark-failed [full_story.id] "Failed during parallel wave [wave]"
+        $AIMI_CLI cascade-skip [full_story.id]
+        Report: "[full_story.id] failed. Dependent stories cascade-skipped."
 
     # Merge all successful worktrees using merge-all
     if len(succeeded_stories) > 0:
-        succeeded_worktree_names = ["aimi-[story.id]" for story in succeeded_stories]
+        succeeded_worktree_names = ["aimi-[full_story.id]" for full_story in succeeded_stories]
 
         merge_result = $WORKTREE_MGR merge-all [succeeded_worktree_names...] --into [branchName]
 
@@ -318,9 +381,9 @@ while true:
             STOP execution.
 
         # All merges succeeded — mark stories complete
-        for story in succeeded_stories:
-            $AIMI_CLI mark-complete [story.id]
-            Report: "[story.id] merged successfully."
+        for full_story in succeeded_stories:
+            $AIMI_CLI mark-complete [full_story.id]
+            Report: "[full_story.id] merged successfully."
 
     # Remove all worktrees from this wave
     for wt in worktree_names:

--- a/plugins/aimi-engineering/commands/next.md
+++ b/plugins/aimi-engineering/commands/next.md
@@ -83,6 +83,7 @@ Interpolate the following into the template:
 - No WORKTREE_PATH (sequential mode — worker operates in current directory)
 
 ```
+# IMPORTANT: subagent_type MUST be "general-purpose" — story-executor is a skill, NOT an agent.
 Task general-purpose: "Execute [STORY_ID]: [STORY_TITLE]
 
 [story-executor/SKILL.md prompt template with interpolated values]
@@ -118,6 +119,7 @@ $AIMI_CLI mark-failed [STORY_ID] "Attempt 1 failed: [error summary]"
 2. RETRY automatically with error context:
 
 ```
+# IMPORTANT: subagent_type MUST be "general-purpose" — story-executor is a skill, NOT an agent.
 Task general-purpose: "RETRY: Execute [STORY_ID]: [STORY_TITLE]
 
 PREVIOUS ATTEMPT FAILED:

--- a/plugins/aimi-engineering/commands/plan.md
+++ b/plugins/aimi-engineering/commands/plan.md
@@ -145,7 +145,7 @@ Write JSON using the Write tool. Validate JSON is well-formed before writing.
 - [ ] `dependsOn` is `[]` for root stories with no upstream dependencies
 - [ ] branchName is valid (alphanumeric, hyphens, slashes)
 - [ ] `planPath` is `null`
-- [ ] Field lengths: title ≤ 200, description ≤ 500, criterion ≤ 300
+- [ ] Field lengths: title ≤ 200, description ≤ 500, criterion ≤ 600
 
 ## Step 5: Aimi-Branded Report
 

--- a/plugins/aimi-engineering/scripts/aimi-cli.sh
+++ b/plugins/aimi-engineering/scripts/aimi-cli.sh
@@ -250,11 +250,21 @@ cmd_metadata() {
 
 # List stories that are ready to execute
 # A story is ready when: status == "pending" AND all dependsOn stories have status "completed" or "skipped"
+# Flags: --brief (return only {id, title, priority, dependsOn} per story)
 cmd_list_ready() {
+  local brief=false
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --brief) brief=true; shift ;;
+      *) break ;;
+    esac
+  done
+
   local tasks_file
   tasks_file=$(get_tasks_file)
 
-  jq '
+  local result
+  result=$(jq '
     . as $root |
     [
       .userStories[] |
@@ -271,7 +281,13 @@ cmd_list_ready() {
       )
     | if . then $story else empty end
     ]
-  ' "$tasks_file"
+  ' "$tasks_file")
+
+  if [ "$brief" = true ]; then
+    echo "$result" | jq '[.[] | {id, title, priority, dependsOn}]'
+  else
+    echo "$result"
+  fi
 }
 
 # Get next pending story
@@ -821,7 +837,8 @@ COMMANDS:
     metadata                  Get metadata only
     next-story                Get next pending story, save to state
     current-story             Get currently active story from state
-    list-ready                List stories ready to execute (dependency-aware)
+    list-ready [--brief]      List stories ready to execute (dependency-aware)
+                              --brief  Return only {id, title, priority, dependsOn} per story
     mark-in-progress <id>     Mark story as in_progress
     mark-complete <id>        Mark story as completed
     mark-failed <id> [notes]  Mark story as failed with notes
@@ -900,7 +917,7 @@ main() {
     metadata)          cmd_metadata ;;
     next-story)        cmd_next_story ;;
     current-story)     cmd_current_story ;;
-    list-ready)        cmd_list_ready ;;
+    list-ready)        shift; cmd_list_ready "$@" ;;
     mark-in-progress)  cmd_mark_in_progress "${2:-}" ;;
     mark-complete)     cmd_mark_complete "${2:-}" ;;
     mark-failed)       cmd_mark_failed "${2:-}" "${3:-}" ;;

--- a/plugins/aimi-engineering/scripts/aimi-cli.sh
+++ b/plugins/aimi-engineering/scripts/aimi-cli.sh
@@ -864,10 +864,10 @@ COMMANDS:
     current-story             Get currently active story from state
     list-ready [--brief]      List stories ready to execute (dependency-aware)
                               --brief  Return only {id, title, priority, dependsOn} per story
-    mark-in-progress <id>     Mark story as in_progress
-    mark-complete <id>        Mark story as completed
-    mark-failed <id> [notes]  Mark story as failed with notes
-    mark-skipped <id>         Mark story as skipped
+    mark-in-progress <id>     Mark story as in_progress (returns {id, status} JSON)
+    mark-complete <id>        Mark story as completed (returns {id, status} JSON)
+    mark-failed <id> [notes]  Mark story as failed (returns {id, status, notes} JSON)
+    mark-skipped <id>         Mark story as skipped (returns {id, status} JSON)
     count-pending             Count pending stories
     validate-deps             Validate dependency graph (no cycles, no missing refs)
     validate-stories          Validate story content (length, suspicious patterns)

--- a/plugins/aimi-engineering/scripts/aimi-cli.sh
+++ b/plugins/aimi-engineering/scripts/aimi-cli.sh
@@ -578,7 +578,7 @@ cmd_validate_stories() {
       (
         (if ($s.title | length) > 200 then ["\($s.id): title exceeds 200 chars"] else [] end) +
         (if ($s.description | length) > 500 then ["\($s.id): description exceeds 500 chars"] else [] end) +
-        ([$s.acceptanceCriteria[] | select(length > 300)] | if length > 0 then ["\($s.id): acceptance criterion exceeds 300 chars"] else [] end) +
+        ([$s.acceptanceCriteria[] | select(length > 600)] | if length > 0 then ["\($s.id): acceptance criterion exceeds 600 chars"] else [] end) +
         (if ($s.title | test("ignore previous|system:|INSTRUCTIONS|```|\\$\\(|`"; "i")) then ["\($s.id): title contains suspicious content"] else [] end) +
         (if ($s.description | test("ignore previous|system:|INSTRUCTIONS|```|\\$\\(|`"; "i")) then ["\($s.id): description contains suspicious content"] else [] end)
       ) | .[]

--- a/plugins/aimi-engineering/scripts/aimi-cli.sh
+++ b/plugins/aimi-engineering/scripts/aimi-cli.sh
@@ -347,6 +347,24 @@ cmd_current_story() {
   jq --arg id "$story_id" '.userStories[] | select(.id == $id)' "$tasks_file"
 }
 
+# Get full story object by ID (read-only)
+cmd_get_story() {
+  local story_id="$1"
+  local tasks_file
+
+  if [ -z "$story_id" ]; then
+    echo "Usage: aimi-cli.sh get-story <story-id>" >&2
+    exit 1
+  fi
+
+  validate_story_id "$story_id"
+
+  tasks_file=$(get_tasks_file)
+  validate_story_exists "$story_id" "$tasks_file"
+
+  jq --arg id "$story_id" '.userStories[] | select(.id == $id)' "$tasks_file"
+}
+
 # Mark a story as in-progress
 cmd_mark_in_progress() {
   local story_id="$1"
@@ -874,6 +892,7 @@ COMMANDS:
     cascade-skip <id>         Skip all stories depending on failed story
     reset-orphaned            Reset all in_progress stories to failed
     get-branch                Get branchName from metadata
+    get-story <id>            Get full story object by ID (read-only)
     get-state                 Get all state files as JSON
     clear-state               Clear all state files
     check-version [--quiet] [--fix]
@@ -910,6 +929,9 @@ EXAMPLES:
 
     # Validate dependency graph
     $AIMI_CLI validate-deps
+
+    # Fetch a specific story by ID
+    $AIMI_CLI get-story US-003
 
     # Cascade skip after failure
     $AIMI_CLI cascade-skip US-003
@@ -953,6 +975,7 @@ main() {
     cascade-skip)      cmd_cascade_skip "${2:-}" ;;
     reset-orphaned)    cmd_reset_orphaned ;;
     get-branch)        cmd_get_branch ;;
+    get-story)         cmd_get_story "${2:-}" ;;
     get-state)         cmd_get_state ;;
     clear-state)       cmd_clear_state ;;
     check-version)     shift; cmd_check_version "$@" ;;

--- a/plugins/aimi-engineering/scripts/aimi-cli.sh
+++ b/plugins/aimi-engineering/scripts/aimi-cli.sh
@@ -222,23 +222,47 @@ cmd_init_session() {
 }
 
 # Get comprehensive status summary
+# Flags: --counts-only (return aggregate counts without userStories array)
 cmd_status() {
+  local counts_only=false
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --counts-only) counts_only=true; shift ;;
+      *) break ;;
+    esac
+  done
+
   local tasks_file
   tasks_file=$(get_tasks_file)
 
-  jq '{
-    schemaVersion: .schemaVersion,
-    title: .metadata.title,
-    branch: .metadata.branchName,
-    maxConcurrency: ((.metadata.maxConcurrency // 4) | if . <= 0 then 4 else . end),
-    pending: [.userStories[] | select(.status == "pending")] | length,
-    in_progress: [.userStories[] | select(.status == "in_progress")] | length,
-    completed: [.userStories[] | select(.status == "completed")] | length,
-    failed: [.userStories[] | select(.status == "failed")] | length,
-    skipped: [.userStories[] | select(.status == "skipped")] | length,
-    total: .userStories | length,
-    userStories: [.userStories[] | {id, title, status, dependsOn: (.dependsOn // []), priority, notes}]
-  }' "$tasks_file"
+  if [ "$counts_only" = true ]; then
+    jq '{
+      schemaVersion: .schemaVersion,
+      title: .metadata.title,
+      branch: .metadata.branchName,
+      maxConcurrency: ((.metadata.maxConcurrency // 4) | if . <= 0 then 4 else . end),
+      pending: [.userStories[] | select(.status == "pending")] | length,
+      in_progress: [.userStories[] | select(.status == "in_progress")] | length,
+      completed: [.userStories[] | select(.status == "completed")] | length,
+      failed: [.userStories[] | select(.status == "failed")] | length,
+      skipped: [.userStories[] | select(.status == "skipped")] | length,
+      total: .userStories | length
+    }' "$tasks_file"
+  else
+    jq '{
+      schemaVersion: .schemaVersion,
+      title: .metadata.title,
+      branch: .metadata.branchName,
+      maxConcurrency: ((.metadata.maxConcurrency // 4) | if . <= 0 then 4 else . end),
+      pending: [.userStories[] | select(.status == "pending")] | length,
+      in_progress: [.userStories[] | select(.status == "in_progress")] | length,
+      completed: [.userStories[] | select(.status == "completed")] | length,
+      failed: [.userStories[] | select(.status == "failed")] | length,
+      skipped: [.userStories[] | select(.status == "skipped")] | length,
+      total: .userStories | length,
+      userStories: [.userStories[] | {id, title, status, dependsOn: (.dependsOn // []), priority, notes}]
+    }' "$tasks_file"
+  fi
 }
 
 # Get metadata only
@@ -833,7 +857,8 @@ USAGE:
 COMMANDS:
     init-session              Initialize execution session, save state
     find-tasks                Find most recent tasks file
-    status                    Get status summary as JSON
+    status [--counts-only]    Get status summary as JSON
+                              --counts-only  Return aggregate counts without userStories array
     metadata                  Get metadata only
     next-story                Get next pending story, save to state
     current-story             Get currently active story from state
@@ -913,7 +938,7 @@ main() {
   case "${1:-help}" in
     init-session)      cmd_init_session ;;
     find-tasks)        cmd_find_tasks ;;
-    status)            cmd_status ;;
+    status)            shift; cmd_status "$@" ;;
     metadata)          cmd_metadata ;;
     next-story)        cmd_next_story ;;
     current-story)     cmd_current_story ;;

--- a/plugins/aimi-engineering/scripts/aimi-cli.sh
+++ b/plugins/aimi-engineering/scripts/aimi-cli.sh
@@ -336,7 +336,7 @@ cmd_mark_in_progress() {
 
   write_state "current-story" "$story_id"
 
-  jq --arg id "$story_id" '.userStories[] | select(.id == $id)' "$tasks_file"
+  printf '{"id":"%s","status":"in_progress"}\n' "$story_id"
 }
 
 # Mark a story as complete
@@ -369,7 +369,7 @@ cmd_mark_complete() {
   clear_state_file "current-story"
   write_state "last-result" "success"
 
-  jq --arg id "$story_id" '.userStories[] | select(.id == $id)' "$tasks_file"
+  printf '{"id":"%s","status":"completed"}\n' "$story_id"
 }
 
 # Mark a story as failed with notes
@@ -403,7 +403,7 @@ cmd_mark_failed() {
   clear_state_file "current-story"
   write_state "last-result" "failed"
 
-  jq --arg id "$story_id" '.userStories[] | select(.id == $id)' "$tasks_file"
+  printf '{"id":"%s","status":"failed","notes":"%s"}\n' "$story_id" "$notes"
 }
 
 # Mark a story as skipped
@@ -436,7 +436,7 @@ cmd_mark_skipped() {
   clear_state_file "current-story"
   write_state "last-result" "skipped"
 
-  jq --arg id "$story_id" '.userStories[] | select(.id == $id)' "$tasks_file"
+  printf '{"id":"%s","status":"skipped"}\n' "$story_id"
 }
 
 # Count pending stories

--- a/plugins/aimi-engineering/scripts/test-aimi-cli.sh
+++ b/plugins/aimi-engineering/scripts/test-aimi-cli.sh
@@ -332,7 +332,7 @@ test_mark_in_progress() {
   local output
   output=$("$CLI" mark-in-progress US-001)
 
-  assert_contains '"status": "in_progress"' "$output" "mark-in-progress sets status to in_progress"
+  assert_contains '"status":"in_progress"' "$output" "mark-in-progress sets status to in_progress"
 }
 
 test_mark_complete() {
@@ -342,7 +342,7 @@ test_mark_complete() {
   local output
   output=$("$CLI" mark-complete US-001)
 
-  assert_contains '"status": "completed"' "$output" "mark-complete sets status to completed"
+  assert_contains '"status":"completed"' "$output" "mark-complete sets status to completed"
 
   # Check last-result state
   local last
@@ -383,8 +383,8 @@ test_mark_failed() {
   local output
   output=$("$CLI" mark-failed US-002 "Build error in module X")
 
-  assert_contains '"status": "failed"' "$output" "mark-failed sets status to failed"
-  assert_contains '"notes": "Build error in module X"' "$output" "mark-failed sets notes"
+  assert_contains '"status":"failed"' "$output" "mark-failed sets status to failed"
+  assert_contains '"notes":"Build error in module X"' "$output" "mark-failed sets notes"
 
   # Check state
   local last
@@ -420,7 +420,7 @@ test_mark_skipped() {
   local output
   output=$("$CLI" mark-skipped US-003)
 
-  assert_contains '"status": "skipped"' "$output" "mark-skipped sets status to skipped"
+  assert_contains '"status":"skipped"' "$output" "mark-skipped sets status to skipped"
 
   # Check state
   local last
@@ -928,6 +928,379 @@ test_auto_discovery_not_found() {
 }
 
 # ============================================================================
+# CLI Output Optimization Tests
+# ============================================================================
+
+# Helper: reset fixture to fresh state with all stories pending
+reset_fixture() {
+  "$CLI" clear-state > /dev/null
+
+  cat > "$TASKS_FILE" << 'EOF'
+{
+  "schemaVersion": "3.0",
+  "metadata": {
+    "title": "feat: Test feature",
+    "type": "feat",
+    "branchName": "feat/test-feature",
+    "createdAt": "2026-02-27",
+    "planPath": null,
+    "brainstormPath": null,
+    "maxConcurrency": 4
+  },
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Schema story (root)",
+      "description": "Independent root story",
+      "acceptanceCriteria": ["Typecheck passes"],
+      "priority": 1,
+      "status": "pending",
+      "dependsOn": [],
+      "notes": ""
+    },
+    {
+      "id": "US-002",
+      "title": "Another root story",
+      "description": "Independent root story 2",
+      "acceptanceCriteria": ["Typecheck passes"],
+      "priority": 2,
+      "status": "pending",
+      "dependsOn": [],
+      "notes": ""
+    },
+    {
+      "id": "US-003",
+      "title": "Backend depends on US-001",
+      "description": "Depends on schema",
+      "acceptanceCriteria": ["Typecheck passes"],
+      "priority": 3,
+      "status": "pending",
+      "dependsOn": ["US-001"],
+      "notes": ""
+    },
+    {
+      "id": "US-004",
+      "title": "UI depends on US-002 and US-003",
+      "description": "Diamond convergence",
+      "acceptanceCriteria": ["Typecheck passes"],
+      "priority": 4,
+      "status": "pending",
+      "dependsOn": ["US-002", "US-003"],
+      "notes": ""
+    }
+  ]
+}
+EOF
+
+  "$CLI" init-session > /dev/null
+}
+
+test_mark_in_progress_minimal_output() {
+  echo ""
+  echo "=== Testing mark-in-progress minimal output ==="
+
+  reset_fixture
+
+  local output
+  output=$("$CLI" mark-in-progress US-001)
+
+  # Should only have id and status keys (2 keys)
+  local key_count
+  key_count=$(echo "$output" | jq 'keys | length')
+  assert_eq "2" "$key_count" "mark-in-progress output has exactly 2 keys"
+
+  # Verify the keys are id and status
+  local has_id has_status
+  has_id=$(echo "$output" | jq 'has("id")')
+  has_status=$(echo "$output" | jq 'has("status")')
+  assert_eq "true" "$has_id" "mark-in-progress output has id key"
+  assert_eq "true" "$has_status" "mark-in-progress output has status key"
+
+  # Verify values
+  local id_val status_val
+  id_val=$(echo "$output" | jq -r '.id')
+  status_val=$(echo "$output" | jq -r '.status')
+  assert_eq "US-001" "$id_val" "mark-in-progress output id is US-001"
+  assert_eq "in_progress" "$status_val" "mark-in-progress output status is in_progress"
+
+  # Should NOT have title, description, etc
+  local has_title has_description
+  has_title=$(echo "$output" | jq 'has("title")')
+  has_description=$(echo "$output" | jq 'has("description")')
+  assert_eq "false" "$has_title" "mark-in-progress output has no title key"
+  assert_eq "false" "$has_description" "mark-in-progress output has no description key"
+}
+
+test_mark_complete_minimal_output() {
+  echo ""
+  echo "=== Testing mark-complete minimal output ==="
+
+  reset_fixture
+
+  local output
+  output=$("$CLI" mark-complete US-001)
+
+  # Should only have id and status keys (2 keys)
+  local key_count
+  key_count=$(echo "$output" | jq 'keys | length')
+  assert_eq "2" "$key_count" "mark-complete output has exactly 2 keys"
+
+  # Verify values
+  local id_val status_val
+  id_val=$(echo "$output" | jq -r '.id')
+  status_val=$(echo "$output" | jq -r '.status')
+  assert_eq "US-001" "$id_val" "mark-complete output id is US-001"
+  assert_eq "completed" "$status_val" "mark-complete output status is completed"
+
+  # Should NOT have title, description, etc
+  local has_title
+  has_title=$(echo "$output" | jq 'has("title")')
+  assert_eq "false" "$has_title" "mark-complete output has no title key"
+}
+
+test_mark_failed_minimal_output() {
+  echo ""
+  echo "=== Testing mark-failed minimal output ==="
+
+  reset_fixture
+
+  local output
+  output=$("$CLI" mark-failed US-001 "Build error in tests")
+
+  # Should have id, status, and notes keys (3 keys)
+  local key_count
+  key_count=$(echo "$output" | jq 'keys | length')
+  assert_eq "3" "$key_count" "mark-failed output has exactly 3 keys"
+
+  # Verify the keys are id, status, and notes
+  local has_id has_status has_notes
+  has_id=$(echo "$output" | jq 'has("id")')
+  has_status=$(echo "$output" | jq 'has("status")')
+  has_notes=$(echo "$output" | jq 'has("notes")')
+  assert_eq "true" "$has_id" "mark-failed output has id key"
+  assert_eq "true" "$has_status" "mark-failed output has status key"
+  assert_eq "true" "$has_notes" "mark-failed output has notes key"
+
+  # Verify values
+  local id_val status_val notes_val
+  id_val=$(echo "$output" | jq -r '.id')
+  status_val=$(echo "$output" | jq -r '.status')
+  notes_val=$(echo "$output" | jq -r '.notes')
+  assert_eq "US-001" "$id_val" "mark-failed output id is US-001"
+  assert_eq "failed" "$status_val" "mark-failed output status is failed"
+  assert_eq "Build error in tests" "$notes_val" "mark-failed output notes match"
+
+  # Should NOT have title, description, etc
+  local has_title
+  has_title=$(echo "$output" | jq 'has("title")')
+  assert_eq "false" "$has_title" "mark-failed output has no title key"
+}
+
+test_mark_skipped_minimal_output() {
+  echo ""
+  echo "=== Testing mark-skipped minimal output ==="
+
+  reset_fixture
+
+  local output
+  output=$("$CLI" mark-skipped US-001)
+
+  # Should only have id and status keys (2 keys)
+  local key_count
+  key_count=$(echo "$output" | jq 'keys | length')
+  assert_eq "2" "$key_count" "mark-skipped output has exactly 2 keys"
+
+  # Verify values
+  local id_val status_val
+  id_val=$(echo "$output" | jq -r '.id')
+  status_val=$(echo "$output" | jq -r '.status')
+  assert_eq "US-001" "$id_val" "mark-skipped output id is US-001"
+  assert_eq "skipped" "$status_val" "mark-skipped output status is skipped"
+
+  # Should NOT have title, description, etc
+  local has_title has_description
+  has_title=$(echo "$output" | jq 'has("title")')
+  has_description=$(echo "$output" | jq 'has("description")')
+  assert_eq "false" "$has_title" "mark-skipped output has no title key"
+  assert_eq "false" "$has_description" "mark-skipped output has no description key"
+}
+
+test_list_ready_full_default() {
+  echo ""
+  echo "=== Testing list-ready full output (default, no flags) ==="
+
+  reset_fixture
+
+  local output
+  output=$("$CLI" list-ready)
+
+  # Default list-ready should return full story objects with description and acceptanceCriteria
+  local has_description has_criteria
+  has_description=$(echo "$output" | jq '.[0] | has("description")')
+  has_criteria=$(echo "$output" | jq '.[0] | has("acceptanceCriteria")')
+  assert_eq "true" "$has_description" "list-ready default includes description"
+  assert_eq "true" "$has_criteria" "list-ready default includes acceptanceCriteria"
+
+  # Should also have status and notes fields
+  local has_status has_notes
+  has_status=$(echo "$output" | jq '.[0] | has("status")')
+  has_notes=$(echo "$output" | jq '.[0] | has("notes")')
+  assert_eq "true" "$has_status" "list-ready default includes status"
+  assert_eq "true" "$has_notes" "list-ready default includes notes"
+}
+
+test_list_ready_brief() {
+  echo ""
+  echo "=== Testing list-ready --brief output ==="
+
+  reset_fixture
+
+  local output
+  output=$("$CLI" list-ready --brief)
+
+  # Brief output should only have {id, title, priority, dependsOn} per story
+  local key_count
+  key_count=$(echo "$output" | jq '.[0] | keys | length')
+  assert_eq "4" "$key_count" "list-ready --brief: each story has exactly 4 keys"
+
+  # Verify the 4 expected keys exist
+  local has_id has_title has_priority has_depends
+  has_id=$(echo "$output" | jq '.[0] | has("id")')
+  has_title=$(echo "$output" | jq '.[0] | has("title")')
+  has_priority=$(echo "$output" | jq '.[0] | has("priority")')
+  has_depends=$(echo "$output" | jq '.[0] | has("dependsOn")')
+  assert_eq "true" "$has_id" "list-ready --brief has id"
+  assert_eq "true" "$has_title" "list-ready --brief has title"
+  assert_eq "true" "$has_priority" "list-ready --brief has priority"
+  assert_eq "true" "$has_depends" "list-ready --brief has dependsOn"
+
+  # Should NOT have description, acceptanceCriteria, status, or notes
+  local has_description has_criteria has_status has_notes
+  has_description=$(echo "$output" | jq '.[0] | has("description")')
+  has_criteria=$(echo "$output" | jq '.[0] | has("acceptanceCriteria")')
+  has_status=$(echo "$output" | jq '.[0] | has("status")')
+  has_notes=$(echo "$output" | jq '.[0] | has("notes")')
+  assert_eq "false" "$has_description" "list-ready --brief has no description"
+  assert_eq "false" "$has_criteria" "list-ready --brief has no acceptanceCriteria"
+  assert_eq "false" "$has_status" "list-ready --brief has no status"
+  assert_eq "false" "$has_notes" "list-ready --brief has no notes"
+}
+
+test_status_full_default() {
+  echo ""
+  echo "=== Testing status full output (default, no flags) ==="
+
+  reset_fixture
+
+  local output
+  output=$("$CLI" status)
+
+  # Default status should include userStories array
+  local has_stories
+  has_stories=$(echo "$output" | jq 'has("userStories")')
+  assert_eq "true" "$has_stories" "status default includes userStories key"
+
+  # Verify userStories is an array with content
+  local stories_len
+  stories_len=$(echo "$output" | jq '.userStories | length')
+  if [ "$stories_len" -gt 0 ]; then
+    echo -e "${GREEN}✓${NC} status default: userStories array is non-empty (count: $stories_len)"
+    ((TESTS_PASSED++))
+  else
+    echo -e "${RED}✗${NC} status default: userStories array is non-empty"
+    echo "  Actual length: $stories_len"
+    ((TESTS_FAILED++))
+  fi
+
+  # Should also include count fields
+  local has_pending has_completed
+  has_pending=$(echo "$output" | jq 'has("pending")')
+  has_completed=$(echo "$output" | jq 'has("completed")')
+  assert_eq "true" "$has_pending" "status default includes pending count"
+  assert_eq "true" "$has_completed" "status default includes completed count"
+}
+
+test_status_counts_only() {
+  echo ""
+  echo "=== Testing status --counts-only output ==="
+
+  reset_fixture
+
+  local output
+  output=$("$CLI" status --counts-only)
+
+  # --counts-only should NOT include userStories
+  local has_stories
+  has_stories=$(echo "$output" | jq 'has("userStories")')
+  assert_eq "false" "$has_stories" "status --counts-only has no userStories key"
+
+  # Should still have count fields
+  local has_pending has_completed has_failed has_skipped has_in_progress has_total
+  has_pending=$(echo "$output" | jq 'has("pending")')
+  has_completed=$(echo "$output" | jq 'has("completed")')
+  has_failed=$(echo "$output" | jq 'has("failed")')
+  has_skipped=$(echo "$output" | jq 'has("skipped")')
+  has_in_progress=$(echo "$output" | jq 'has("in_progress")')
+  has_total=$(echo "$output" | jq 'has("total")')
+  assert_eq "true" "$has_pending" "status --counts-only has pending count"
+  assert_eq "true" "$has_completed" "status --counts-only has completed count"
+  assert_eq "true" "$has_failed" "status --counts-only has failed count"
+  assert_eq "true" "$has_skipped" "status --counts-only has skipped count"
+  assert_eq "true" "$has_in_progress" "status --counts-only has in_progress count"
+  assert_eq "true" "$has_total" "status --counts-only has total count"
+
+  # Verify count values with fresh fixture (all pending)
+  local pending_val total_val
+  pending_val=$(echo "$output" | jq '.pending')
+  total_val=$(echo "$output" | jq '.total')
+  assert_eq "4" "$pending_val" "status --counts-only pending is 4"
+  assert_eq "4" "$total_val" "status --counts-only total is 4"
+
+  # Should still have metadata fields
+  local has_schema has_branch
+  has_schema=$(echo "$output" | jq 'has("schemaVersion")')
+  has_branch=$(echo "$output" | jq 'has("branch")')
+  assert_eq "true" "$has_schema" "status --counts-only has schemaVersion"
+  assert_eq "true" "$has_branch" "status --counts-only has branch"
+}
+
+test_next_story_returns_full_object() {
+  echo ""
+  echo "=== Testing next-story returns full object (regression) ==="
+
+  reset_fixture
+
+  local output
+  output=$("$CLI" next-story)
+
+  # next-story should return full story object with description and acceptanceCriteria
+  local has_description has_criteria has_id has_title has_status has_priority
+  has_description=$(echo "$output" | jq 'has("description")')
+  has_criteria=$(echo "$output" | jq 'has("acceptanceCriteria")')
+  has_id=$(echo "$output" | jq 'has("id")')
+  has_title=$(echo "$output" | jq 'has("title")')
+  has_status=$(echo "$output" | jq 'has("status")')
+  has_priority=$(echo "$output" | jq 'has("priority")')
+
+  assert_eq "true" "$has_id" "next-story returns id"
+  assert_eq "true" "$has_title" "next-story returns title"
+  assert_eq "true" "$has_description" "next-story returns description"
+  assert_eq "true" "$has_criteria" "next-story returns acceptanceCriteria"
+  assert_eq "true" "$has_status" "next-story returns status"
+  assert_eq "true" "$has_priority" "next-story returns priority"
+
+  # Verify it is the right story (US-001 by priority)
+  local id_val
+  id_val=$(echo "$output" | jq -r '.id')
+  assert_eq "US-001" "$id_val" "next-story returns US-001 (first by priority)"
+
+  # Verify description has actual content (not empty)
+  local desc_val
+  desc_val=$(echo "$output" | jq -r '.description')
+  assert_eq "Independent root story" "$desc_val" "next-story description has content"
+}
+
+# ============================================================================
 # Main
 # ============================================================================
 
@@ -1004,6 +1377,19 @@ main() {
   echo "--- Auto-Discovery Tests ---"
   test_auto_discovery_from_subdirectory
   test_auto_discovery_not_found
+
+  # CLI output optimization tests — run with fresh fixture each time
+  echo ""
+  echo "--- CLI Output Optimization Tests ---"
+  test_mark_in_progress_minimal_output
+  test_mark_complete_minimal_output
+  test_mark_failed_minimal_output
+  test_mark_skipped_minimal_output
+  test_list_ready_full_default
+  test_list_ready_brief
+  test_status_full_default
+  test_status_counts_only
+  test_next_story_returns_full_object
 
   cleanup
 

--- a/plugins/aimi-engineering/skills/story-executor/SKILL.md
+++ b/plugins/aimi-engineering/skills/story-executor/SKILL.md
@@ -81,6 +81,11 @@ Description: [STORY_DESCRIPTION]
 
 [story.notes]
 
+## Tools
+
+Use built-in tools directly: Read, Write, Edit, Bash, Grep, Glob.
+Do NOT invoke these via the Skill tool — "write" is a Write tool, not a skill.
+
 ## Execution Flow
 
 0. If WORKTREE_PATH is set, cd to WORKTREE_PATH

--- a/plugins/aimi-engineering/skills/task-planner/SKILL.md
+++ b/plugins/aimi-engineering/skills/task-planner/SKILL.md
@@ -147,7 +147,7 @@ See `references/task-format-v3.md` for the complete v3 schema definition, status
 - [ ] Acceptance criteria are verifiable (not vague)
 - [ ] branchName is valid (alphanumeric, hyphens, slashes)
 - [ ] `planPath` is `null`
-- [ ] Field lengths: title ≤ 200, description ≤ 500, criterion ≤ 300
+- [ ] Field lengths: title ≤ 200, description ≤ 500, criterion ≤ 600
 
 ### v3 Schema Validations
 - [ ] `schemaVersion` is `"3.0"`

--- a/plugins/aimi-engineering/skills/task-planner/references/story-decomposition.md
+++ b/plugins/aimi-engineering/skills/task-planner/references/story-decomposition.md
@@ -244,7 +244,7 @@ When generating stories from research output and user input:
 
 - **Title**: Strip markdown headers (`#`), limit to 200 characters
 - **Description**: Strip code fences, limit to 500 characters
-- **Acceptance criteria**: Strip newlines, limit each to 300 characters
+- **Acceptance criteria**: Strip newlines, limit each to 600 characters
 - **branchName**: Validate against `^[a-zA-Z0-9][a-zA-Z0-9/_-]*$`
 
 ---
@@ -260,7 +260,7 @@ Before finalizing stories, verify:
 - [ ] UI stories have "Verify in browser" as criterion
 - [ ] Acceptance criteria are verifiable (not vague)
 - [ ] IDs are sequential (US-001, US-002, ...)
-- [ ] Field lengths within limits (title ≤ 200, description ≤ 500, criterion ≤ 300)
+- [ ] Field lengths within limits (title ≤ 200, description ≤ 500, criterion ≤ 600)
 - [ ] branchName matches validation regex
 
 ### Dependency Graph (`dependsOn`)

--- a/plugins/aimi-engineering/skills/task-planner/references/task-format-v3.md
+++ b/plugins/aimi-engineering/skills/task-planner/references/task-format-v3.md
@@ -61,7 +61,7 @@ Each story is ONE atomic unit of work completable in a single agent iteration.
 | `id` | string | Yes | — | Unique identifier (e.g., `US-001`, `US-002`) |
 | `title` | string | Yes | — | Short story title (max 200 chars) |
 | `description` | string | Yes | — | User story format: "As a [user], I want [feature] so that [benefit]" (max 500 chars) |
-| `acceptanceCriteria` | string[] | Yes | — | Verifiable criteria (must include `"Typecheck passes"`, each max 300 chars) |
+| `acceptanceCriteria` | string[] | Yes | — | Verifiable criteria (must include `"Typecheck passes"`, each max 600 chars) |
 | `priority` | number | Yes | — | Tiebreaker for stories at the same dependency depth. Lower = runs first among peers. |
 | `status` | string | Yes | `"pending"` | One of: `"pending"`, `"in_progress"`, `"completed"`, `"failed"`, `"skipped"` |
 | `dependsOn` | string[] | Yes | `[]` | Array of story IDs this story depends on (e.g., `["US-001", "US-002"]`) |


### PR DESCRIPTION
## Summary
  - Introduce lazy story loading: `list-ready --brief` returns lightweight stubs (`{id, title,
  priority, dependsOn}`) for wave scheduling, then `get-story <id>` fetches full story data only
  for claimed stories — reducing context window usage during execution
  - Add `get-story` CLI command for on-demand full story retrieval
  - Reduce `mark-*` command output from full story JSON to minimal `{id, status}` confirmation
  - Add `--counts-only` flag to `status` and `--brief` flag to `list-ready` for token-efficient
  queries
  - Bump acceptance criterion validation limit from 300 to 600 chars
  - Fix `subagent_type` guard in `next.md`
  - Update execute.md orchestration to use two-phase loading with proper error handling for failed
  `get-story` calls

  ## Test plan
  - [ ] Run `aimi-cli.sh list-ready --brief` and verify output contains only `{id, title, priority,
   dependsOn}` fields
  - [ ] Run `aimi-cli.sh get-story <id>` and verify full story object is returned
  - [ ] Run `aimi-cli.sh status --counts-only` and verify no `userStories` array in output
  - [ ] Run `aimi-cli.sh mark-complete <id>` and verify minimal JSON confirmation
  - [ ] Run existing test suite (`test-aimi-cli.sh`) to validate all changes