### PR TITLE
fix: enforce Ralph-style user story descriptions in task generation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and worktree+team orchestration.",
-      "version": "1.28.0",
+      "version": "1.28.1",
       "author": {
         "name": "Stanley Takamatsu",
         "url": "https://github.com/aimi-so"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.28.1] - 2026-03-03
+
+### Fixed
+
+- **task-format-v3.md**: Enforce specific role in user story descriptions — `[user]` replaced with `[specific role]` with examples (e.g., "store admin", "developer"), preventing generic "As a user" descriptions
+- **story-decomposition.md**: Add "Description Format" section with required format, good/bad examples, and 500-char limit
+- **task-planner/SKILL.md**: Add description format step to Phase 3 story decomposition and checklist validation
+- **plan.md**: Add description format step to Phase 3 story decomposition and checklist validation
+
 ## [1.28.0] - 2026-03-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -536,9 +536,13 @@ Invalid characters (spaces, semicolons, quotes) trigger validation errors.
 
 ## Version History
 
-**Current Version:** 1.28.0
+**Current Version:** 1.28.1
 
 ### Recent Changes
+
+**v1.28.1** - Enforce Ralph-style User Story Descriptions
+- Task generation now enforces "As a [specific role], I want [feature] so that [benefit]" format
+- Description format rules added to schema spec, story decomposition, task-planner skill, and plan command
 
 **v1.28.0** - CLAUDE_CONFIG_DIR Support & Project-Root Security
 - New `_claude_config_dir()` helper supporting `CLAUDE_CONFIG_DIR` env var with `~/.claude` fallback

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi"

--- a/plugins/aimi-engineering/commands/plan.md
+++ b/plugins/aimi-engineering/commands/plan.md
@@ -87,9 +87,10 @@ Using consolidated research and spec-flow output:
 2. Group by layer (schema → backend → UI → aggregation)
 3. Size check: each story must be completable in ONE agent iteration (one context window)
 4. Order by dependency: assign `dependsOn` arrays (explicit story IDs) and `priority` as tiebreaker
-5. Generate verifiable acceptance criteria (every story must have "Typecheck passes")
-6. Initialize every story with `status: "pending"` and appropriate `dependsOn` array
-7. Validate: no circular dependencies in `dependsOn`, no self-references, all referenced IDs exist, no vague criteria
+5. Write descriptions in user story format: "As a [specific role], I want [feature] so that [benefit]" — role must name the actor, never just "user"
+6. Generate verifiable acceptance criteria (every story must have "Typecheck passes")
+7. Initialize every story with `status: "pending"` and appropriate `dependsOn` array
+8. Validate: no circular dependencies in `dependsOn`, no self-references, all referenced IDs exist, no vague criteria
 
 See `references/story-decomposition.md` for detailed rules.
 
@@ -145,6 +146,7 @@ Write JSON using the Write tool. Validate JSON is well-formed before writing.
 - [ ] `dependsOn` is `[]` for root stories with no upstream dependencies
 - [ ] branchName is valid (alphanumeric, hyphens, slashes)
 - [ ] `planPath` is `null`
+- [ ] Every description follows "As a [specific role], I want [feature] so that [benefit]" format — role names the actor, never just "user"
 - [ ] Field lengths: title ≤ 200, description ≤ 500, criterion ≤ 600
 
 ## Step 5: Aimi-Branded Report

--- a/plugins/aimi-engineering/skills/task-planner/SKILL.md
+++ b/plugins/aimi-engineering/skills/task-planner/SKILL.md
@@ -103,8 +103,9 @@ Apply rules from `references/story-decomposition.md`:
    - **Same layer, shared concern** (FK referencing another story's table) → add dependency
    - **Cross-layer**: backend depends on schema stories it reads/writes; UI depends on backend it calls; aggregation depends on what it consumes
    - **Skip layers when appropriate**: UI reading directly from a new table depends on the schema story, not a non-existent backend story
-6. Generate verifiable acceptance criteria
-7. Validate dependency graph:
+6. Write descriptions in user story format: "As a [specific role], I want [feature] so that [benefit]" — role must name the actor, never just "user"
+7. Generate verifiable acceptance criteria
+8. Validate dependency graph:
    - No circular dependencies (DAG check)
    - No self-references (no story lists its own ID)
    - All IDs referenced in `dependsOn` exist as story IDs
@@ -147,6 +148,7 @@ See `references/task-format-v3.md` for the complete v3 schema definition, status
 - [ ] Acceptance criteria are verifiable (not vague)
 - [ ] branchName is valid (alphanumeric, hyphens, slashes)
 - [ ] `planPath` is `null`
+- [ ] Every description follows "As a [specific role], I want [feature] so that [benefit]" format — role names the actor, never just "user"
 - [ ] Field lengths: title ≤ 200, description ≤ 500, criterion ≤ 600
 
 ### v3 Schema Validations

--- a/plugins/aimi-engineering/skills/task-planner/references/story-decomposition.md
+++ b/plugins/aimi-engineering/skills/task-planner/references/story-decomposition.md
@@ -209,6 +209,32 @@ Each criterion must be something the agent can CHECK, not something vague.
 
 ---
 
+## Description Format
+
+Every story description **must** follow the user story format:
+
+```
+As a [specific role], I want [feature] so that [benefit]
+```
+
+### Rules
+
+- **`[specific role]`** must name the actor — never use the generic word "user"
+- Identify the role from the feature context (who benefits from or interacts with this change)
+- Keep under 500 characters
+
+### Good descriptions:
+- "As a store admin, I want to export orders so that I can reconcile monthly revenue"
+- "As a plugin developer, I want CLI path resolution to use CLAUDE_CONFIG_DIR so that custom config locations are supported"
+- "As an API consumer, I want paginated responses so that I can handle large datasets efficiently"
+
+### Bad descriptions:
+- "As a user, I want to export orders" (generic role, missing benefit)
+- "Add export functionality" (not user story format)
+- "Implement the orders export feature for admins" (missing structure)
+
+---
+
 ## Conversion Rules
 
 1. Each requirement becomes one or more JSON stories

--- a/plugins/aimi-engineering/skills/task-planner/references/task-format-v3.md
+++ b/plugins/aimi-engineering/skills/task-planner/references/task-format-v3.md
@@ -60,7 +60,7 @@ Each story is ONE atomic unit of work completable in a single agent iteration.
 |-------|------|----------|---------|-------------|
 | `id` | string | Yes | — | Unique identifier. **Must follow `US-NNN` format** (e.g., `US-001`, `US-002`). Three zero-padded digits, optionally followed by a lowercase letter for sub-stories (e.g., `US-001a`). |
 | `title` | string | Yes | — | Short story title (max 200 chars) |
-| `description` | string | Yes | — | User story format: "As a [user], I want [feature] so that [benefit]" (max 500 chars) |
+| `description` | string | Yes | — | User story format: "As a [specific role], I want [feature] so that [benefit]" — role must name the actor (e.g., "store admin", "developer", "end user"), never just "user" (max 500 chars) |
 | `acceptanceCriteria` | string[] | Yes | — | Verifiable criteria (must include `"Typecheck passes"`, each max 600 chars) |
 | `priority` | number | Yes | — | Tiebreaker for stories at the same dependency depth. Lower = runs first among peers. |
 | `status` | string | Yes | `"pending"` | One of: `"pending"`, `"in_progress"`, `"completed"`, `"failed"`, `"skipped"` |


### PR DESCRIPTION
## Summary

- Enforce "As a [specific role], I want [feature] so that [benefit]" format across all task generation touchpoints
- Add description format rules, good/bad examples, and checklist validation to schema spec, story decomposition, task-planner skill, and plan command
- Bump version to 1.28.1

## Changed Files

- `task-format-v3.md` — Updated `description` field spec to require specific role instead of generic "user"
- `story-decomposition.md` — Added "Description Format" section with rules and examples
- `task-planner/SKILL.md` — Added description format step to Phase 3 and checklist item
- `commands/plan.md` — Added description format step to Phase 3 and checklist item
- Version bump to 1.28.1, CHANGELOG and README updated
