### PR TITLE
Fix CLI path resolution with three-layer cache fallback

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and worktree+team orchestration.",
-      "version": "1.28.3",
+      "version": "1.28.4",
       "author": {
         "name": "Stanley Takamatsu",
         "url": "https://github.com/aimi-so"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and worktree+team orchestration.",
-      "version": "1.28.4",
+      "version": "1.29.0",
       "author": {
         "name": "Stanley Takamatsu",
         "url": "https://github.com/aimi-so"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and worktree+team orchestration.",
-      "version": "1.28.2",
+      "version": "1.28.3",
       "author": {
         "name": "Stanley Takamatsu",
         "url": "https://github.com/aimi-so"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.28.3] - 2026-03-06
+
+### Fixed
+
+- **cli-path-resolution.md**: Rewrite CLI resolution with three-layer strategy (global cache, zsh-safe glob fallback, per-project fallback) for reliable path discovery across shells and plugin updates
+- **cli-path-resolution.md**: Add equivalent WORKTREE_MGR three-layer resolution section
+- **cli-path-resolution.md**: Structure resolution as sequential commands (no compound && or ||) for auto-approve hook compatibility
+
 ## [1.28.2] - 2026-03-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.28.4] - 2026-03-06
+
+### Fixed
+
+- **auto-approve-cli.sh**: Add auto-approve patterns for three-layer CLI resolution commands (cache read via `cat`, Layer 1 validation, Layer 2 `bash -c` glob fallback, Layer 2 cache write via `printf`/`mv`/`chmod`, Layer 3 per-project fallback)
+
 ## [1.28.3] - 2026-03-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.28.4] - 2026-03-06
+## [1.29.0] - 2026-03-06
 
-### Fixed
+### Changed
 
-- **auto-approve-cli.sh**: Add auto-approve patterns for three-layer CLI resolution commands (cache read via `cat`, Layer 1 validation, Layer 2 `bash -c` glob fallback, Layer 2 cache write via `printf`/`mv`/`chmod`, Layer 3 per-project fallback)
-
-## [1.28.3] - 2026-03-06
-
-### Fixed
-
-- **cli-path-resolution.md**: Rewrite CLI resolution with three-layer strategy (global cache, zsh-safe glob fallback, per-project fallback) for reliable path discovery across shells and plugin updates
+- **cli-path-resolution.md**: Rewrite CLI resolution with three-layer strategy — global cache, zsh-safe glob fallback, per-project fallback — for reliable path discovery across shells and plugin updates
 - **cli-path-resolution.md**: Add equivalent WORKTREE_MGR three-layer resolution section
-- **cli-path-resolution.md**: Structure resolution as sequential commands (no compound && or ||) for auto-approve hook compatibility
+- **cli-path-resolution.md**: Structure resolution as sequential commands (no compound `&&` or `||`) for auto-approve hook compatibility
+
+### Added
+
+- **aimi-cli.sh**: Global cache functions (`_cache_path`, `_read_cache`, `_write_cache`) for persistent CLI and worktree manager path storage across sessions
+- **auto-approve-cli.sh**: Auto-approve patterns for three-layer CLI resolution commands (cache read via `cat`, Layer 1 validation, Layer 2 `bash -c` glob fallback, Layer 2 cache write via `printf`/`mv`/`chmod`, Layer 3 per-project fallback)
+- **aimi-cli.sh / worktree-manager.sh**: Tests for global cache read/write/invalidation functions
 
 ## [1.28.2] - 2026-03-04
 

--- a/README.md
+++ b/README.md
@@ -536,19 +536,25 @@ Invalid characters (spaces, semicolons, quotes) trigger validation errors.
 
 ## Version History
 
-**Current Version:** 1.28.1
+**Current Version:** 1.29.0
 
 ### Recent Changes
 
-**v1.28.1** - Enforce Ralph-style User Story Descriptions
-- Task generation now enforces "As a [specific role], I want [feature] so that [benefit]" format
-- Description format rules added to schema spec, story decomposition, task-planner skill, and plan command
+**v1.29.0** - Three-Layer CLI Resolution with Global Cache
+- Rewrite CLI path resolution with three-layer strategy: global cache, zsh-safe glob fallback, per-project fallback
+- Global cache functions for persistent CLI and worktree manager path storage across sessions
+- Auto-approve hook patterns for all resolution layers
+- Tests for global cache read/write/invalidation
 
 **v1.28.2** - US-NNN ID Format Enforcement & Post-Generation Validation
 - Add US-NNN format step to Phase 3 in plan.md, SKILL.md, pipeline-phases.md — LLM sees format before generating IDs
 - Strengthen story-decomposition.md with zero-padding language and negative examples
 - New `validate-ids` CLI command checks all story IDs at once
 - Phase 4.5 post-generation validation runs `validate-ids` + `validate-deps` after writing tasks.json
+
+**v1.28.1** - Enforce Ralph-style User Story Descriptions
+- Task generation now enforces "As a [specific role], I want [feature] so that [benefit]" format
+- Description format rules added to schema spec, story decomposition, task-planner skill, and plan command
 
 **v1.28.0** - CLAUDE_CONFIG_DIR Support & Project-Root Security
 - New `_claude_config_dir()` helper supporting `CLAUDE_CONFIG_DIR` env var with `~/.claude` fallback

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.28.4",
+  "version": "1.29.0",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi"

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.28.3",
+  "version": "1.28.4",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi"

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.28.2",
+  "version": "1.28.3",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi"

--- a/plugins/aimi-engineering/commands/references/cli-path-resolution.md
+++ b/plugins/aimi-engineering/commands/references/cli-path-resolution.md
@@ -1,21 +1,82 @@
 # CLI Path Resolution
 
-Shared reference for resolving `$AIMI_CLI` across all commands. This file is the single source of truth for the CLI resolution logic.
+Shared reference for resolving `$AIMI_CLI` and `$WORKTREE_MGR` across all commands. This file is the single source of truth for the CLI resolution logic.
 
 ## Resolve CLI Path
 
-**CRITICAL:** The CLI script lives in the plugin install directory, NOT the project directory. Resolve it first:
+**CRITICAL:** The CLI script lives in the plugin install directory, NOT the project directory. Resolve it using the three-layer strategy below. Each command is a separate Bash call (no compound operators).
+
+### Layer 1: Global cache (fast path)
 
 ```bash
-# Glob always finds the latest installed version
-AIMI_CLI=$(ls ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh 2>/dev/null | tail -1)
-# Fallback to cached cli-path if glob found nothing (edge case)
-if [ -z "$AIMI_CLI" ] && [ -f .aimi/cli-path ] && [ -x "$(cat .aimi/cli-path)" ]; then
-  AIMI_CLI=$(cat .aimi/cli-path)
-fi
+AIMI_CLI=$(cat ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path 2>/dev/null)
+```
+
+### Layer 1 validation: verify cached path exists and is executable
+
+```bash
+if [ -n "$AIMI_CLI" ] && [ ! -x "$AIMI_CLI" ]; then AIMI_CLI=""; fi
+```
+
+### Layer 2: Glob fallback (zsh-safe)
+
+Only runs if Layer 1 failed. Uses `bash -c` to avoid zsh `NOMATCH` errors.
+
+```bash
+if [ -z "$AIMI_CLI" ]; then AIMI_CLI=$(bash -c 'ls ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh 2>/dev/null | tail -1'); fi
+```
+
+### Layer 2 cache update: save for next time
+
+```bash
+if [ -n "$AIMI_CLI" ]; then printf '%s\n' "$AIMI_CLI" > "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path.tmp" && mv "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path.tmp" "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" && chmod 600 "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path"; fi
+```
+
+### Layer 3: Per-project fallback (last resort)
+
+```bash
+if [ -z "$AIMI_CLI" ] && [ -f .aimi/cli-path ] && [ -x "$(cat .aimi/cli-path)" ]; then AIMI_CLI=$(cat .aimi/cli-path); fi
 ```
 
 If empty, report: "aimi-cli.sh not found. Reinstall plugin: `/plugin install aimi-engineering`" and STOP.
+
+## Resolve Worktree Manager Path
+
+**CRITICAL:** The worktree manager script lives alongside the CLI. Resolve `$WORKTREE_MGR` using the same three-layer strategy.
+
+### Layer 1: Global cache (fast path)
+
+```bash
+WORKTREE_MGR=$(cat ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-worktree-path 2>/dev/null)
+```
+
+### Layer 1 validation: verify cached path exists and is executable
+
+```bash
+if [ -n "$WORKTREE_MGR" ] && [ ! -x "$WORKTREE_MGR" ]; then WORKTREE_MGR=""; fi
+```
+
+### Layer 2: Glob fallback (zsh-safe)
+
+Only runs if Layer 1 failed. Uses `bash -c` to avoid zsh `NOMATCH` errors.
+
+```bash
+if [ -z "$WORKTREE_MGR" ]; then WORKTREE_MGR=$(bash -c 'ls ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/cache/*/aimi-engineering/*/scripts/worktree-manager.sh 2>/dev/null | tail -1'); fi
+```
+
+### Layer 2 cache update: save for next time
+
+```bash
+if [ -n "$WORKTREE_MGR" ]; then printf '%s\n' "$WORKTREE_MGR" > "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-worktree-path.tmp" && mv "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-worktree-path.tmp" "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-worktree-path" && chmod 600 "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-worktree-path"; fi
+```
+
+### Layer 3: Per-project fallback (last resort)
+
+```bash
+if [ -z "$WORKTREE_MGR" ] && [ -f .aimi/cli-path ]; then WORKTREE_MGR=$(dirname "$(cat .aimi/cli-path)")/worktree-manager.sh; if [ ! -x "$WORKTREE_MGR" ]; then WORKTREE_MGR=""; fi; fi
+```
+
+If empty, report: "worktree-manager.sh not found. Reinstall plugin: `/plugin install aimi-engineering`" and STOP.
 
 ## Version Check
 

--- a/plugins/aimi-engineering/hooks/auto-approve-cli.sh
+++ b/plugins/aimi-engineering/hooks/auto-approve-cli.sh
@@ -47,8 +47,15 @@ has_metacharacters() {
 # --- Pattern 1: AIMI_CLI= assignment ---
 # Validates the assigned path matches the expected plugin cache pattern.
 # Accepts config dir as ~/.claude, ${CLAUDE_CONFIG_DIR:-$HOME/.claude}, or resolved absolute path.
+# Supports both legacy $(ls ...) form and new $(cat ...) cache read form.
 if echo "$COMMAND" | grep -qE '^AIMI_CLI='; then
+  # Legacy: AIMI_CLI=$(ls <config>/plugins/cache/.../aimi-cli.sh)
   if echo "$COMMAND" | grep -qE "^AIMI_CLI=\\$\\(ls ${CONFIG_DIR_RE}/plugins/cache/[a-zA-Z0-9_-]+/aimi-engineering/[0-9][a-zA-Z0-9._-]*/scripts/aimi-cli\\.sh\\)\$"; then
+    echo "$ALLOW"
+    exit 0
+  fi
+  # Cache read: AIMI_CLI=$(cat <config>/aimi-engineering-cli-path 2>/dev/null)
+  if echo "$COMMAND" | grep -qE "^AIMI_CLI=\\$\\(cat ${CONFIG_DIR_RE}/aimi-engineering-cli-path 2>/dev/null\\)\$"; then
     echo "$ALLOW"
     exit 0
   fi
@@ -86,8 +93,15 @@ fi
 # --- Pattern 3: WORKTREE_MGR= assignment ---
 # Validates the assigned path matches the expected worktree manager plugin path.
 # Accepts config dir as ~/.claude, ${CLAUDE_CONFIG_DIR:-$HOME/.claude}, or resolved absolute path.
+# Supports both legacy $(ls ...) form and new $(cat ...) cache read form.
 if echo "$COMMAND" | grep -qE '^WORKTREE_MGR='; then
+  # Legacy: WORKTREE_MGR=$(ls <config>/plugins/cache/.../worktree-manager.sh)
   if echo "$COMMAND" | grep -qE "^WORKTREE_MGR=\\$\\(ls ${CONFIG_DIR_RE}/plugins/cache/[a-zA-Z0-9_-]+/aimi-engineering/[0-9][a-zA-Z0-9._-]*/skills/git-worktree/scripts/worktree-manager\\.sh\\)\$"; then
+    echo "$ALLOW"
+    exit 0
+  fi
+  # Cache read: WORKTREE_MGR=$(cat <config>/aimi-engineering-worktree-path 2>/dev/null)
+  if echo "$COMMAND" | grep -qE "^WORKTREE_MGR=\\$\\(cat ${CONFIG_DIR_RE}/aimi-engineering-worktree-path 2>/dev/null\\)\$"; then
     echo "$ALLOW"
     exit 0
   fi
@@ -118,13 +132,69 @@ if echo "$COMMAND" | grep -qE '^\$WORKTREE_MGR\b|^\$\{WORKTREE_MGR\}'; then
   esac
 fi
 
+# --- Pattern 5: AIMI_CLI Layer 1 validation ---
+# Approves: if [ -n "$AIMI_CLI" ] && [ ! -x "$AIMI_CLI" ]; then AIMI_CLI=""; fi
+if echo "$COMMAND" | grep -qE '^if \[ -n "\$AIMI_CLI" \] && \[ ! -x "\$AIMI_CLI" \]; then AIMI_CLI=""; fi$'; then
+  echo "$ALLOW"
+  exit 0
+fi
+
+# --- Pattern 6: WORKTREE_MGR Layer 1 validation ---
+# Approves: if [ -n "$WORKTREE_MGR" ] && [ ! -x "$WORKTREE_MGR" ]; then WORKTREE_MGR=""; fi
+if echo "$COMMAND" | grep -qE '^if \[ -n "\$WORKTREE_MGR" \] && \[ ! -x "\$WORKTREE_MGR" \]; then WORKTREE_MGR=""; fi$'; then
+  echo "$ALLOW"
+  exit 0
+fi
+
+# --- Pattern 7: AIMI_CLI Layer 2 glob fallback (bash -c wrapper) ---
+# Approves: if [ -z "$AIMI_CLI" ]; then AIMI_CLI=$(bash -c 'ls <config>/plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh 2>/dev/null | tail -1'); fi
+if echo "$COMMAND" | grep -qE "^if \\[ -z \"\\\$AIMI_CLI\" \\]; then AIMI_CLI=\\$\\(bash -c 'ls ${CONFIG_DIR_RE}/plugins/cache/\\*/aimi-engineering/\\*/scripts/aimi-cli\\.sh 2>/dev/null \\| tail -1'\\); fi\$"; then
+  echo "$ALLOW"
+  exit 0
+fi
+
+# --- Pattern 8: WORKTREE_MGR Layer 2 glob fallback (bash -c wrapper) ---
+# Approves: if [ -z "$WORKTREE_MGR" ]; then WORKTREE_MGR=$(bash -c 'ls <config>/plugins/cache/*/aimi-engineering/*/scripts/worktree-manager.sh 2>/dev/null | tail -1'); fi
+if echo "$COMMAND" | grep -qE "^if \\[ -z \"\\\$WORKTREE_MGR\" \\]; then WORKTREE_MGR=\\$\\(bash -c 'ls ${CONFIG_DIR_RE}/plugins/cache/\\*/aimi-engineering/\\*/scripts/worktree-manager\\.sh 2>/dev/null \\| tail -1'\\); fi\$"; then
+  echo "$ALLOW"
+  exit 0
+fi
+
+# --- Pattern 9: AIMI_CLI Layer 2 cache write ---
+# Approves: if [ -n "$AIMI_CLI" ]; then printf '%s\n' "$AIMI_CLI" > "<config>/aimi-engineering-cli-path.tmp" && mv "<config>/aimi-engineering-cli-path.tmp" "<config>/aimi-engineering-cli-path" && chmod 600 "<config>/aimi-engineering-cli-path"; fi
+if echo "$COMMAND" | grep -qE "^if \\[ -n \"\\\$AIMI_CLI\" \\]; then printf '%s\\\\n' \"\\\$AIMI_CLI\" > \"${CONFIG_DIR_RE}/aimi-engineering-cli-path\\.tmp\" && mv \"${CONFIG_DIR_RE}/aimi-engineering-cli-path\\.tmp\" \"${CONFIG_DIR_RE}/aimi-engineering-cli-path\" && chmod 600 \"${CONFIG_DIR_RE}/aimi-engineering-cli-path\"; fi\$"; then
+  echo "$ALLOW"
+  exit 0
+fi
+
+# --- Pattern 10: WORKTREE_MGR Layer 2 cache write ---
+# Approves: if [ -n "$WORKTREE_MGR" ]; then printf '%s\n' "$WORKTREE_MGR" > "<config>/aimi-engineering-worktree-path.tmp" && mv "<config>/aimi-engineering-worktree-path.tmp" "<config>/aimi-engineering-worktree-path" && chmod 600 "<config>/aimi-engineering-worktree-path"; fi
+if echo "$COMMAND" | grep -qE "^if \\[ -n \"\\\$WORKTREE_MGR\" \\]; then printf '%s\\\\n' \"\\\$WORKTREE_MGR\" > \"${CONFIG_DIR_RE}/aimi-engineering-worktree-path\\.tmp\" && mv \"${CONFIG_DIR_RE}/aimi-engineering-worktree-path\\.tmp\" \"${CONFIG_DIR_RE}/aimi-engineering-worktree-path\" && chmod 600 \"${CONFIG_DIR_RE}/aimi-engineering-worktree-path\"; fi\$"; then
+  echo "$ALLOW"
+  exit 0
+fi
+
+# --- Pattern 11: AIMI_CLI Layer 3 per-project fallback ---
+# Approves: if [ -z "$AIMI_CLI" ] && [ -f .aimi/cli-path ] && [ -x "$(cat .aimi/cli-path)" ]; then AIMI_CLI=$(cat .aimi/cli-path); fi
+if echo "$COMMAND" | grep -qE '^if \[ -z "\$AIMI_CLI" \] && \[ -f \.aimi/cli-path \] && \[ -x "\$\(cat \.aimi/cli-path\)" \]; then AIMI_CLI=\$\(cat \.aimi/cli-path\); fi$'; then
+  echo "$ALLOW"
+  exit 0
+fi
+
+# --- Pattern 12: WORKTREE_MGR Layer 3 per-project fallback ---
+# Approves: if [ -z "$WORKTREE_MGR" ] && [ -f .aimi/cli-path ]; then WORKTREE_MGR=$(dirname "$(cat .aimi/cli-path)")/worktree-manager.sh; if [ ! -x "$WORKTREE_MGR" ]; then WORKTREE_MGR=""; fi; fi
+if echo "$COMMAND" | grep -qE '^if \[ -z "\$WORKTREE_MGR" \] && \[ -f \.aimi/cli-path \]; then WORKTREE_MGR=\$\(dirname "\$\(cat \.aimi/cli-path\)"\)/worktree-manager\.sh; if \[ ! -x "\$WORKTREE_MGR" \]; then WORKTREE_MGR=""; fi; fi$'; then
+  echo "$ALLOW"
+  exit 0
+fi
+
 # =============================================================================
-# Docker patterns for /aimi:swarm (Patterns 5–9)
+# Docker patterns for /aimi:swarm (Patterns 13–18)
 # Safety rule: all approved Docker commands must involve the aimi- prefix
 # (container names) or aimi-swarm label. Arbitrary Docker commands are rejected.
 # =============================================================================
 
-# --- Pattern 5: docker version (availability check) ---
+# --- Pattern 13: docker version (availability check) ---
 # Approves: docker version, docker version --format '...'
 # Used by swarm to verify Docker is available before launching workers.
 if echo "$COMMAND" | grep -qE '^docker\s+version(\s|$)'; then
@@ -136,7 +206,7 @@ if echo "$COMMAND" | grep -qE '^docker\s+version(\s|$)'; then
   exit 0
 fi
 
-# --- Pattern 6: docker run --rm with aimi-swarm- container name ---
+# --- Pattern 14: docker run --rm with aimi-swarm- container name ---
 # Approves: docker run --rm ... --name aimi-swarm-<slug> ... (worker containers)
 # Requires: --rm flag, --name with aimi-swarm- prefix, -v mounting paths.
 # Rejects: any docker run without the aimi-swarm- container name prefix.
@@ -165,7 +235,7 @@ if echo "$COMMAND" | grep -qE '^docker\s+run\s'; then
   exit 0
 fi
 
-# --- Pattern 7: docker container ls with aimi-swarm filter ---
+# --- Pattern 15: docker container ls with aimi-swarm filter ---
 # Approves: docker container ls -a --filter "name=aimi-swarm-" ...
 # Used by swarm cleanup to list worker containers.
 if echo "$COMMAND" | grep -qE '^docker\s+container\s+ls\s'; then
@@ -183,7 +253,7 @@ if echo "$COMMAND" | grep -qE '^docker\s+container\s+ls\s'; then
   exit 0
 fi
 
-# --- Pattern 8: docker rm -f with aimi-swarm- container name ---
+# --- Pattern 16: docker rm -f with aimi-swarm- container name ---
 # Approves: docker rm -f aimi-swarm-<name>
 # Used by swarm cleanup to remove worker containers.
 if echo "$COMMAND" | grep -qE '^docker\s+rm\s'; then
@@ -218,7 +288,7 @@ if echo "$COMMAND" | grep -qE '^docker\s+rm\s'; then
   exit 0
 fi
 
-# --- Pattern 9: docker container prune with aimi-swarm label ---
+# --- Pattern 17: docker container prune with aimi-swarm label ---
 # Approves: docker container prune -f --filter "label=aimi-swarm"
 # Safety net to clean up any orphaned worker containers.
 if echo "$COMMAND" | grep -qE '^docker\s+container\s+prune\s'; then
@@ -241,7 +311,7 @@ if echo "$COMMAND" | grep -qE '^docker\s+container\s+prune\s'; then
   exit 0
 fi
 
-# --- Pattern 10: docker ps with aimi- filter ---
+# --- Pattern 18: docker ps with aimi- filter ---
 # Approves: docker ps --filter name=aimi-* (for status/cleanup checks)
 if echo "$COMMAND" | grep -qE '^docker\s+ps\s'; then
   # Reject any shell metacharacters

--- a/plugins/aimi-engineering/scripts/aimi-cli.sh
+++ b/plugins/aimi-engineering/scripts/aimi-cli.sh
@@ -200,6 +200,84 @@ _claude_config_dir() {
   printf '%s\n' "${dir%/}"
 }
 
+# Return the global cache file path for aimi-cli.sh
+_global_cache_path() {
+  local config_dir
+  config_dir=$(_claude_config_dir)
+  printf '%s\n' "$config_dir/aimi-engineering-cli-path"
+}
+
+# Return the global cache file path for worktree-manager.sh
+_global_worktree_cache_path() {
+  local config_dir
+  config_dir=$(_claude_config_dir)
+  printf '%s\n' "$config_dir/aimi-engineering-worktree-path"
+}
+
+# Atomically write the CLI path to the global cache file
+# Usage: write_global_cli_cache "/path/to/aimi-cli.sh"
+write_global_cli_cache() {
+  local path="$1"
+  local cache_file
+  cache_file=$(_global_cache_path)
+  local tmp_file
+  tmp_file=$(mktemp "${cache_file}.XXXXXX")
+  printf '%s\n' "$path" > "$tmp_file"
+  chmod 0600 "$tmp_file"
+  mv "$tmp_file" "$cache_file"
+}
+
+# Read and validate the cached CLI path from the global cache file
+# Returns the cached path if valid, empty string otherwise
+read_global_cli_cache() {
+  local cache_file
+  cache_file=$(_global_cache_path)
+  if [ ! -f "$cache_file" ] || [ ! -r "$cache_file" ]; then
+    return 0
+  fi
+  local cached_path
+  cached_path=$(cat "$cache_file" 2>/dev/null) || return 0
+  # Validate path matches expected pattern
+  # Expected: */plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh
+  case "$cached_path" in
+    */plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh)
+      printf '%s\n' "$cached_path"
+      ;;
+  esac
+}
+
+# Atomically write the worktree manager path to the global cache file
+# Usage: write_global_worktree_cache "/path/to/worktree-manager.sh"
+write_global_worktree_cache() {
+  local path="$1"
+  local cache_file
+  cache_file=$(_global_worktree_cache_path)
+  local tmp_file
+  tmp_file=$(mktemp "${cache_file}.XXXXXX")
+  printf '%s\n' "$path" > "$tmp_file"
+  chmod 0600 "$tmp_file"
+  mv "$tmp_file" "$cache_file"
+}
+
+# Read and validate the cached worktree manager path from the global cache file
+# Returns the cached path if valid, empty string otherwise
+read_global_worktree_cache() {
+  local cache_file
+  cache_file=$(_global_worktree_cache_path)
+  if [ ! -f "$cache_file" ] || [ ! -r "$cache_file" ]; then
+    return 0
+  fi
+  local cached_path
+  cached_path=$(cat "$cache_file" 2>/dev/null) || return 0
+  # Validate path matches expected pattern
+  # Expected: */plugins/cache/*/aimi-engineering/*/skills/git-worktree/scripts/worktree-manager.sh
+  case "$cached_path" in
+    */plugins/cache/*/aimi-engineering/*/skills/git-worktree/scripts/worktree-manager.sh)
+      printf '%s\n' "$cached_path"
+      ;;
+  esac
+}
+
 # Validate story ID format (US-NNN or US-NNNa)
 validate_story_id() {
   local story_id="$1"

--- a/plugins/aimi-engineering/scripts/aimi-cli.sh
+++ b/plugins/aimi-engineering/scripts/aimi-cli.sh
@@ -353,7 +353,10 @@ cmd_init_session() {
   write_state "current-tasks" "$tasks_file"
 
   # Self-resolve: persist this CLI's absolute path for future sessions
-  write_state "cli-path" "$(resolve_path "$0")"
+  local self_path
+  self_path=$(resolve_path "$0")
+  write_state "cli-path" "$self_path"
+  write_global_cli_cache "$self_path"
 
   branch=$(jq -r '.metadata.branchName' "$tasks_file")
 
@@ -981,6 +984,7 @@ cmd_check_version() {
   # Case: stored path differs — stale
   if [ "$fix" = true ]; then
     write_state "cli-path" "$latest_path"
+    write_global_cli_cache "$latest_path"
     jq -n --arg sv "$stored_version" --arg lv "$latest_version" \
       '{status: "fixed", storedVersion: $sv, latestVersion: $lv}'
     return 0
@@ -1043,6 +1047,7 @@ cmd_cleanup_versions() {
 
   # Update cli-path state to point to the latest version
   write_state "cli-path" "$latest_path"
+  write_global_cli_cache "$latest_path"
 
   jq -n --argjson removed "$removed" --arg kept "$latest_version" \
     '{removed: $removed, kept: $kept}'

--- a/plugins/aimi-engineering/scripts/test-aimi-cli.sh
+++ b/plugins/aimi-engineering/scripts/test-aimi-cli.sh
@@ -1364,6 +1364,336 @@ test_next_story_returns_full_object() {
 }
 
 # ============================================================================
+# Global Cache Tests
+# ============================================================================
+#
+# These tests exercise the global cache functions (write_global_cli_cache,
+# read_global_cli_cache, write_global_worktree_cache, read_global_worktree_cache)
+# and their integration with init-session and check-version --fix.
+#
+# NOTE: These tests run under bash. The zsh-specific resolution paths
+# (e.g., ${(%):-%x} vs BASH_SOURCE) cannot be tested here. For zsh
+# behavior, manually source aimi-cli.sh in a zsh shell and verify
+# _global_cache_path and read_global_cli_cache return correct results.
+
+# Helper: set up an isolated CLAUDE_CONFIG_DIR with a mock plugin cache
+# structure so the CLI's glob-based resolution finds a fake aimi-cli.sh.
+# Sets CLAUDE_CONFIG_DIR, MOCK_CLI_PATH, and MOCK_WORKTREE_PATH globals.
+setup_global_cache_env() {
+  GLOBAL_CACHE_TMPDIR=$(mktemp -d)
+  export CLAUDE_CONFIG_DIR="$GLOBAL_CACHE_TMPDIR/claude-config"
+  mkdir -p "$CLAUDE_CONFIG_DIR"
+
+  # Build a mock plugin cache directory structure:
+  #   <config>/plugins/cache/marketplace-hash/aimi-engineering/1.99.0/scripts/aimi-cli.sh
+  #   <config>/plugins/cache/marketplace-hash/aimi-engineering/1.99.0/skills/git-worktree/scripts/worktree-manager.sh
+  local mock_scripts_dir="$CLAUDE_CONFIG_DIR/plugins/cache/abc123/aimi-engineering/1.99.0/scripts"
+  local mock_worktree_dir="$CLAUDE_CONFIG_DIR/plugins/cache/abc123/aimi-engineering/1.99.0/skills/git-worktree/scripts"
+  mkdir -p "$mock_scripts_dir"
+  mkdir -p "$mock_worktree_dir"
+
+  # Create mock executables (content doesn't matter for cache tests)
+  echo '#!/usr/bin/env bash' > "$mock_scripts_dir/aimi-cli.sh"
+  chmod +x "$mock_scripts_dir/aimi-cli.sh"
+  MOCK_CLI_PATH="$mock_scripts_dir/aimi-cli.sh"
+
+  echo '#!/usr/bin/env bash' > "$mock_worktree_dir/worktree-manager.sh"
+  chmod +x "$mock_worktree_dir/worktree-manager.sh"
+  MOCK_WORKTREE_PATH="$mock_worktree_dir/worktree-manager.sh"
+}
+
+# Helper: tear down the isolated environment
+teardown_global_cache_env() {
+  rm -rf "$GLOBAL_CACHE_TMPDIR"
+  unset CLAUDE_CONFIG_DIR
+  unset GLOBAL_CACHE_TMPDIR
+  unset MOCK_CLI_PATH
+  unset MOCK_WORKTREE_PATH
+}
+
+# Source the global cache functions from aimi-cli.sh for direct testing.
+# We extract the needed functions using sed so we can call them directly.
+source_cache_functions() {
+  eval "$(sed -n '/^_claude_config_dir()/,/^}/p' "$CLI")"
+  eval "$(sed -n '/^_global_cache_path()/,/^}/p' "$CLI")"
+  eval "$(sed -n '/^_global_worktree_cache_path()/,/^}/p' "$CLI")"
+  eval "$(sed -n '/^write_global_cli_cache()/,/^}/p' "$CLI")"
+  eval "$(sed -n '/^read_global_cli_cache()/,/^}/p' "$CLI")"
+  eval "$(sed -n '/^write_global_worktree_cache()/,/^}/p' "$CLI")"
+  eval "$(sed -n '/^read_global_worktree_cache()/,/^}/p' "$CLI")"
+}
+
+test_write_global_cli_cache() {
+  echo ""
+  echo "=== Testing write_global_cli_cache creates file with correct content and permissions ==="
+
+  setup_global_cache_env
+  source_cache_functions
+
+  local test_path="$MOCK_CLI_PATH"
+  write_global_cli_cache "$test_path"
+
+  local cache_file
+  cache_file=$(_global_cache_path)
+
+  # File should exist
+  if [ -f "$cache_file" ]; then
+    echo -e "${GREEN}✓${NC} write_global_cli_cache: cache file exists"
+    ((TESTS_PASSED++))
+  else
+    echo -e "${RED}✗${NC} write_global_cli_cache: cache file exists"
+    echo "  Expected file at: $cache_file"
+    ((TESTS_FAILED++))
+    teardown_global_cache_env
+    return
+  fi
+
+  # Content should match the written path
+  local content
+  content=$(cat "$cache_file")
+  assert_eq "$test_path" "$content" "write_global_cli_cache: file content matches written path"
+
+  # Permissions should be 0600
+  local perms
+  perms=$(stat -c '%a' "$cache_file" 2>/dev/null || stat -f '%Lp' "$cache_file" 2>/dev/null)
+  assert_eq "600" "$perms" "write_global_cli_cache: file permissions are 0600"
+
+  teardown_global_cache_env
+}
+
+test_read_global_cli_cache_valid() {
+  echo ""
+  echo "=== Testing read_global_cli_cache returns cached path when valid ==="
+
+  setup_global_cache_env
+  source_cache_functions
+
+  # Write a valid path that matches the expected pattern
+  write_global_cli_cache "$MOCK_CLI_PATH"
+
+  local result
+  result=$(read_global_cli_cache)
+
+  assert_eq "$MOCK_CLI_PATH" "$result" "read_global_cli_cache: returns valid cached path"
+
+  teardown_global_cache_env
+}
+
+test_read_global_cli_cache_missing() {
+  echo ""
+  echo "=== Testing read_global_cli_cache returns empty when file is missing ==="
+
+  setup_global_cache_env
+  source_cache_functions
+
+  # Do NOT write any cache file — it should not exist
+  local result
+  result=$(read_global_cli_cache)
+
+  assert_eq "" "$result" "read_global_cli_cache: returns empty when cache file missing"
+
+  teardown_global_cache_env
+}
+
+test_read_global_cli_cache_tampered() {
+  echo ""
+  echo "=== Testing read_global_cli_cache returns empty when path doesn't match pattern ==="
+
+  setup_global_cache_env
+  source_cache_functions
+
+  # Write a tampered/invalid path that does not match the expected glob pattern
+  local cache_file
+  cache_file=$(_global_cache_path)
+  printf '%s\n' "/tmp/hacked/evil-script.sh" > "$cache_file"
+
+  local result
+  result=$(read_global_cli_cache)
+
+  assert_eq "" "$result" "read_global_cli_cache: returns empty for tampered path (no pattern match)"
+
+  teardown_global_cache_env
+}
+
+test_read_global_cli_cache_stale() {
+  echo ""
+  echo "=== Testing read_global_cli_cache returns path even when cached file no longer exists on disk ==="
+
+  setup_global_cache_env
+  source_cache_functions
+
+  # Write a valid-pattern path, then delete the actual file
+  write_global_cli_cache "$MOCK_CLI_PATH"
+  rm -f "$MOCK_CLI_PATH"
+
+  # read_global_cli_cache only validates the pattern, not file existence
+  # (staleness detection is done by the caller, e.g., check-version)
+  local result
+  result=$(read_global_cli_cache)
+
+  # The function returns the path because it matches the pattern
+  # even though the file no longer exists on disk
+  assert_eq "$MOCK_CLI_PATH" "$result" "read_global_cli_cache: returns pattern-valid path even if file deleted (caller detects staleness)"
+
+  teardown_global_cache_env
+}
+
+test_write_global_worktree_cache() {
+  echo ""
+  echo "=== Testing write_global_worktree_cache and read_global_worktree_cache ==="
+
+  setup_global_cache_env
+  source_cache_functions
+
+  # Write the worktree manager path
+  write_global_worktree_cache "$MOCK_WORKTREE_PATH"
+
+  local cache_file
+  cache_file=$(_global_worktree_cache_path)
+
+  # File should exist
+  if [ -f "$cache_file" ]; then
+    echo -e "${GREEN}✓${NC} write_global_worktree_cache: cache file exists"
+    ((TESTS_PASSED++))
+  else
+    echo -e "${RED}✗${NC} write_global_worktree_cache: cache file exists"
+    ((TESTS_FAILED++))
+    teardown_global_cache_env
+    return
+  fi
+
+  # Content should match
+  local content
+  content=$(cat "$cache_file")
+  assert_eq "$MOCK_WORKTREE_PATH" "$content" "write_global_worktree_cache: file content matches"
+
+  # Permissions should be 0600
+  local perms
+  perms=$(stat -c '%a' "$cache_file" 2>/dev/null || stat -f '%Lp' "$cache_file" 2>/dev/null)
+  assert_eq "600" "$perms" "write_global_worktree_cache: file permissions are 0600"
+
+  # Read it back
+  local result
+  result=$(read_global_worktree_cache)
+  assert_eq "$MOCK_WORKTREE_PATH" "$result" "read_global_worktree_cache: returns valid cached path"
+
+  teardown_global_cache_env
+}
+
+test_read_global_worktree_cache_tampered() {
+  echo ""
+  echo "=== Testing read_global_worktree_cache returns empty for invalid pattern ==="
+
+  setup_global_cache_env
+  source_cache_functions
+
+  local cache_file
+  cache_file=$(_global_worktree_cache_path)
+  printf '%s\n' "/tmp/bad-path/not-worktree.sh" > "$cache_file"
+
+  local result
+  result=$(read_global_worktree_cache)
+
+  assert_eq "" "$result" "read_global_worktree_cache: returns empty for tampered path"
+
+  teardown_global_cache_env
+}
+
+test_init_session_writes_global_cache() {
+  echo ""
+  echo "=== Testing init-session writes global cache alongside per-project cache ==="
+
+  setup_global_cache_env
+  source_cache_functions
+
+  # init-session calls write_global_cli_cache internally.
+  # We need to run the actual CLI with our custom CLAUDE_CONFIG_DIR.
+  # First, reset and run init-session.
+  "$CLI" clear-state > /dev/null 2>&1 || true
+  "$CLI" init-session > /dev/null
+
+  # The global cache file should now exist
+  local cache_file
+  cache_file=$(_global_cache_path)
+
+  if [ -f "$cache_file" ]; then
+    echo -e "${GREEN}✓${NC} init-session: global CLI cache file created"
+    ((TESTS_PASSED++))
+  else
+    echo -e "${RED}✗${NC} init-session: global CLI cache file created"
+    echo "  Expected file at: $cache_file"
+    ((TESTS_FAILED++))
+    teardown_global_cache_env
+    return
+  fi
+
+  # The content should be a path ending in aimi-cli.sh
+  local content
+  content=$(cat "$cache_file")
+  assert_contains "aimi-cli.sh" "$content" "init-session: global cache contains aimi-cli.sh path"
+
+  # The per-project state should also be set
+  local state_path
+  state_path=$(cat "$AIMI_DIR/cli-path" 2>/dev/null)
+  assert_eq "$content" "$state_path" "init-session: global cache matches per-project cli-path state"
+
+  teardown_global_cache_env
+}
+
+test_check_version_fix_updates_global_cache() {
+  echo ""
+  echo "=== Testing check-version --fix updates global cache when stale ==="
+
+  setup_global_cache_env
+  source_cache_functions
+
+  # Initialize session first to set up state
+  "$CLI" clear-state > /dev/null 2>&1 || true
+  "$CLI" init-session > /dev/null
+
+  # Resolve the latest path in our mock env
+  local latest_glob_path
+  latest_glob_path=$(ls "$CLAUDE_CONFIG_DIR"/plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh 2>/dev/null | tail -1)
+
+  if [ -z "$latest_glob_path" ]; then
+    echo "  (skipping: no mock CLI in plugin cache)"
+    teardown_global_cache_env
+    return
+  fi
+
+  # Write a stale cli-path to force check-version to detect staleness
+  echo "/fake/old/plugins/cache/abc/aimi-engineering/0.0.1/scripts/aimi-cli.sh" > "$AIMI_DIR/cli-path"
+
+  # Also clear the global cache to verify --fix writes it
+  local cache_file
+  cache_file=$(_global_cache_path)
+  rm -f "$cache_file"
+
+  local output exit_code
+  output=$("$CLI" check-version --fix 2>/dev/null) && exit_code=0 || exit_code=$?
+
+  assert_exit_code "0" "$exit_code" "check-version --fix: exits 0"
+  assert_contains '"status": "fixed"' "$output" "check-version --fix: returns fixed status"
+
+  # Verify the global cache was updated
+  if [ -f "$cache_file" ]; then
+    echo -e "${GREEN}✓${NC} check-version --fix: global cache file exists after fix"
+    ((TESTS_PASSED++))
+  else
+    echo -e "${RED}✗${NC} check-version --fix: global cache file exists after fix"
+    ((TESTS_FAILED++))
+    teardown_global_cache_env
+    return
+  fi
+
+  local cached_content
+  cached_content=$(cat "$cache_file")
+  assert_eq "$latest_glob_path" "$cached_content" "check-version --fix: global cache updated to latest path"
+
+  teardown_global_cache_env
+}
+
+# ============================================================================
 # Main
 # ============================================================================
 
@@ -1447,6 +1777,19 @@ main() {
   echo "--- Auto-Discovery Tests ---"
   test_auto_discovery_from_subdirectory
   test_auto_discovery_not_found
+
+  # Global cache tests — run with isolated CLAUDE_CONFIG_DIR
+  echo ""
+  echo "--- Global Cache Tests ---"
+  test_write_global_cli_cache
+  test_read_global_cli_cache_valid
+  test_read_global_cli_cache_missing
+  test_read_global_cli_cache_tampered
+  test_read_global_cli_cache_stale
+  test_write_global_worktree_cache
+  test_read_global_worktree_cache_tampered
+  test_init_session_writes_global_cache
+  test_check_version_fix_updates_global_cache
 
   # CLI output optimization tests — run with fresh fixture each time
   echo ""


### PR DESCRIPTION
## Summary
- Add global cache layer (`~/.claude/aimi-engineering-cli-path`) for fast CLI path resolution across projects, avoiding repeated `ls` glob lookups
- Implement three-layer resolution strategy: Layer 1 (global cache read) → Layer 2 (glob fallback + cache write) → Layer 3 (per-project `.aimi/cli-path` fallback)
- Update auto-approve hook with 8 new patterns (5–12) to support cache read/write, validation, and fallback commands
- Add comprehensive tests for global cache functions (read/write for both CLI and worktree manager paths)