### PR TITLE
ref: Add CLAUDE_CONFIG_DIR support and project-root access restriction

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and worktree+team orchestration.",
-      "version": "1.27.4",
+      "version": "1.27.5",
       "author": {
         "name": "Stanley Takamatsu",
         "url": "https://github.com/aimi-so"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and worktree+team orchestration.",
-      "version": "1.27.4",
+      "version": "1.28.0",
       "author": {
         "name": "Stanley Takamatsu",
         "url": "https://github.com/aimi-so"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **aimi-cli.sh**: New `_claude_config_dir()` helper that resolves the Claude config directory from `CLAUDE_CONFIG_DIR` env var, falling back to `~/.claude` -- validates the path is absolute when set, and strips trailing slashes
 - **aimi-cli.sh**: All hardcoded `~/.claude/plugins/cache/` glob patterns in `cmd_check_version()`, `cmd_cleanup_versions()`, and help text examples now use the resolved config dir variable, enabling custom config directory support
+- **test-aimi-cli.sh**: New test cases for `CLAUDE_CONFIG_DIR` support — validates custom config dir resolution, absolute path enforcement, and trailing slash stripping
+
+### Changed
+
+- **auto-approve-cli.sh**: Dynamic config dir resolution using `CONFIG_DIR_RE` alternation — auto-approve patterns now match both `~/.claude` and custom `CLAUDE_CONFIG_DIR` paths
+- **cli-path-resolution.md**: Parameterized CLI resolution example to use `${CLAUDE_CONFIG_DIR:-$HOME/.claude}` instead of hardcoded `~/.claude`
+- **execute.md**: Parameterized CLI path resolution to support custom config directories via `CLAUDE_CONFIG_DIR`
+- **swarm.md**: Parameterized CLI path resolution to support custom config directories via `CLAUDE_CONFIG_DIR`
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.27.5] - 2026-03-03
+
+### Security
+
+- **aimi-cli.sh**: Add `PROJECT_ROOT` export to `find_aimi_root()` — discovers git repository root and exports it for use by other functions
+- **aimi-cli.sh**: Add `validate_path_in_project()` function — validates resolved paths are under `PROJECT_ROOT` using realpath comparison, exits with clear error if path escapes project root
+- **aimi-cli.sh**: Add path validation to file operation functions (`read_state`, `write_state`, `clear_state_file`, `get_tasks_file`) — prevents directory traversal attacks
+- **story-executor/SKILL.md**: Add explicit project-root boundary guardrails — agents must not read or modify files outside the git repository root, worktree paths are explicitly allowed
+
 ## [1.27.4] - 2026-03-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.28.0] - 2026-03-03
+
+### Added
+
+- **aimi-cli.sh**: New `_claude_config_dir()` helper that resolves the Claude config directory from `CLAUDE_CONFIG_DIR` env var, falling back to `~/.claude` -- validates the path is absolute when set, and strips trailing slashes
+- **aimi-cli.sh**: All hardcoded `~/.claude/plugins/cache/` glob patterns in `cmd_check_version()`, `cmd_cleanup_versions()`, and help text examples now use the resolved config dir variable, enabling custom config directory support
+
 ## [1.27.4] - 2026-03-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ Commands use `aimi-cli.sh` (installed with the plugin) to extract only what's ne
 
 ```bash
 # Resolve CLI path (plugin install directory)
-AIMI_CLI=$(ls ~/.claude/plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh 2>/dev/null | tail -1)
+AIMI_CLI=$(ls "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh 2>/dev/null | tail -1)
 
 # /aimi:execute - initialize session with metadata
 $AIMI_CLI init-session
@@ -536,9 +536,15 @@ Invalid characters (spaces, semicolons, quotes) trigger validation errors.
 
 ## Version History
 
-**Current Version:** 1.27.4
+**Current Version:** 1.28.0
 
 ### Recent Changes
+
+**v1.28.0** - CLAUDE_CONFIG_DIR Support & Project-Root Security
+- New `_claude_config_dir()` helper supporting `CLAUDE_CONFIG_DIR` env var with `~/.claude` fallback
+- All CLI glob patterns, auto-approve hooks, and command markdown files parameterized for custom config directories
+- `PROJECT_ROOT` export and `validate_path_in_project()` guardrails prevent directory traversal
+- Story-executor agents restricted to git repository root boundary
 
 **v1.27.4** - Worktree Branch Prefix
 - Use task branch name as worktree branch prefix instead of hardcoded `aimi-`

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.27.4",
+  "version": "1.27.5",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi"

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.27.4",
+  "version": "1.28.0",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi"

--- a/plugins/aimi-engineering/commands/execute.md
+++ b/plugins/aimi-engineering/commands/execute.md
@@ -142,7 +142,7 @@ Beginning wave execution loop...
 ## Step 3.1: Resolve Worktree Manager
 
 ```bash
-WORKTREE_MGR=$(ls ~/.claude/plugins/cache/*/aimi-engineering/*/skills/git-worktree/scripts/worktree-manager.sh 2>/dev/null | tail -1)
+WORKTREE_MGR=$(ls ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/cache/*/aimi-engineering/*/skills/git-worktree/scripts/worktree-manager.sh 2>/dev/null | tail -1)
 ```
 
 If empty, report:

--- a/plugins/aimi-engineering/commands/references/cli-path-resolution.md
+++ b/plugins/aimi-engineering/commands/references/cli-path-resolution.md
@@ -8,7 +8,7 @@ Shared reference for resolving `$AIMI_CLI` across all commands. This file is the
 
 ```bash
 # Glob always finds the latest installed version
-AIMI_CLI=$(ls ~/.claude/plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh 2>/dev/null | tail -1)
+AIMI_CLI=$(ls ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh 2>/dev/null | tail -1)
 # Fallback to cached cli-path if glob found nothing (edge case)
 if [ -z "$AIMI_CLI" ] && [ -f .aimi/cli-path ] && [ -x "$(cat .aimi/cli-path)" ]; then
   AIMI_CLI=$(cat .aimi/cli-path)

--- a/plugins/aimi-engineering/commands/swarm.md
+++ b/plugins/aimi-engineering/commands/swarm.md
@@ -32,7 +32,7 @@ Resolve `$AIMI_CLI` path using glob discovery with fallback, then verify version
 ### Worktree Manager
 
 ```bash
-WORKTREE_MGR=$(ls ~/.claude/plugins/cache/*/aimi-engineering/*/skills/git-worktree/scripts/worktree-manager.sh 2>/dev/null | tail -1)
+WORKTREE_MGR=$(ls ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/cache/*/aimi-engineering/*/skills/git-worktree/scripts/worktree-manager.sh 2>/dev/null | tail -1)
 ```
 
 If empty, report: "worktree-manager.sh not found. Reinstall plugin: `/plugin install aimi-engineering`" and STOP.
@@ -260,12 +260,13 @@ TeamCreate({ team_name: "aimi-swarm" })
 5. **Build the Docker command** that will run inside the worker Task:
 
    ```bash
+   CLAUDE_DIR=${CLAUDE_CONFIG_DIR:-$HOME/.claude}
    docker run --rm \
      --label aimi-swarm \
      --name aimi-swarm-<slug> \
      --user $(id -u):$(id -g) \
      -v <WORKTREE_PATH>:/workspace \
-     -v ~/.claude:/home/user/.claude:ro \
+     -v $CLAUDE_DIR:/home/user/.claude:ro \
      -e ANTHROPIC_API_KEY \
      -e GITHUB_TOKEN \
      -w /workspace \

--- a/plugins/aimi-engineering/hooks/auto-approve-cli.sh
+++ b/plugins/aimi-engineering/hooks/auto-approve-cli.sh
@@ -12,6 +12,22 @@ fi
 
 ALLOW='{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"allow"}}}'
 
+# --- Resolve config directory for dynamic path matching ---
+# The hook receives literal command text BEFORE shell expansion.
+# Commands may reference the config dir as:
+#   1. ~/.claude                              (old/default form)
+#   2. ${CLAUDE_CONFIG_DIR:-$HOME/.claude}    (parameterized form)
+#   3. /absolute/path/.claude                 (resolved absolute path)
+# We build a regex alternation that matches any of these forms.
+RESOLVED_CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+# Remove trailing slash if present
+RESOLVED_CONFIG_DIR="${RESOLVED_CONFIG_DIR%/}"
+# Escape special regex characters in the resolved path (. / are the main ones)
+ESCAPED_CONFIG_DIR=$(printf '%s' "$RESOLVED_CONFIG_DIR" | sed 's/[.[\*^$()+?{|\\]/\\&/g; s/\//\\\//g')
+# Build the config dir regex alternation:
+#   ~\/.claude  |  \$\{CLAUDE_CONFIG_DIR:-\$HOME\/\.claude\}  |  /resolved/path
+CONFIG_DIR_RE="(~/\\.claude|\\\$\\{CLAUDE_CONFIG_DIR:-\\\$HOME/\\.claude\\}|${ESCAPED_CONFIG_DIR})"
+
 # --- Helper: Reject shell metacharacters ---
 # Returns 0 (true) if dangerous metacharacters are found after the variable reference.
 has_metacharacters() {
@@ -30,8 +46,9 @@ has_metacharacters() {
 
 # --- Pattern 1: AIMI_CLI= assignment ---
 # Validates the assigned path matches the expected plugin cache pattern.
+# Accepts config dir as ~/.claude, ${CLAUDE_CONFIG_DIR:-$HOME/.claude}, or resolved absolute path.
 if echo "$COMMAND" | grep -qE '^AIMI_CLI='; then
-  if echo "$COMMAND" | grep -qE '^AIMI_CLI=\$\(ls ~/.claude/plugins/cache/[a-zA-Z0-9_-]+/aimi-engineering/[0-9][a-zA-Z0-9._-]*/scripts/aimi-cli\.sh\)$'; then
+  if echo "$COMMAND" | grep -qE "^AIMI_CLI=\\$\\(ls ${CONFIG_DIR_RE}/plugins/cache/[a-zA-Z0-9_-]+/aimi-engineering/[0-9][a-zA-Z0-9._-]*/scripts/aimi-cli\\.sh\\)\$"; then
     echo "$ALLOW"
     exit 0
   fi
@@ -68,8 +85,9 @@ fi
 
 # --- Pattern 3: WORKTREE_MGR= assignment ---
 # Validates the assigned path matches the expected worktree manager plugin path.
+# Accepts config dir as ~/.claude, ${CLAUDE_CONFIG_DIR:-$HOME/.claude}, or resolved absolute path.
 if echo "$COMMAND" | grep -qE '^WORKTREE_MGR='; then
-  if echo "$COMMAND" | grep -qE '^WORKTREE_MGR=\$\(ls ~/.claude/plugins/cache/[a-zA-Z0-9_-]+/aimi-engineering/[0-9][a-zA-Z0-9._-]*/skills/git-worktree/scripts/worktree-manager\.sh\)$'; then
+  if echo "$COMMAND" | grep -qE "^WORKTREE_MGR=\\$\\(ls ${CONFIG_DIR_RE}/plugins/cache/[a-zA-Z0-9_-]+/aimi-engineering/[0-9][a-zA-Z0-9._-]*/skills/git-worktree/scripts/worktree-manager\\.sh\\)\$"; then
     echo "$ALLOW"
     exit 0
   fi

--- a/plugins/aimi-engineering/scripts/aimi-cli.sh
+++ b/plugins/aimi-engineering/scripts/aimi-cli.sh
@@ -120,13 +120,28 @@ clear_state_file() {
 }
 
 # Extract version string from an aimi-cli.sh path
-# Given: ~/.claude/plugins/cache/foo/aimi-engineering/1.4.0/scripts/aimi-cli.sh
+# Given: <config_dir>/plugins/cache/foo/aimi-engineering/1.4.0/scripts/aimi-cli.sh
 # Returns: 1.4.0
 _extract_version_from_path() {
   local path="$1"
   local no_script="${path%/*}"       # strip /aimi-cli.sh -> .../scripts
   local no_scripts="${no_script%/*}" # strip /scripts -> .../1.4.0
   printf '%s\n' "${no_scripts##*/}"  # strip prefix -> 1.4.0
+}
+
+# Resolve the Claude config directory.
+# Honors CLAUDE_CONFIG_DIR env var; falls back to ~/.claude.
+# When CLAUDE_CONFIG_DIR is set, validates it is an absolute path.
+# Always returns the path with any trailing slash stripped.
+_claude_config_dir() {
+  local dir="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+  # Validate absolute path when explicitly set
+  if [ -n "${CLAUDE_CONFIG_DIR:-}" ] && [ "${dir#/}" = "$dir" ]; then
+    echo "Error: CLAUDE_CONFIG_DIR must be an absolute path, got: $dir" >&2
+    exit 1
+  fi
+  # Strip trailing slash
+  printf '%s\n' "${dir%/}"
 }
 
 # Validate story ID format (US-NNN or US-NNNa)
@@ -760,9 +775,11 @@ cmd_check_version() {
   done
 
   local stored_path latest_path stored_version latest_version
+  local config_dir
+  config_dir=$(_claude_config_dir)
 
   # Resolve the latest installed path via glob
-  latest_path=$(ls ~/.claude/plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh 2>/dev/null | tail -1)
+  latest_path=$(ls "$config_dir"/plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh 2>/dev/null | tail -1)
 
   # Case: glob returns empty — no installed version found
   if [ -z "$latest_path" ]; then
@@ -814,14 +831,16 @@ cmd_check_version() {
 }
 
 # Remove old cached plugin version directories, keeping only the latest
-# Scans ~/.claude/plugins/cache/*/aimi-engineering/*/ for version dirs
+# Scans <config_dir>/plugins/cache/*/aimi-engineering/*/ for version dirs
 # Outputs JSON {"removed":<count>,"kept":"<version>"} to stdout
 cmd_cleanup_versions() {
   local latest_path latest_version latest_version_dir
   local removed=0
+  local config_dir
+  config_dir=$(_claude_config_dir)
 
   # Resolve the latest installed path via glob
-  latest_path=$(ls ~/.claude/plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh 2>/dev/null | tail -1)
+  latest_path=$(ls "$config_dir"/plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh 2>/dev/null | tail -1)
 
   # No installed versions found
   if [ -z "$latest_path" ]; then
@@ -835,7 +854,7 @@ cmd_cleanup_versions() {
 
   # Iterate all version directories under all marketplace cache entries
   local version_dir
-  for version_dir in ~/.claude/plugins/cache/*/aimi-engineering/*/; do
+  for version_dir in "$config_dir"/plugins/cache/*/aimi-engineering/*/; do
     # Strip trailing slash for clean comparison
     version_dir="${version_dir%/}"
 
@@ -908,9 +927,14 @@ STATE FILES (.aimi/):
     current-story             ID of story being executed
     last-result               Result of last execution (success/failed/skipped)
 
+ENVIRONMENT:
+    CLAUDE_CONFIG_DIR  Override Claude config directory (default: ~/.claude)
+                       Must be an absolute path when set.
+
 EXAMPLES:
-    # Resolve CLI path first
-    AIMI_CLI=$(ls ~/.claude/plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh 2>/dev/null | tail -1)
+    # Resolve CLI path first (honors CLAUDE_CONFIG_DIR)
+    CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+    AIMI_CLI=$(ls "$CONFIG_DIR"/plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh 2>/dev/null | tail -1)
 
     # Initialize a new session
     $AIMI_CLI init-session

--- a/plugins/aimi-engineering/scripts/aimi-cli.sh
+++ b/plugins/aimi-engineering/scripts/aimi-cli.sh
@@ -29,7 +29,8 @@ resolve_path() {
 }
 
 # Auto-discover the project root containing .aimi/ by walking up the directory tree.
-# On success: cd to the discovered root, rewrite AIMI_DIR and TASKS_DIR to absolute paths.
+# On success: cd to the discovered root, rewrite AIMI_DIR and TASKS_DIR to absolute paths,
+#             and export PROJECT_ROOT for use by other functions.
 # On failure (reached /): exit 1 with error to stderr.
 find_aimi_root() {
   local dir
@@ -39,6 +40,13 @@ find_aimi_root() {
       cd "$dir"
       AIMI_DIR="$dir/.aimi"
       TASKS_DIR="$AIMI_DIR/tasks"
+
+      # Discover the git repository root and export as PROJECT_ROOT
+      local git_root
+      git_root=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null) || git_root="$dir"
+      PROJECT_ROOT=$(resolve_path "$git_root")
+      export PROJECT_ROOT
+
       return 0
     fi
     local parent
@@ -50,6 +58,51 @@ find_aimi_root() {
     fi
     dir="$parent"
   done
+}
+
+# Validate that a given path resolves to a location within PROJECT_ROOT.
+# Worktree paths (under .worktrees/ inside PROJECT_ROOT) are explicitly allowed.
+# Usage: validate_path_in_project "/some/path"
+# Returns 0 if path is within PROJECT_ROOT, exits with error otherwise.
+validate_path_in_project() {
+  local target_path="$1"
+
+  if [ -z "$target_path" ]; then
+    echo "Error: validate_path_in_project requires a path argument" >&2
+    exit 1
+  fi
+
+  if [ -z "$PROJECT_ROOT" ]; then
+    echo "Error: PROJECT_ROOT is not set — call find_aimi_root() first" >&2
+    exit 1
+  fi
+
+  # Resolve the target path to its absolute form
+  local resolved_target
+  if [ -e "$target_path" ]; then
+    resolved_target=$(resolve_path "$target_path")
+  else
+    # For paths that don't exist yet, resolve the parent directory
+    local parent_dir
+    parent_dir=$(dirname "$target_path")
+    if [ -e "$parent_dir" ]; then
+      resolved_target="$(resolve_path "$parent_dir")/$(basename "$target_path")"
+    else
+      resolved_target="$target_path"
+    fi
+  fi
+
+  # Check if the resolved path is under PROJECT_ROOT
+  case "$resolved_target" in
+    "$PROJECT_ROOT"/*) return 0 ;;  # Under project root (includes .worktrees/)
+    "$PROJECT_ROOT")   return 0 ;;  # Exactly the project root
+    *)
+      echo "Error: Path escapes project root — access denied" >&2
+      echo "  Path:         $resolved_target" >&2
+      echo "  Project root: $PROJECT_ROOT" >&2
+      exit 1
+      ;;
+  esac
 }
 
 # Portable exclusive lock (Linux: flock, macOS: mkdir spinlock)
@@ -94,6 +147,7 @@ ensure_state_dir() {
 read_state() {
   local key="$1"
   local file="$AIMI_DIR/$key"
+  validate_path_in_project "$file"
   if [ -f "$file" ]; then
     cat "$file"
   fi
@@ -104,6 +158,7 @@ write_state() {
   local key="$1"
   local value="$2"
   ensure_state_dir
+  validate_path_in_project "$AIMI_DIR/$key"
   (
     _lock "$AIMI_DIR/.state.lock"
     echo "$value" > "$AIMI_DIR/$key"
@@ -113,6 +168,7 @@ write_state() {
 # Clear a single state file (flock-protected for parallel safety)
 clear_state_file() {
   local key="$1"
+  validate_path_in_project "$AIMI_DIR/$key"
   (
     _lock "$AIMI_DIR/.state.lock"
     rm -f "$AIMI_DIR/$key"
@@ -161,6 +217,7 @@ get_tasks_file() {
       exit 1
     fi
     tasks_file=$(resolve_path "$tasks_file")
+    validate_path_in_project "$tasks_file"
     echo "Warning: state file pointed to $stale_path which no longer exists. Using $tasks_file instead." >&2
     write_state "current-tasks" "$tasks_file"
   elif [ -z "$tasks_file" ]; then
@@ -170,6 +227,9 @@ get_tasks_file() {
       exit 1
     fi
     tasks_file=$(resolve_path "$tasks_file")
+    validate_path_in_project "$tasks_file"
+  else
+    validate_path_in_project "$tasks_file"
   fi
 
   echo "$tasks_file"
@@ -901,6 +961,11 @@ COMMANDS:
                               --fix    Auto-update cli-path on stale detection (exits 0)
     cleanup-versions          Remove old cached plugin versions, keep latest only
     help                      Show this help message
+
+ENVIRONMENT:
+    PROJECT_ROOT              Exported by find_aimi_root(); git repository root path
+                              All file operations are validated to stay within this boundary
+                              Worktree paths (.worktrees/ inside git root) are allowed
 
 STATE FILES (.aimi/):
     current-tasks             Path to active tasks file

--- a/plugins/aimi-engineering/scripts/test-aimi-cli.sh
+++ b/plugins/aimi-engineering/scripts/test-aimi-cli.sh
@@ -165,6 +165,13 @@ assert_stderr_contains() {
   fi
 }
 
+# Helper: resolve the Claude config directory exactly as the CLI does.
+# Honors CLAUDE_CONFIG_DIR, falls back to $HOME/.claude, strips trailing slash.
+_test_claude_config_dir() {
+  local dir="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+  printf '%s\n' "${dir%/}"
+}
+
 # ============================================================================
 # General Tests
 # ============================================================================
@@ -697,8 +704,9 @@ test_check_version() {
 
   # --- Test 1: Current version (stored cli-path matches glob-resolved latest) ---
   # Write cli-path to exactly match what the glob resolves, so check-version sees "current"
-  local latest_glob_path
-  latest_glob_path=$(ls ~/.claude/plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh 2>/dev/null | tail -1)
+  local latest_glob_path config_dir
+  config_dir=$(_test_claude_config_dir)
+  latest_glob_path=$(ls "$config_dir"/plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh 2>/dev/null | tail -1)
 
   local output exit_code
 
@@ -753,8 +761,9 @@ test_check_version_fix() {
   "$CLI" clear-state > /dev/null
   "$CLI" init-session > /dev/null
 
-  local latest_glob_path
-  latest_glob_path=$(ls ~/.claude/plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh 2>/dev/null | tail -1)
+  local latest_glob_path config_dir
+  config_dir=$(_test_claude_config_dir)
+  latest_glob_path=$(ls "$config_dir"/plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh 2>/dev/null | tail -1)
 
   if [ -z "$latest_glob_path" ]; then
     echo "  (skipping --fix test: no installed version in cache)"
@@ -788,8 +797,9 @@ test_check_version_quiet_fix() {
   "$CLI" clear-state > /dev/null
   "$CLI" init-session > /dev/null
 
-  local latest_glob_path
-  latest_glob_path=$(ls ~/.claude/plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh 2>/dev/null | tail -1)
+  local latest_glob_path config_dir
+  config_dir=$(_test_claude_config_dir)
+  latest_glob_path=$(ls "$config_dir"/plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh 2>/dev/null | tail -1)
 
   if [ -z "$latest_glob_path" ]; then
     echo "  (skipping --quiet --fix test: no installed version in cache)"
@@ -836,8 +846,9 @@ test_check_version_backward_compat() {
   assert_contains "No stored cli-path" "$stderr_content" "check-version (no flags): stderr contains warning"
 
   # Test 2: No flags, current version => "current" status
-  local latest_glob_path
-  latest_glob_path=$(ls ~/.claude/plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh 2>/dev/null | tail -1)
+  local latest_glob_path config_dir
+  config_dir=$(_test_claude_config_dir)
+  latest_glob_path=$(ls "$config_dir"/plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh 2>/dev/null | tail -1)
 
   if [ -n "$latest_glob_path" ]; then
     "$CLI" init-session > /dev/null
@@ -885,6 +896,58 @@ test_cleanup_versions() {
   # Validate JSON output format has both keys
   assert_contains '"removed"' "$output" "cleanup-versions: output contains removed key"
   assert_contains '"kept"' "$output" "cleanup-versions: output contains kept key"
+}
+
+# ============================================================================
+# CLAUDE_CONFIG_DIR Tests
+# ============================================================================
+
+test_claude_config_dir_default() {
+  echo ""
+  echo "=== Testing _claude_config_dir: unset falls back to \$HOME/.claude ==="
+
+  # Source only the _claude_config_dir function from the CLI script
+  eval "$(sed -n '/^_claude_config_dir()/,/^}/p' "$CLI")"
+
+  # Ensure CLAUDE_CONFIG_DIR is unset
+  local result
+  result=$(unset CLAUDE_CONFIG_DIR; _claude_config_dir)
+
+  assert_eq "$HOME/.claude" "$result" "_claude_config_dir: unset CLAUDE_CONFIG_DIR falls back to \$HOME/.claude"
+}
+
+test_claude_config_dir_custom_absolute() {
+  echo ""
+  echo "=== Testing _claude_config_dir: custom absolute path resolves correctly ==="
+
+  # Source only the _claude_config_dir function from the CLI script
+  eval "$(sed -n '/^_claude_config_dir()/,/^}/p' "$CLI")"
+
+  # Test with a custom absolute path
+  local result
+  result=$(CLAUDE_CONFIG_DIR="/tmp/custom-claude" _claude_config_dir)
+
+  assert_eq "/tmp/custom-claude" "$result" "_claude_config_dir: custom absolute path resolves correctly"
+
+  # Test that trailing slash is stripped
+  result=$(CLAUDE_CONFIG_DIR="/tmp/custom-claude/" _claude_config_dir)
+
+  assert_eq "/tmp/custom-claude" "$result" "_claude_config_dir: trailing slash is stripped from custom path"
+}
+
+test_claude_config_dir_relative_path_error() {
+  echo ""
+  echo "=== Testing _claude_config_dir: relative path produces validation error ==="
+
+  # Source only the _claude_config_dir function from the CLI script
+  eval "$(sed -n '/^_claude_config_dir()/,/^}/p' "$CLI")"
+
+  # Test with a relative path — should produce an error on stderr and exit non-zero
+  local stderr_output exit_code
+  stderr_output=$(CLAUDE_CONFIG_DIR="relative/path" _claude_config_dir 2>&1 >/dev/null) && exit_code=0 || exit_code=$?
+
+  assert_contains "must be an absolute path" "$stderr_output" "_claude_config_dir: relative path produces error message"
+  assert_exit_code "1" "$exit_code" "_claude_config_dir: relative path exits with code 1"
 }
 
 # ============================================================================
@@ -1371,6 +1434,13 @@ main() {
   test_check_version_quiet_fix
   test_check_version_backward_compat
   test_cleanup_versions
+
+  # CLAUDE_CONFIG_DIR tests
+  echo ""
+  echo "--- CLAUDE_CONFIG_DIR Tests ---"
+  test_claude_config_dir_default
+  test_claude_config_dir_custom_absolute
+  test_claude_config_dir_relative_path_error
 
   # Auto-discovery tests
   echo ""

--- a/plugins/aimi-engineering/skills/story-executor/SKILL.md
+++ b/plugins/aimi-engineering/skills/story-executor/SKILL.md
@@ -39,6 +39,19 @@ The agent spawns fresh with no memory of previous work. If the story is too big,
 
 ---
 
+## Project Root Boundary (CRITICAL)
+
+**Agents must NOT read or modify files outside the git repository root.**
+
+- All file operations (Read, Write, Edit, Bash) must target paths within the project root directory
+- The project root is the git repository root (where `.git/` lives)
+- Worktree paths under `.worktrees/` inside the git root are explicitly allowed
+- Never use `../` traversal to escape the project root
+- Never read system files, home directory configs, or files in parent directories
+- If a task seems to require accessing files outside the project root, report failure instead of proceeding
+
+---
+
 ## Prompt Template
 
 > This is the canonical worker prompt template. execute.md and next.md should reference this skill rather than duplicating the prompt inline.
@@ -86,6 +99,14 @@ Description: [STORY_DESCRIPTION]
 Use built-in tools directly: Read, Write, Edit, Bash, Grep, Glob.
 Do NOT invoke these via the Skill tool — "write" is a Write tool, not a skill.
 
+## Project Root Boundary (CRITICAL)
+
+All file operations MUST stay within the git repository root directory.
+- Do NOT read or modify files outside the project root
+- Worktree paths (.worktrees/ inside git root) are allowed
+- Never use ../ traversal to escape the project root
+- If a task requires accessing external files, report failure instead
+
 ## Execution Flow
 
 0. If WORKTREE_PATH is set, cd to WORKTREE_PATH
@@ -126,6 +147,7 @@ If you cannot complete a story:
 
 Before completing a story:
 
+- [ ] All file operations stayed within project root (no parent directory access)
 - [ ] All acceptance criteria verified
 - [ ] Typecheck passes (`npx tsc --noEmit`)
 - [ ] Changes committed with proper format


### PR DESCRIPTION
## Summary

- Add `CLAUDE_CONFIG_DIR` env var support across all plugin scripts, commands, and hooks — falls back silently to `~/.claude` when unset
- Add project-root access restriction with prompt guardrails in story-executor and `validate_path_in_project()` enforcement in aimi-cli.sh
- Update auto-approve hook with dynamic config dir resolution (accepts `~/.claude`, `${CLAUDE_CONFIG_DIR:-$HOME/.claude}`, and resolved absolute paths)

## Changes

### CLAUDE_CONFIG_DIR support
- **aimi-cli.sh**: New `_claude_config_dir()` helper — resolves config dir, validates absolute path, strips trailing slashes
- **auto-approve-cli.sh**: Dynamic `CONFIG_DIR_RE` regex alternation replaces hardcoded `~/.claude` patterns
- **cli-path-resolution.md, execute.md, swarm.md**: All glob paths and Docker volume mounts parameterized
- **test-aimi-cli.sh**: 3 new test cases (default fallback, custom absolute path, relative path error)

### Project-root restriction
- **aimi-cli.sh**: `PROJECT_ROOT` export in `find_aimi_root()`, `validate_path_in_project()` function, path validation in `read_state`, `write_state`, `clear_state_file`, `get_tasks_file`
- **story-executor/SKILL.md**: Explicit "Project Root Boundary" guardrail in both skill docs and agent prompt template
