### PR TITLE
fix: use task branch name as worktree branch prefix

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and worktree+team orchestration.",
-      "version": "1.27.3",
+      "version": "1.27.4",
       "author": {
         "name": "Stanley Takamatsu",
         "url": "https://github.com/aimi-so"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.27.4] - 2026-03-03
+
+### Fixed
+
+- **execute.md**: Use task branch name as worktree branch prefix instead of hardcoded `aimi-` — worktree branches are now named `[branchName]-[storyId]` (e.g., `feat/feature-name-US-001`) for clearer branch association
+
 ## [1.27.3] - 2026-03-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -536,9 +536,12 @@ Invalid characters (spaces, semicolons, quotes) trigger validation errors.
 
 ## Version History
 
-**Current Version:** 1.27.0
+**Current Version:** 1.27.4
 
 ### Recent Changes
+
+**v1.27.4** - Worktree Branch Prefix
+- Use task branch name as worktree branch prefix instead of hardcoded `aimi-`
 
 **v1.27.0** - Lazy Story Loading
 - Added `get-story <id>` CLI command for on-demand story fetching

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.27.3",
+  "version": "1.27.4",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi"

--- a/plugins/aimi-engineering/commands/execute.md
+++ b/plugins/aimi-engineering/commands/execute.md
@@ -308,7 +308,7 @@ while true:
     worktree_names = []
 
     for full_story in full_stories:
-        worktree_name = "aimi-[full_story.id]"
+        worktree_name = "[branchName]-[full_story.id]"
         worktree_names.append(worktree_name)
 
         # Create worktree from current feature branch
@@ -324,7 +324,7 @@ while true:
     # IMPORTANT: subagent_type MUST be "general-purpose" — story-executor is a skill, NOT an agent.
     # In one tool-call turn, emit N Task calls:
     for full_story in full_stories:
-        worktree_name = "aimi-[full_story.id]"
+        worktree_name = "[branchName]-[full_story.id]"
         worktree_path = [worktree path for this story]
 
         Task(
@@ -362,7 +362,7 @@ while true:
 
     # Merge all successful worktrees using merge-all
     if len(succeeded_stories) > 0:
-        succeeded_worktree_names = ["aimi-[full_story.id]" for full_story in succeeded_stories]
+        succeeded_worktree_names = ["[branchName]-[full_story.id]" for full_story in succeeded_stories]
 
         merge_result = $WORKTREE_MGR merge-all [succeeded_worktree_names...] --into [branchName]
 
@@ -400,7 +400,7 @@ After the wave loop ends (all stories processed or deadlock):
 ```
 # Remove any remaining worktrees (safety cleanup)
 $WORKTREE_MGR list
-# For each worktree matching "aimi-US-*":
+# For each worktree matching "[branchName]-US-*":
 $WORKTREE_MGR remove [worktree_name]
 ```
 


### PR DESCRIPTION
## Summary

- Replace hardcoded `aimi-` worktree branch prefix with `[branchName]-` so worktree branches are named after the task's feature branch (e.g., `feat/feature-name-US-001` instead of `aimi-US-001`)
- Bump version to 1.27.4
