### PR TITLE
Fix story ID format enforcement and add CLAUDE_CONFIG_DIR support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and worktree+team orchestration.",
-      "version": "1.28.1",
+      "version": "1.28.2",
       "author": {
         "name": "Stanley Takamatsu",
         "url": "https://github.com/aimi-so"

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .worktrees
+.aimi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.28.2] - 2026-03-04
+
+### Fixed
+
+- **plan.md**: Add explicit US-NNN ID format step to Phase 3 story decomposition and checklist — LLM now sees the format requirement before generating IDs, not just in reference docs
+- **task-planner/SKILL.md**: Add US-NNN ID format step to Phase 3 between dependency assignment and description writing
+- **pipeline-phases.md**: Add US-NNN ID format to Phase 3 and Phase 4 metadata derivation
+- **story-decomposition.md**: Strengthen ID format with explicit zero-padding language, regex pattern, and negative examples (US-1, story-1, S1, F1)
+
+### Added
+
+- **aimi-cli.sh**: New `validate-ids` command — validates all story IDs in a tasks file match `^US-[0-9]{3}[a-z]?$` regex, returns JSON with valid/count or errors array
+- **plan.md**: Phase 4.5 post-generation validation step — runs `validate-ids` and `validate-deps` after writing tasks.json, with fix-and-rewrite loop if validation fails
+- **task-planner/SKILL.md**: Matching Phase 4.5 post-generation validation step
+
 ## [1.28.1] - 2026-03-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -544,6 +544,12 @@ Invalid characters (spaces, semicolons, quotes) trigger validation errors.
 - Task generation now enforces "As a [specific role], I want [feature] so that [benefit]" format
 - Description format rules added to schema spec, story decomposition, task-planner skill, and plan command
 
+**v1.28.2** - US-NNN ID Format Enforcement & Post-Generation Validation
+- Add US-NNN format step to Phase 3 in plan.md, SKILL.md, pipeline-phases.md — LLM sees format before generating IDs
+- Strengthen story-decomposition.md with zero-padding language and negative examples
+- New `validate-ids` CLI command checks all story IDs at once
+- Phase 4.5 post-generation validation runs `validate-ids` + `validate-deps` after writing tasks.json
+
 **v1.28.0** - CLAUDE_CONFIG_DIR Support & Project-Root Security
 - New `_claude_config_dir()` helper supporting `CLAUDE_CONFIG_DIR` env var with `~/.claude` fallback
 - All CLI glob patterns, auto-approve hooks, and command markdown files parameterized for custom config directories

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.28.1",
+  "version": "1.28.2",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi"

--- a/plugins/aimi-engineering/commands/plan.md
+++ b/plugins/aimi-engineering/commands/plan.md
@@ -151,6 +151,30 @@ Write JSON using the Write tool. Validate JSON is well-formed before writing.
 - [ ] Every description follows "As a [specific role], I want [feature] so that [benefit]" format — role names the actor, never just "user"
 - [ ] Field lengths: title ≤ 200, description ≤ 500, criterion ≤ 600
 
+## Phase 4.5: Post-Generation Validation
+
+After writing the tasks.json file, validate the generated output using the CLI:
+
+### Validate Story IDs
+
+```bash
+$AIMI_CLI validate-ids
+```
+
+### Validate Dependency Graph
+
+```bash
+$AIMI_CLI validate-deps
+```
+
+**If either validation fails (non-zero exit):**
+1. Read the error output to identify the issues
+2. Fix the offending story IDs, `dependsOn` references, or dependency cycles
+3. Re-write the tasks.json file using the Write tool
+4. Re-run both validations until they pass
+
+Do **not** proceed to the report step until both validations succeed.
+
 ## Step 5: Aimi-Branded Report
 
 ```

--- a/plugins/aimi-engineering/commands/plan.md
+++ b/plugins/aimi-engineering/commands/plan.md
@@ -85,12 +85,13 @@ Using consolidated research and spec-flow output:
 
 1. Extract all requirements (explicit + spec-flow identified)
 2. Group by layer (schema → backend → UI → aggregation)
-3. Size check: each story must be completable in ONE agent iteration (one context window)
-4. Order by dependency: assign `dependsOn` arrays (explicit story IDs) and `priority` as tiebreaker
-5. Write descriptions in user story format: "As a [specific role], I want [feature] so that [benefit]" — role must name the actor, never just "user"
-6. Generate verifiable acceptance criteria (every story must have "Typecheck passes")
-7. Initialize every story with `status: "pending"` and appropriate `dependsOn` array
-8. Validate: no circular dependencies in `dependsOn`, no self-references, all referenced IDs exist, no vague criteria
+3. Assign IDs in `US-NNN` zero-padded format (`US-001`, `US-002`, ...) — never `US-1`, `story-1`, `S1`, or any other format
+4. Size check: each story must be completable in ONE agent iteration (one context window)
+5. Order by dependency: assign `dependsOn` arrays (explicit story IDs) and `priority` as tiebreaker
+6. Write descriptions in user story format: "As a [specific role], I want [feature] so that [benefit]" — role must name the actor, never just "user"
+7. Generate verifiable acceptance criteria (every story must have "Typecheck passes")
+8. Initialize every story with `status: "pending"` and appropriate `dependsOn` array
+9. Validate: no circular dependencies in `dependsOn`, no self-references, all referenced IDs exist, no vague criteria
 
 See `references/story-decomposition.md` for detailed rules.
 
@@ -136,6 +137,7 @@ Write JSON using the Write tool. Validate JSON is well-formed before writing.
 
 ### Checklist Before Writing
 
+- [ ] Every story `id` uses `US-NNN` zero-padded format (`US-001`, `US-002`, ...) — not `US-1`, `S1`, `TASK-1`, or any other format
 - [ ] Each story completable in one agent iteration
 - [ ] Stories ordered by dependency (schema → backend → UI)
 - [ ] Every story has "Typecheck passes" as criterion

--- a/plugins/aimi-engineering/scripts/aimi-cli.sh
+++ b/plugins/aimi-engineering/scripts/aimi-cli.sh
@@ -682,6 +682,33 @@ cmd_validate_stories() {
   ' "$tasks_file"
 }
 
+# Validate all story IDs in the tasks file against the US-NNN format
+cmd_validate_ids() {
+  local tasks_file
+  tasks_file=$(get_tasks_file)
+
+  local ids errors=() count=0
+  ids=$(jq -r '.userStories[].id' "$tasks_file")
+
+  while IFS= read -r id; do
+    [ -z "$id" ] && continue
+    count=$((count + 1))
+    if ! [[ "$id" =~ ^US-[0-9]{3}[a-z]?$ ]]; then
+      errors+=("Invalid story ID: $id (expected US-NNN)")
+    fi
+  done <<< "$ids"
+
+  if [ ${#errors[@]} -eq 0 ]; then
+    jq -n --argjson count "$count" '{valid: true, count: $count}'
+    return 0
+  else
+    local errors_json
+    errors_json=$(printf '%s\n' "${errors[@]}" | jq -R . | jq -s .)
+    jq -n --argjson errors "$errors_json" '{valid: false, errors: $errors}'
+    return 1
+  fi
+}
+
 # Cascade skip: given a failed story ID, mark all transitively-dependent stories as skipped
 cmd_cascade_skip() {
   local failed_id="$1"
@@ -968,6 +995,7 @@ COMMANDS:
     count-pending             Count pending stories
     validate-deps             Validate dependency graph (no cycles, no missing refs)
     validate-stories          Validate story content (length, suspicious patterns)
+    validate-ids              Validate all story IDs match US-NNN format
     cascade-skip <id>         Skip all stories depending on failed story
     reset-orphaned            Reset all in_progress stories to failed
     get-branch                Get branchName from metadata
@@ -1061,6 +1089,7 @@ main() {
     count-pending)     cmd_count_pending ;;
     validate-deps)     cmd_validate_deps ;;
     validate-stories)  cmd_validate_stories ;;
+    validate-ids)      cmd_validate_ids ;;
     cascade-skip)      cmd_cascade_skip "${2:-}" ;;
     reset-orphaned)    cmd_reset_orphaned ;;
     get-branch)        cmd_get_branch ;;

--- a/plugins/aimi-engineering/skills/task-planner/SKILL.md
+++ b/plugins/aimi-engineering/skills/task-planner/SKILL.md
@@ -124,6 +124,23 @@ Apply rules from `references/story-decomposition.md`:
 
 See `references/task-format-v3.md` for the complete v3 schema definition, status state machine, and validation rules.
 
+### Phase 4.5: Post-Generation Validation
+
+After writing the tasks.json file, validate the generated output:
+
+```bash
+$AIMI_CLI validate-ids
+$AIMI_CLI validate-deps
+```
+
+**If either validation fails (non-zero exit):**
+1. Read the error output to identify the issues
+2. Fix the offending story IDs, `dependsOn` references, or dependency cycles
+3. Re-write the tasks.json file using the Write tool
+4. Re-run both validations until they pass
+
+Do **not** proceed to the report step until both validations succeed.
+
 ---
 
 ## Error Handling

--- a/plugins/aimi-engineering/skills/task-planner/SKILL.md
+++ b/plugins/aimi-engineering/skills/task-planner/SKILL.md
@@ -103,9 +103,10 @@ Apply rules from `references/story-decomposition.md`:
    - **Same layer, shared concern** (FK referencing another story's table) → add dependency
    - **Cross-layer**: backend depends on schema stories it reads/writes; UI depends on backend it calls; aggregation depends on what it consumes
    - **Skip layers when appropriate**: UI reading directly from a new table depends on the schema story, not a non-existent backend story
-6. Write descriptions in user story format: "As a [specific role], I want [feature] so that [benefit]" — role must name the actor, never just "user"
-7. Generate verifiable acceptance criteria
-8. Validate dependency graph:
+6. Assign IDs in `US-NNN` zero-padded format (`US-001`, `US-002`, ...) — never `US-1`, `story-1`, `S1`, or any other format
+7. Write descriptions in user story format: "As a [specific role], I want [feature] so that [benefit]" — role must name the actor, never just "user"
+8. Generate verifiable acceptance criteria
+9. Validate dependency graph:
    - No circular dependencies (DAG check)
    - No self-references (no story lists its own ID)
    - All IDs referenced in `dependsOn` exist as story IDs

--- a/plugins/aimi-engineering/skills/task-planner/references/pipeline-phases.md
+++ b/plugins/aimi-engineering/skills/task-planner/references/pipeline-phases.md
@@ -184,10 +184,11 @@ Using the consolidated research and spec-flow output:
 
 1. Extract all requirements (explicit + spec-flow identified)
 2. Group by layer (schema → backend → UI → aggregation)
-3. Apply sizing rules (one context window per story)
-4. Assign priority numbers by dependency order
-5. Generate verifiable acceptance criteria per story
-6. Run validation checklist
+3. Assign IDs in `US-NNN` zero-padded format (`US-001`, `US-002`, ...) — never `US-1`, `story-1`, `S1`, or any other format
+4. Apply sizing rules (one context window per story)
+5. Assign priority numbers by dependency order
+6. Generate verifiable acceptance criteria per story
+7. Run validation checklist
 
 ---
 
@@ -201,6 +202,7 @@ Using the consolidated research and spec-flow output:
 - **createdAt**: Today's date (YYYY-MM-DD)
 - **planPath**: Always `null`
 - **brainstormPath**: Path to brainstorm if one was used, otherwise omit
+- **Story IDs**: Must use `US-NNN` zero-padded format (`US-001`, `US-002`, ...) — never `US-1`, `story-1`, `S1`, or any other format
 
 ### Derive Filename
 

--- a/plugins/aimi-engineering/skills/task-planner/references/story-decomposition.md
+++ b/plugins/aimi-engineering/skills/task-planner/references/story-decomposition.md
@@ -238,7 +238,9 @@ As a [specific role], I want [feature] so that [benefit]
 ## Conversion Rules
 
 1. Each requirement becomes one or more JSON stories
-2. **IDs**: Sequential — `US-001`, `US-002`, etc.
+2. **IDs**: Sequential — `US-001`, `US-002`, etc. The numeric portion is **zero-padded to 3 digits** (e.g., `001`, `012`, `099`). IDs must match the regex `^US-\d{3}$`.
+   - **Valid**: `US-001`, `US-012`, `US-100`
+   - **Invalid**: `US-1`, `US-01`, `story-1`, `S1`, `F1`, `US-1234` (no abbreviations, no missing padding, no alternative prefixes, no more than 3 digits)
 3. **Priority**: Based on dependency order (lower = executes first)
 4. **All stories**: `status: "pending"` and empty `notes`
 5. **branchName**: Derive from feature name, kebab-case, prefixed with type
@@ -285,7 +287,7 @@ Before finalizing stories, verify:
 - [ ] Every story has "Typecheck passes" as criterion
 - [ ] UI stories have "Verify in browser" as criterion
 - [ ] Acceptance criteria are verifiable (not vague)
-- [ ] IDs are sequential (US-001, US-002, ...)
+- [ ] IDs are sequential, zero-padded to 3 digits, and match `^US-\d{3}$` (e.g., `US-001`, `US-002`). Reject: `US-1`, `story-1`, `S1`, `F1`
 - [ ] Field lengths within limits (title ≤ 200, description ≤ 500, criterion ≤ 600)
 - [ ] branchName matches validation regex
 


### PR DESCRIPTION
## Summary

- Fix story ID generation to enforce `US-NNN` zero-padded format by surfacing the requirement directly in LLM-facing prompts (Phase 3), adding negative examples, regex patterns, and a post-generation `validate-ids` validation step
- Enforce Ralph-style user story descriptions (`As a [specific role]...`) preventing generic "As a user" patterns
- Add `CLAUDE_CONFIG_DIR` environment variable support across CLI, hooks, commands, and tests — replaces hardcoded `~/.claude` paths
- Add project-root access restriction guardrails to prevent directory traversal in file operations

## Changes

### Bug fixes (v1.28.1–v1.28.2)
- Add `US-NNN` ID format instructions to `plan.md`, `SKILL.md`, `pipeline-phases.md`, and `story-decomposition.md`
- New `validate-ids` CLI command with regex-based validation
- Post-generation validation step (Phase 4.5) that runs `validate-ids` + `validate-deps` after writing `tasks.json`
- Enforce specific-role user story descriptions in task format spec and decomposition rules

### Refactor (v1.28.0)
- New `_claude_config_dir()` helper resolving `CLAUDE_CONFIG_DIR` with fallback to `~/.claude`
- Parameterized config paths in `execute.md`, `swarm.md`, `cli-path-resolution.md`, and `auto-approve-cli.sh`
- `validate_path_in_project()` guardrail preventing path escape from git root
- Updated tests for custom config dir resolution

## Test plan
- [ ] Run `aimi validate-ids` against a tasks.json with valid and invalid IDs
- [ ] Verify `CLAUDE_CONFIG_DIR=/custom/path aimi check-version` resolves correctly
- [ ] Run `test-aimi-cli.sh` to confirm new test cases pass
- [ ] Generate a new tasks.json via `/aimi:plan` and verify all story IDs match `US-NNN` format
