### PR TITLE
feat: Add per-story project field for multi-repo execution

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and worktree+team orchestration.",
-      "version": "1.30.0",
+      "version": "1.30.1",
       "author": {
         "name": "Stanley Takamatsu",
         "url": "https://github.com/aimi-so"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and worktree+team orchestration.",
-      "version": "1.30.1",
+      "version": "1.30.2",
       "author": {
         "name": "Stanley Takamatsu",
         "url": "https://github.com/aimi-so"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and worktree+team orchestration.",
-      "version": "1.29.0",
+      "version": "1.30.0",
       "author": {
         "name": "Stanley Takamatsu",
         "url": "https://github.com/aimi-so"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and worktree+team orchestration.",
-      "version": "1.30.0",
+      "version": "1.31.0",
       "author": {
         "name": "Stanley Takamatsu",
         "url": "https://github.com/aimi-so"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and worktree+team orchestration.",
-      "version": "1.31.0",
+      "version": "1.30.0",
       "author": {
         "name": "Stanley Takamatsu",
         "url": "https://github.com/aimi-so"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.30.1] - 2026-03-27
+
+### Fixed
+
+- **plan.md**: Inline schema v3 structure and dependsOn inference rules — planner agent no longer fails to find reference files when running outside the plugin repo
+- **plan.md**: Add `validate-stories` to Phase 4.5 validation step
+- **SKILL.md (task-planner)**: Remove broken relative path references to `references/task-format-v3.md`, `references/pipeline-phases.md`, and `references/story-decomposition.md` — inline essential content instead
+- **SKILL.md (task-planner)**: Inline git repo auto-scan bash command (previously only in pipeline-phases.md)
+
 ## [1.30.0] - 2026-03-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,23 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.31.0] - 2026-03-26
+## [1.30.0] - 2026-03-26
 
 ### Added
 
+- **task-format-v3.md**: Optional per-story `project` field added to task schema v3 — specifies the relative path from AIMI_ROOT to the target git repository for multi-repo story execution
+- **aimi-cli.sh**: Project field validation in `cmd_validate_stories()` — rejects absolute paths, path traversal (`..`), and shell metacharacters (`$`, `` ` ``, `;`, `|`, `&`); accepts valid relative paths; backwards compatible when project is absent
+- **aimi-cli.sh**: Project field included in `cmd_list_ready --brief` output (`{id, title, priority, dependsOn, project}`)
 - **next.md**: Per-story project path resolution — when a story has a `project` field, resolves PROJECT_PATH relative to AIMI_ROOT and passes it to the worker agent prompt; loads CLAUDE.md from PROJECT_PATH when set; backwards compatible when project field is absent
 - **execute.md**: Per-project worktree grouping for multi-repo execution — wave stories are grouped by `project` field before worktree creation, worktrees are created within each project's git repo, merge-all runs per-project group
 - **execute.md**: Per-project branch setup — creates/checks out the feature branch in each unique project's git repo when stories target different repos
 - **execute.md**: Per-project guidelines loading — builds `PROJECT_GUIDELINES_MAP` from each project's CLAUDE.md/AGENTS.md
 - **execute.md**: Single-story waves pass `PROJECT_PATH` to worker prompt when story has `project` field
 - **execute.md**: Post-loop cleanup handles per-project worktree removal
-
-## [1.30.0] - 2026-03-26
-
-### Added
-
-- **aimi-cli.sh**: Project field validation in `cmd_validate_stories()` — rejects absolute paths, path traversal (`..`), and shell metacharacters (`$`, `` ` ``, `;`, `|`, `&`); accepts valid relative paths; backwards compatible when project is absent
-- **aimi-cli.sh**: Project field included in `cmd_list_ready --brief` output (`{id, title, priority, dependsOn, project}`)
+- **plan.md / story-decomposition.md**: Multi-repo project assignment rules — planner auto-scans subfolders for git repos and assigns `project` field to stories targeting specific repositories
 - **test-aimi-cli.sh**: Updated `--brief` key count assertion to include project field
 
 ## [1.29.0] - 2026-03-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.30.0] - 2026-03-26
+
+### Added
+
+- **aimi-cli.sh**: Project field validation in `cmd_validate_stories()` — rejects absolute paths, path traversal (`..`), and shell metacharacters (`$`, `` ` ``, `;`, `|`, `&`); accepts valid relative paths; backwards compatible when project is absent
+- **aimi-cli.sh**: Project field included in `cmd_list_ready --brief` output (`{id, title, priority, dependsOn, project}`)
+- **test-aimi-cli.sh**: Updated `--brief` key count assertion to include project field
+
 ## [1.29.0] - 2026-03-06
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.30.2] - 2026-03-30
+
+### Fixed
+
+- **execute.md, next.md, status.md, swarm.md**: Inline CLI path resolution logic — removes broken `See commands/references/cli-path-resolution.md` references that fail when plugin is installed outside the repo
+- **status.md**: Remove broken `See task-format-v3.md` reference
+- **SKILL.md (story-executor)**: Remove broken `See task-format-v3.md in ../task-planner/references/` reference — inline key fields with constraints instead
+- **CLAUDE.md**: Remove broken `See task-format-v3.md` reference — inline schema version and key fields
+
 ## [1.30.1] - 2026-03-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.31.0] - 2026-03-26
+
+### Added
+
+- **next.md**: Per-story project path resolution — when a story has a `project` field, resolves PROJECT_PATH relative to AIMI_ROOT and passes it to the worker agent prompt; loads CLAUDE.md from PROJECT_PATH when set; backwards compatible when project field is absent
+
 ## [1.30.0] - 2026-03-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.31.0] - 2026-03-26
+
+### Added
+
+- **execute.md**: Per-project worktree grouping for multi-repo execution — wave stories are grouped by `project` field before worktree creation, worktrees are created within each project's git repo, merge-all runs per-project group
+- **execute.md**: Per-project branch setup — creates/checks out the feature branch in each unique project's git repo when stories target different repos
+- **execute.md**: Per-project guidelines loading — builds `PROJECT_GUIDELINES_MAP` from each project's CLAUDE.md/AGENTS.md
+- **execute.md**: Single-story waves pass `PROJECT_PATH` to worker prompt when story has `project` field
+- **execute.md**: Post-loop cleanup handles per-project worktree removal
+
 ## [1.30.0] - 2026-03-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ All execution state lives in `.aimi/tasks/YYYY-MM-DD-[feature-name]-tasks.json`.
 
 ```json
 {
-  "schemaVersion": "3.0",
+  "schemaVersion": "3.1",
   "metadata": {
     "title": "feat: Add user authentication",
     "type": "feat",
@@ -355,7 +355,7 @@ All execution state lives in `.aimi/tasks/YYYY-MM-DD-[feature-name]-tasks.json`.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `schemaVersion` | string | Schema version: `"3.0"` or `"3.1"` (use 3.1 for multi-repo with `project` field) |
+| `schemaVersion` | string | Schema version: `"3.1"` |
 | `metadata` | object | Project metadata |
 | `userStories` | array | Array of Story objects |
 

--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ All execution state lives in `.aimi/tasks/YYYY-MM-DD-[feature-name]-tasks.json`.
 | `status` | string | One of: `pending`, `in_progress`, `completed`, `failed`, `skipped` |
 | `dependsOn` | array | Story IDs that must complete before this story can start |
 | `notes` | string | Error details or learnings |
+| `project` | string | (optional) Relative path from AIMI_ROOT to the target git repository for multi-repo execution |
 
 > **Note:** As of v1.11.0, only schema v3.0 is supported. v2.2 backward compatibility was removed.
 
@@ -536,9 +537,15 @@ Invalid characters (spaces, semicolons, quotes) trigger validation errors.
 
 ## Version History
 
-**Current Version:** 1.29.0
+**Current Version:** 1.30.0
 
 ### Recent Changes
+
+**v1.30.0** - Per-Story Project Field for Multi-Repo Execution
+- Optional `project` field on stories for targeting specific git repositories in multi-repo setups
+- CLI validation for project paths (blocks traversal, absolute paths, metacharacters) and --brief output includes project
+- next.md and execute.md resolve PROJECT_PATH, group worktrees per project, and load per-project guidelines
+- Planner auto-scans subfolders for git repos and assigns project fields during story decomposition
 
 **v1.29.0** - Three-Layer CLI Resolution with Global Cache
 - Rewrite CLI path resolution with three-layer strategy: global cache, zsh-safe glob fallback, per-project fallback

--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ All execution state lives in `.aimi/tasks/YYYY-MM-DD-[feature-name]-tasks.json`.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `schemaVersion` | string | Schema version (currently "3.0", also supports "2.2") |
+| `schemaVersion` | string | Schema version: `"3.0"` or `"3.1"` (use 3.1 for multi-repo with `project` field) |
 | `metadata` | object | Project metadata |
 | `userStories` | array | Array of Story objects |
 

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.30.0",
+  "version": "1.30.1",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi"

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi"

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.31.0",
+  "version": "1.30.0",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi"

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.30.0",
+  "version": "1.31.0",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi"

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.30.1",
+  "version": "1.30.2",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi"

--- a/plugins/aimi-engineering/CLAUDE.md
+++ b/plugins/aimi-engineering/CLAUDE.md
@@ -85,8 +85,7 @@ Learnings are stored in project files (not separate progress log):
 
 ## Tasks File Schema
 
-> **Schema:** See `task-format-v3.md` in `skills/task-planner/references/`. Full v3 specification with status state machine, dependency system, and validation rules.
-> Key fields: `schemaVersion`, `metadata{title,type,branchName,maxConcurrency}`, `userStories[]{id,title,description,acceptanceCriteria,status,dependsOn,project}`
+> Key fields: `schemaVersion` ("3.1"), `metadata{title,type,branchName,maxConcurrency}`, `userStories[]{id(US-NNN),title,description,acceptanceCriteria,status,dependsOn,project}`
 > The `project` field is optional on stories — when present, it specifies the relative path from AIMI_ROOT to the target git repository for multi-repo execution.
 
 

--- a/plugins/aimi-engineering/CLAUDE.md
+++ b/plugins/aimi-engineering/CLAUDE.md
@@ -86,7 +86,8 @@ Learnings are stored in project files (not separate progress log):
 ## Tasks File Schema
 
 > **Schema:** See `task-format-v3.md` in `skills/task-planner/references/`. Full v3 specification with status state machine, dependency system, and validation rules.
-> Key fields: `schemaVersion`, `metadata{title,type,branchName,maxConcurrency}`, `userStories[]{id,title,description,acceptanceCriteria,status,dependsOn}`
+> Key fields: `schemaVersion`, `metadata{title,type,branchName,maxConcurrency}`, `userStories[]{id,title,description,acceptanceCriteria,status,dependsOn,project}`
+> The `project` field is optional on stories — when present, it specifies the relative path from AIMI_ROOT to the target git repository for multi-repo execution.
 
 
 ## Performance Guidelines

--- a/plugins/aimi-engineering/commands/execute.md
+++ b/plugins/aimi-engineering/commands/execute.md
@@ -10,7 +10,7 @@ allowed-tools: Read, Write, Edit, Bash(git:*), Bash(AIMI_CLI=*), Bash($AIMI_CLI:
 Execute all pending stories autonomously using wave-based fan-out.
 
 Each wave uses two-phase story loading to conserve context:
-- **Phase 1 (wave selection):** `list-ready --brief` returns lightweight story stubs `{id, title, priority, dependsOn}` for scheduling decisions.
+- **Phase 1 (wave selection):** `list-ready --brief` returns lightweight story stubs `{id, title, priority, dependsOn, project}` for scheduling decisions.
 - **Phase 2 (prompt construction):** `get-story <id>` fetches full story data `{description, acceptanceCriteria, notes}` only for selected stories, after they are claimed with `mark-in-progress`.
 
 Single-story waves run inline (no worktree overhead). Multi-story waves spawn N foreground Tasks in one tool-call turn with worktrees, wait for all results, then merge.
@@ -100,6 +100,30 @@ Report:
 Switched to branch: [branchName]
 ```
 
+### Per-Project Branch Setup
+
+After setting up the branch in the current repo, check if any stories have a `project` field by running `$AIMI_CLI list-ready --brief` and inspecting the results.
+
+If any story has a non-null `project` field:
+
+1. Collect unique project paths from ALL pending stories (not just ready ones — use `$AIMI_CLI status` and filter stories with a `project` field).
+2. Resolve each project path to an absolute path: `AIMI_ROOT / story.project` where AIMI_ROOT is the directory containing `.aimi/`.
+3. For each unique project path:
+   ```bash
+   cd [resolved_project_path]
+   git branch --list [branchName]
+   ```
+   - If branch exists: `git checkout [branchName]`
+   - If not exists: `git checkout -b [branchName]`
+   - Then return to the original directory.
+
+Report for each project:
+```
+Branch [branchName] set up in project: [project_path]
+```
+
+If no stories have a `project` field, skip this step (backwards compatible).
+
 ## Step 3: Check for Pending Stories
 
 ```bash
@@ -173,6 +197,14 @@ Load project guidelines following the discovery order defined in `story-executor
 
 Read these files and store the content as `PROJECT_GUIDELINES`.
 
+### Per-Project Guidelines
+
+When stories target different projects (via the `project` field), each project may have its own `CLAUDE.md` and `AGENTS.md`. Load guidelines per unique project path and store as a map: `PROJECT_GUIDELINES_MAP[project_path] = guidelines_content`.
+
+- For stories without a `project` field, use the default `PROJECT_GUIDELINES` (loaded from the current repo root).
+- For stories with a `project` field, look up `PROJECT_GUIDELINES_MAP[story.project]` and pass it as `PROJECT_GUIDELINES` in the worker prompt.
+- If no stories have `project` fields, skip this map and use default `PROJECT_GUIDELINES` (backwards compatible).
+
 ## Step 4: Wave Execution Loop
 
 ```
@@ -183,7 +215,7 @@ while true:
     pending = $AIMI_CLI count-pending
     if pending == 0: break
 
-    # Get ready stories (brief mode — returns {id, title, priority, dependsOn} only)
+    # Get ready stories (brief mode — returns {id, title, priority, dependsOn, project} only)
     ready_stories = $AIMI_CLI list-ready --brief
     if ready_stories is empty:
         if pending > 0:
@@ -222,20 +254,29 @@ while true:
             wave += 1
             continue
 
+        # Resolve PROJECT_PATH from story.project if present
+        # AIMI_ROOT = directory containing .aimi/ (resolved during init-session)
+        project_path = null
+        project_guidelines = PROJECT_GUIDELINES
+        if full_story.project is not null/absent:
+            project_path = AIMI_ROOT / full_story.project  (resolve to absolute path)
+            project_guidelines = PROJECT_GUIDELINES_MAP[full_story.project] or PROJECT_GUIDELINES
+
         # Spawn a single foreground Task — same pattern as next.md
-        # No worktree, worker operates in current directory
+        # No worktree, worker operates in current directory (or PROJECT_PATH if set)
         # IMPORTANT: subagent_type MUST be "general-purpose" — story-executor is a skill, NOT an agent.
         Task(
             subagent_type: "general-purpose",
             description: "Execute [full_story.id]: [full_story.title]",
             prompt: [story-executor SKILL.md prompt template with:
-                - PROJECT_GUIDELINES = PROJECT_GUIDELINES
+                - PROJECT_GUIDELINES = project_guidelines
+                - PROJECT_PATH = project_path (only include if non-null)
                 - STORY_ID = full_story.id
                 - STORY_TITLE = full_story.title
                 - STORY_DESCRIPTION = full_story.description
                 - ACCEPTANCE_CRITERIA = full_story.acceptanceCriteria (bulleted)
                 - full_story.notes = full_story.notes (include PREVIOUS NOTES section only if non-empty)
-                - No WORKTREE_PATH (sequential — worker operates in current directory)
+                - No WORKTREE_PATH (sequential — worker operates in current directory or PROJECT_PATH)
             ]
         )
 
@@ -278,11 +319,20 @@ while true:
     # If only one story remains after fetch failures, use single-story path (no worktree)
     if len(full_stories) == 1:
         full_story = full_stories[0]
+
+        # Resolve PROJECT_PATH if story has project field
+        project_path = null
+        project_guidelines = PROJECT_GUIDELINES
+        if full_story.project is not null/absent:
+            project_path = AIMI_ROOT / full_story.project
+            project_guidelines = PROJECT_GUIDELINES_MAP[full_story.project] or PROJECT_GUIDELINES
+
         Task(
             subagent_type: "general-purpose",
             description: "Execute [full_story.id]: [full_story.title]",
             prompt: [story-executor SKILL.md prompt template with:
-                - PROJECT_GUIDELINES = PROJECT_GUIDELINES
+                - PROJECT_GUIDELINES = project_guidelines
+                - PROJECT_PATH = project_path (only include if non-null)
                 - STORY_ID = full_story.id
                 - STORY_TITLE = full_story.title
                 - STORY_DESCRIPTION = full_story.description
@@ -305,34 +355,72 @@ while true:
         continue
 
     # Multiple stories remain — proceed with worktree parallelism
-    worktree_names = []
 
+    # ========================================
+    # GROUP STORIES BY PROJECT
+    # ========================================
+    # Group full_stories by their `project` field.
+    # Stories without a `project` field (null/absent) go into the DEFAULT group.
+    # DEFAULT group uses the current repo (no cd needed).
+    # Each project group has its own git root for worktree operations.
+
+    project_groups = {}  # key: project_path (or "DEFAULT"), value: list of full_story
     for full_story in full_stories:
-        worktree_name = "[branchName]-[full_story.id]"
-        worktree_names.append(worktree_name)
+        if full_story.project is not null/absent:
+            group_key = full_story.project
+        else:
+            group_key = "DEFAULT"
+        project_groups[group_key].append(full_story)
 
-        # Create worktree from current feature branch
-        $WORKTREE_MGR create [worktree_name] --from [branchName]
+    # Resolve absolute paths for each project group
+    # AIMI_ROOT = directory containing .aimi/ (resolved during init-session)
+    project_roots = {}  # key: group_key, value: absolute path to git root
+    for group_key in project_groups:
+        if group_key == "DEFAULT":
+            project_roots[group_key] = CWD  (current working directory / git root)
+        else:
+            project_roots[group_key] = AIMI_ROOT / group_key  (resolve to absolute path)
 
-        # Get the worktree path from the create output
-        worktree_path = [path from output]
+    # ========================================
+    # CREATE WORKTREES PER PROJECT GROUP
+    # ========================================
+    all_worktrees = {}  # key: full_story.id, value: {worktree_name, worktree_path, group_key}
+
+    for group_key, stories in project_groups:
+        project_root = project_roots[group_key]
+
+        for full_story in stories:
+            worktree_name = "[branchName]-[full_story.id]"
+
+            # cd to the project's git root before creating worktree
+            cd [project_root]
+            $WORKTREE_MGR create [worktree_name] --from [branchName]
+
+            worktree_path = [path from output]
+            all_worktrees[full_story.id] = {
+                worktree_name: worktree_name,
+                worktree_path: worktree_path,
+                group_key: group_key
+            }
 
     # Spawn ALL workers as foreground Tasks in a SINGLE tool-call turn.
     # Claude Code runs multiple foreground Tasks concurrently and returns
     # all results before the agent's turn ends.
     #
     # IMPORTANT: subagent_type MUST be "general-purpose" — story-executor is a skill, NOT an agent.
-    # In one tool-call turn, emit N Task calls:
+    # In one tool-call turn, emit N Task calls (across ALL project groups):
     for full_story in full_stories:
-        worktree_name = "[branchName]-[full_story.id]"
-        worktree_path = [worktree path for this story]
+        wt = all_worktrees[full_story.id]
+        project_path = project_roots[wt.group_key] if wt.group_key != "DEFAULT" else null
+        project_guidelines = PROJECT_GUIDELINES_MAP[wt.group_key] if wt.group_key != "DEFAULT" else PROJECT_GUIDELINES
 
         Task(
             subagent_type: "general-purpose",
             description: "Execute [full_story.id]: [full_story.title]",
             prompt: [story-executor SKILL.md prompt template with:
-                - WORKTREE_PATH = worktree_path
-                - PROJECT_GUIDELINES = PROJECT_GUIDELINES
+                - WORKTREE_PATH = wt.worktree_path
+                - PROJECT_PATH = project_path (only include if non-null)
+                - PROJECT_GUIDELINES = project_guidelines
                 - STORY_ID = full_story.id
                 - STORY_TITLE = full_story.title
                 - STORY_DESCRIPTION = full_story.description
@@ -360,34 +448,51 @@ while true:
         $AIMI_CLI cascade-skip [full_story.id]
         Report: "[full_story.id] failed. Dependent stories cascade-skipped."
 
-    # Merge all successful worktrees using merge-all
+    # ========================================
+    # MERGE PER PROJECT GROUP (not across repos)
+    # ========================================
+    # Merge successful worktrees grouped by project.
+    # Each project group merges independently into its own repo's branch.
+
     if len(succeeded_stories) > 0:
-        succeeded_worktree_names = ["[branchName]-[full_story.id]" for full_story in succeeded_stories]
-
-        merge_result = $WORKTREE_MGR merge-all [succeeded_worktree_names...] --into [branchName]
-
-        if merge conflict (non-zero exit):
-            Report:
-            "MERGE CONFLICT during wave [wave] merge."
-            "Conflicting files:"
-            "[conflict output from merge-all]"
-            ""
-            "Resolve the conflict on branch [branchName] and re-run `/aimi:execute` to continue."
-
-            # Cleanup all worktrees from this wave before stopping
-            for wt in worktree_names:
-                $WORKTREE_MGR remove [wt]
-
-            STOP execution.
-
-        # All merges succeeded — mark stories complete
+        # Group succeeded stories by project
+        succeeded_by_project = {}
         for full_story in succeeded_stories:
-            $AIMI_CLI mark-complete [full_story.id]
-            Report: "[full_story.id] merged successfully."
+            group_key = all_worktrees[full_story.id].group_key
+            succeeded_by_project[group_key].append(full_story)
 
-    # Remove all worktrees from this wave
-    for wt in worktree_names:
-        $WORKTREE_MGR remove [wt]
+        for group_key, stories in succeeded_by_project:
+            project_root = project_roots[group_key]
+            succeeded_worktree_names = [all_worktrees[s.id].worktree_name for s in stories]
+
+            # cd to the project's git root before merging
+            cd [project_root]
+            merge_result = $WORKTREE_MGR merge-all [succeeded_worktree_names...] --into [branchName]
+
+            if merge conflict (non-zero exit):
+                Report:
+                "MERGE CONFLICT during wave [wave] merge in project [group_key]."
+                "Conflicting files:"
+                "[conflict output from merge-all]"
+                ""
+                "Resolve the conflict on branch [branchName] in [project_root] and re-run `/aimi:execute` to continue."
+
+                # Cleanup ALL worktrees from this wave (across all project groups) before stopping
+                for full_story_id, wt in all_worktrees:
+                    cd [project_roots[wt.group_key]]
+                    $WORKTREE_MGR remove [wt.worktree_name]
+
+                STOP execution.
+
+            # Merges succeeded for this project group — mark stories complete
+            for full_story in stories:
+                $AIMI_CLI mark-complete [full_story.id]
+                Report: "[full_story.id] merged successfully."
+
+    # Remove all worktrees from this wave (per project group)
+    for full_story_id, wt in all_worktrees:
+        cd [project_roots[wt.group_key]]
+        $WORKTREE_MGR remove [wt.worktree_name]
 
     Report: "Wave [wave] complete: [len(succeeded_stories)] succeeded, [len(failed_stories)] failed"
     wave += 1
@@ -399,6 +504,14 @@ After the wave loop ends (all stories processed or deadlock):
 
 ```
 # Remove any remaining worktrees (safety cleanup)
+# When stories have project fields, clean up per project root:
+for each unique project_root (including CWD for DEFAULT group):
+    cd [project_root]
+    $WORKTREE_MGR list
+    # For each worktree matching "[branchName]-US-*":
+    $WORKTREE_MGR remove [worktree_name]
+
+# When no stories have project fields, use current directory (backwards compatible):
 $WORKTREE_MGR list
 # For each worktree matching "[branchName]-US-*":
 $WORKTREE_MGR remove [worktree_name]

--- a/plugins/aimi-engineering/commands/execute.md
+++ b/plugins/aimi-engineering/commands/execute.md
@@ -17,7 +17,41 @@ Single-story waves run inline (no worktree overhead). Multi-story waves spawn N 
 
 ## Step 0: Resolve CLI Path
 
-Resolve `$AIMI_CLI` path using glob discovery with fallback, then verify version. See `commands/references/cli-path-resolution.md` for the full resolution logic (glob -> fallback -> version check). Use `$AIMI_CLI` for all subsequent script calls.
+Resolve `$AIMI_CLI` path using the three-layer strategy below. Each command is a separate Bash call (no compound operators).
+
+**Layer 1 — Global cache (fast path):**
+```bash
+AIMI_CLI=$(cat ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path 2>/dev/null)
+```
+
+**Layer 1 validation:**
+```bash
+if [ -n "$AIMI_CLI" ] && [ ! -x "$AIMI_CLI" ]; then AIMI_CLI=""; fi
+```
+
+**Layer 2 — Glob fallback (zsh-safe, only if Layer 1 failed):**
+```bash
+if [ -z "$AIMI_CLI" ]; then AIMI_CLI=$(bash -c 'ls ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh 2>/dev/null | tail -1'); fi
+```
+
+**Layer 2 cache update:**
+```bash
+if [ -n "$AIMI_CLI" ]; then printf '%s\n' "$AIMI_CLI" > "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path.tmp" && mv "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path.tmp" "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" && chmod 600 "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path"; fi
+```
+
+**Layer 3 — Per-project fallback (last resort):**
+```bash
+if [ -z "$AIMI_CLI" ] && [ -f .aimi/cli-path ] && [ -x "$(cat .aimi/cli-path)" ]; then AIMI_CLI=$(cat .aimi/cli-path); fi
+```
+
+If empty, report: "aimi-cli.sh not found. Reinstall plugin: `/plugin install aimi-engineering`" and STOP.
+
+**Version check:**
+```bash
+$AIMI_CLI check-version --quiet --fix
+```
+
+Use `$AIMI_CLI` for all subsequent script calls.
 
 ## Step 1: Initialize Session
 

--- a/plugins/aimi-engineering/commands/next.md
+++ b/plugins/aimi-engineering/commands/next.md
@@ -11,7 +11,41 @@ Execute the next pending story using a Task-spawned agent.
 
 ## Step 0: Resolve CLI Path
 
-Resolve `$AIMI_CLI` path using glob discovery with fallback, then verify version. See `commands/references/cli-path-resolution.md` for the full resolution logic (glob -> fallback -> version check). Use `$AIMI_CLI` for all subsequent script calls.
+Resolve `$AIMI_CLI` path using the three-layer strategy below. Each command is a separate Bash call (no compound operators).
+
+**Layer 1 — Global cache (fast path):**
+```bash
+AIMI_CLI=$(cat ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path 2>/dev/null)
+```
+
+**Layer 1 validation:**
+```bash
+if [ -n "$AIMI_CLI" ] && [ ! -x "$AIMI_CLI" ]; then AIMI_CLI=""; fi
+```
+
+**Layer 2 — Glob fallback (zsh-safe, only if Layer 1 failed):**
+```bash
+if [ -z "$AIMI_CLI" ]; then AIMI_CLI=$(bash -c 'ls ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh 2>/dev/null | tail -1'); fi
+```
+
+**Layer 2 cache update:**
+```bash
+if [ -n "$AIMI_CLI" ]; then printf '%s\n' "$AIMI_CLI" > "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path.tmp" && mv "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path.tmp" "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" && chmod 600 "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path"; fi
+```
+
+**Layer 3 — Per-project fallback (last resort):**
+```bash
+if [ -z "$AIMI_CLI" ] && [ -f .aimi/cli-path ] && [ -x "$(cat .aimi/cli-path)" ]; then AIMI_CLI=$(cat .aimi/cli-path); fi
+```
+
+If empty, report: "aimi-cli.sh not found. Reinstall plugin: `/plugin install aimi-engineering`" and STOP.
+
+**Version check:**
+```bash
+$AIMI_CLI check-version --quiet --fix
+```
+
+Use `$AIMI_CLI` for all subsequent script calls.
 
 ## Step 1: Get Next Story
 

--- a/plugins/aimi-engineering/commands/next.md
+++ b/plugins/aimi-engineering/commands/next.md
@@ -45,11 +45,21 @@ STOP execution.
 
 The CLI also saves the story ID to `.aimi/current-story` for tracking.
 
+## Step 1b: Resolve Project Path
+
+If the story JSON contains a `project` field:
+
+1. Determine `AIMI_ROOT` — the parent directory of `.aimi/` (the CLI auto-discovers `.aimi/` by walking up from CWD)
+2. Resolve `PROJECT_PATH = realpath(AIMI_ROOT / story.project)`
+3. Verify `PROJECT_PATH` exists as a directory; if not, report failure and STOP
+
+If the story does **not** have a `project` field, skip this step — `PROJECT_PATH` remains unset and behavior is unchanged (CWD fallback).
+
 ## Step 2: Load Project Guidelines
 
 Load project guidelines following the discovery order defined in `story-executor/SKILL.md` → "PROJECT GUIDELINES" section:
 
-1. **CLAUDE.md** (project root) - Primary project instructions
+1. **CLAUDE.md** — If `PROJECT_PATH` is set, look for `CLAUDE.md` in `PROJECT_PATH` first. Otherwise use the current project root.
 2. **AGENTS.md** (any directory) - Module-specific patterns
 3. **Aimi defaults** from story-executor - Fallback if neither exists
 
@@ -75,12 +85,13 @@ Acceptance Criteria:
 
 Interpolate the following into the template:
 - `PROJECT_GUIDELINES` = guidelines loaded in Step 2
+- `PROJECT_PATH` = resolved project path from Step 1b (include `## Project Context` section only if set)
 - `STORY_ID` = story.id
 - `STORY_TITLE` = story.title
 - `STORY_DESCRIPTION` = story.description
 - `ACCEPTANCE_CRITERIA` = story.acceptanceCriteria (bulleted)
 - `story.notes` = story.notes (include PREVIOUS NOTES section only if non-empty)
-- No WORKTREE_PATH (sequential mode — worker operates in current directory)
+- No WORKTREE_PATH (sequential mode — worker operates in current directory, or PROJECT_PATH if set)
 
 ```
 # IMPORTANT: subagent_type MUST be "general-purpose" — story-executor is a skill, NOT an agent.

--- a/plugins/aimi-engineering/commands/plan.md
+++ b/plugins/aimi-engineering/commands/plan.md
@@ -93,7 +93,19 @@ Using consolidated research and spec-flow output:
 8. Initialize every story with `status: "pending"` and appropriate `dependsOn` array
 9. Validate: no circular dependencies in `dependsOn`, no self-references, all referenced IDs exist, no vague criteria
 
-See `references/story-decomposition.md` for detailed rules.
+### `dependsOn` Inference Rules
+
+- **Same layer, independent concerns** (different tables, different pages, different routes) → no dependency between them (`dependsOn: []`)
+- **Same layer, shared concern** (FK referencing another story's table, component extending another) → add dependency
+- **Cross-layer**: backend depends on schema stories it reads/writes; UI depends on backend it calls; aggregation depends on what it consumes
+- **Skip layers when appropriate**: UI reading directly from a new table depends on the schema story, not a non-existent backend story
+
+### Multi-Repo Project Assignment
+
+When the workspace has multiple git repos under one parent folder:
+- Set `project` to relative path from `.aimi/` parent (e.g., `backend`, `services/api`)
+- Omit `project` when only one repo exists or all stories target the same repo
+- Cross-repo dependencies in `dependsOn` are valid
 
 ### Type Values
 
@@ -130,10 +142,35 @@ mkdir -p .aimi/tasks
 
 Write JSON using the Write tool. Validate JSON is well-formed before writing.
 
-### Output Format
+### Schema v3 Structure
 
-> **Schema:** See `task-format-v3.md` in `skills/task-planner/references/`. Full v3 specification with complete example, validation rules, and dependency system.
-> Key fields: `schemaVersion`, `metadata{title,type,branchName,createdAt,planPath,maxConcurrency}`, `userStories[]{id,title,description,acceptanceCriteria,priority,status,dependsOn,notes}`
+```json
+{
+  "schemaVersion": "3.0",
+  "metadata": {
+    "title": "string (required)",
+    "type": "feat|ref|bug|chore (required)",
+    "branchName": "string (required, regex: ^[a-zA-Z0-9][a-zA-Z0-9/_-]*$)",
+    "createdAt": "YYYY-MM-DD (required)",
+    "planPath": "null (always null for planner-generated)",
+    "brainstormPath": "string (optional)",
+    "maxConcurrency": "number (optional, default 4)"
+  },
+  "userStories": [
+    {
+      "id": "US-NNN (required, zero-padded, regex: ^US-[0-9]{3}[a-z]?$)",
+      "title": "string (required, max 200 chars)",
+      "description": "string (required, max 500 chars, user story format)",
+      "acceptanceCriteria": ["string[] (required, each max 600 chars, must include 'Typecheck passes')"],
+      "priority": "number (required, sequential integers, tiebreaker for same-depth stories)",
+      "status": "pending (required, always 'pending' for new stories)",
+      "dependsOn": ["US-NNN (required, array of story IDs, empty [] for root stories)"],
+      "notes": "string (optional, default '')",
+      "project": "string (optional, relative path for multi-repo, no '..' components)"
+    }
+  ]
+}
+```
 
 ### Checklist Before Writing
 
@@ -167,7 +204,13 @@ $AIMI_CLI validate-ids
 $AIMI_CLI validate-deps
 ```
 
-**If either validation fails (non-zero exit):**
+### Validate Story Content
+
+```bash
+$AIMI_CLI validate-stories
+```
+
+**If any validation fails (non-zero exit):**
 1. Read the error output to identify the issues
 2. Fix the offending story IDs, `dependsOn` references, or dependency cycles
 3. Re-write the tasks.json file using the Write tool

--- a/plugins/aimi-engineering/commands/plan.md
+++ b/plugins/aimi-engineering/commands/plan.md
@@ -146,7 +146,7 @@ Write JSON using the Write tool. Validate JSON is well-formed before writing.
 
 ```json
 {
-  "schemaVersion": "3.0 (use 3.1 when any story has project field)",
+  "schemaVersion": "3.1",
   "metadata": {
     "title": "string (required)",
     "type": "feat|ref|bug|chore (required)",

--- a/plugins/aimi-engineering/commands/plan.md
+++ b/plugins/aimi-engineering/commands/plan.md
@@ -146,7 +146,7 @@ Write JSON using the Write tool. Validate JSON is well-formed before writing.
 
 ```json
 {
-  "schemaVersion": "3.0",
+  "schemaVersion": "3.0 (use 3.1 when any story has project field)",
   "metadata": {
     "title": "string (required)",
     "type": "feat|ref|bug|chore (required)",

--- a/plugins/aimi-engineering/commands/status.md
+++ b/plugins/aimi-engineering/commands/status.md
@@ -10,7 +10,41 @@ Display the current execution progress using the CLI script.
 
 ## Step 0: Resolve CLI Path
 
-Resolve `$AIMI_CLI` path using glob discovery with fallback, then verify version. See `commands/references/cli-path-resolution.md` for the full resolution logic (glob -> fallback -> version check). Use `$AIMI_CLI` for all subsequent script calls.
+Resolve `$AIMI_CLI` path using the three-layer strategy below. Each command is a separate Bash call (no compound operators).
+
+**Layer 1 — Global cache (fast path):**
+```bash
+AIMI_CLI=$(cat ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path 2>/dev/null)
+```
+
+**Layer 1 validation:**
+```bash
+if [ -n "$AIMI_CLI" ] && [ ! -x "$AIMI_CLI" ]; then AIMI_CLI=""; fi
+```
+
+**Layer 2 — Glob fallback (zsh-safe, only if Layer 1 failed):**
+```bash
+if [ -z "$AIMI_CLI" ]; then AIMI_CLI=$(bash -c 'ls ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh 2>/dev/null | tail -1'); fi
+```
+
+**Layer 2 cache update:**
+```bash
+if [ -n "$AIMI_CLI" ]; then printf '%s\n' "$AIMI_CLI" > "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path.tmp" && mv "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path.tmp" "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" && chmod 600 "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path"; fi
+```
+
+**Layer 3 — Per-project fallback (last resort):**
+```bash
+if [ -z "$AIMI_CLI" ] && [ -f .aimi/cli-path ] && [ -x "$(cat .aimi/cli-path)" ]; then AIMI_CLI=$(cat .aimi/cli-path); fi
+```
+
+If empty, report: "aimi-cli.sh not found. Reinstall plugin: `/plugin install aimi-engineering`" and STOP.
+
+**Version check:**
+```bash
+$AIMI_CLI check-version --quiet --fix
+```
+
+Use `$AIMI_CLI` for all subsequent script calls.
 
 ## Step 1: Get Status via CLI
 
@@ -22,7 +56,7 @@ $AIMI_CLI status
 
 This returns JSON with status counts and story list.
 
-> **Schema:** See `task-format-v3.md` in `skills/task-planner/references/`. The CLI status output mirrors the tasks.json structure with added aggregate counts.
+> The CLI status output mirrors the tasks.json structure with added aggregate counts.
 > Key fields: `schemaVersion`, `title`, `branch`, `maxConcurrency`, status counts (`pending`,`in_progress`,`completed`,`failed`,`skipped`,`total`), `userStories[]{id,title,status,dependsOn,priority,notes}`
 
 If no tasks file found, the script exits with error. Report:

--- a/plugins/aimi-engineering/commands/swarm.md
+++ b/plugins/aimi-engineering/commands/swarm.md
@@ -27,7 +27,39 @@ User runs /aimi:swarm
 
 ### AIMI CLI
 
-Resolve `$AIMI_CLI` path using glob discovery with fallback, then verify version. See `commands/references/cli-path-resolution.md` for the full resolution logic (glob -> fallback -> version check).
+Resolve `$AIMI_CLI` path using the three-layer strategy below. Each command is a separate Bash call (no compound operators).
+
+**Layer 1 — Global cache (fast path):**
+```bash
+AIMI_CLI=$(cat ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path 2>/dev/null)
+```
+
+**Layer 1 validation:**
+```bash
+if [ -n "$AIMI_CLI" ] && [ ! -x "$AIMI_CLI" ]; then AIMI_CLI=""; fi
+```
+
+**Layer 2 — Glob fallback (zsh-safe, only if Layer 1 failed):**
+```bash
+if [ -z "$AIMI_CLI" ]; then AIMI_CLI=$(bash -c 'ls ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh 2>/dev/null | tail -1'); fi
+```
+
+**Layer 2 cache update:**
+```bash
+if [ -n "$AIMI_CLI" ]; then printf '%s\n' "$AIMI_CLI" > "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path.tmp" && mv "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path.tmp" "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" && chmod 600 "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path"; fi
+```
+
+**Layer 3 — Per-project fallback (last resort):**
+```bash
+if [ -z "$AIMI_CLI" ] && [ -f .aimi/cli-path ] && [ -x "$(cat .aimi/cli-path)" ]; then AIMI_CLI=$(cat .aimi/cli-path); fi
+```
+
+If empty, report: "aimi-cli.sh not found. Reinstall plugin: `/plugin install aimi-engineering`" and STOP.
+
+**Version check:**
+```bash
+$AIMI_CLI check-version --quiet --fix
+```
 
 ### Worktree Manager
 

--- a/plugins/aimi-engineering/scripts/aimi-cli.sh
+++ b/plugins/aimi-engineering/scripts/aimi-cli.sh
@@ -464,7 +464,7 @@ cmd_list_ready() {
   ' "$tasks_file")
 
   if [ "$brief" = true ]; then
-    echo "$result" | jq '[.[] | {id, title, priority, dependsOn}]'
+    echo "$result" | jq '[.[] | {id, title, priority, dependsOn, project}]'
   else
     echo "$result"
   fi
@@ -754,7 +754,14 @@ cmd_validate_stories() {
         (if ($s.description | length) > 500 then ["\($s.id): description exceeds 500 chars"] else [] end) +
         ([$s.acceptanceCriteria[] | select(length > 600)] | if length > 0 then ["\($s.id): acceptance criterion exceeds 600 chars"] else [] end) +
         (if ($s.title | test("ignore previous|system:|INSTRUCTIONS|```|\\$\\(|`"; "i")) then ["\($s.id): title contains suspicious content"] else [] end) +
-        (if ($s.description | test("ignore previous|system:|INSTRUCTIONS|```|\\$\\(|`"; "i")) then ["\($s.id): description contains suspicious content"] else [] end)
+        (if ($s.description | test("ignore previous|system:|INSTRUCTIONS|```|\\$\\(|`"; "i")) then ["\($s.id): description contains suspicious content"] else [] end) +
+        (if ($s.project != null) then
+          (if ($s.project | test("^/")) then ["\($s.id): project must not be an absolute path"]
+           elif ($s.project | test("\\.\\.")) then ["\($s.id): project must not contain path traversal (..)"]
+           elif ($s.project | test("[\\$`;|&]")) then ["\($s.id): project contains shell metacharacters"]
+           elif ($s.project | test("^[a-zA-Z0-9_.][a-zA-Z0-9_./@-]*$") | not) then ["\($s.id): project contains invalid characters"]
+           else [] end)
+         else [] end)
       ) | .[]
     ] |
     if length == 0 then {valid: true, errors: []}

--- a/plugins/aimi-engineering/scripts/aimi-cli.sh
+++ b/plugins/aimi-engineering/scripts/aimi-cli.sh
@@ -49,6 +49,11 @@ find_aimi_root() {
 
       return 0
     fi
+    # Stop at HOME — never scan above the user's home directory
+    if [ "$dir" = "$HOME" ]; then
+      echo "Error: .aimi/ directory not found (searched up to \$HOME)" >&2
+      exit 1
+    fi
     local parent
     parent=$(dirname "$dir")
     if [ "$parent" = "$dir" ]; then

--- a/plugins/aimi-engineering/scripts/test-aimi-cli.sh
+++ b/plugins/aimi-engineering/scripts/test-aimi-cli.sh
@@ -1696,6 +1696,238 @@ test_check_version_fix_updates_global_cache() {
 }
 
 # ============================================================================
+# Project Field Validation Tests
+# ============================================================================
+
+# Helper: create a project-field test fixture and point CLI at it.
+# Accepts a JSON string to write and sets PROJECT_FIXTURE_FILE.
+_setup_project_fixture() {
+  local json="$1"
+  PROJECT_FIXTURE_FILE="$TASKS_DIR/9999-99-96-project-test.json"
+  printf '%s\n' "$json" > "$PROJECT_FIXTURE_FILE"
+  echo "$PROJECT_FIXTURE_FILE" > "$AIMI_DIR/current-tasks"
+}
+
+_teardown_project_fixture() {
+  rm -f "$PROJECT_FIXTURE_FILE"
+  echo "$TASKS_FILE" > "$AIMI_DIR/current-tasks"
+}
+
+test_validate_stories_with_valid_project() {
+  echo ""
+  echo "=== Testing validate-stories with valid project fields ==="
+
+  "$CLI" clear-state > /dev/null
+  "$CLI" init-session > /dev/null
+
+  _setup_project_fixture '{
+  "schemaVersion": "3.0",
+  "metadata": {
+    "title": "feat: Project test",
+    "type": "feat",
+    "branchName": "feat/project-test",
+    "createdAt": "2026-03-26",
+    "planPath": null,
+    "maxConcurrency": 2
+  },
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Story with simple project",
+      "description": "Has a simple project field",
+      "acceptanceCriteria": ["Passes"],
+      "priority": 1,
+      "status": "pending",
+      "dependsOn": [],
+      "notes": "",
+      "project": "backend"
+    },
+    {
+      "id": "US-002",
+      "title": "Story with nested project",
+      "description": "Has a nested project field",
+      "acceptanceCriteria": ["Passes"],
+      "priority": 2,
+      "status": "pending",
+      "dependsOn": [],
+      "notes": "",
+      "project": "services/api"
+    },
+    {
+      "id": "US-003",
+      "title": "Story without project",
+      "description": "No project field at all",
+      "acceptanceCriteria": ["Passes"],
+      "priority": 3,
+      "status": "pending",
+      "dependsOn": [],
+      "notes": ""
+    }
+  ]
+}'
+
+  local output exit_code
+  output=$("$CLI" validate-stories) && exit_code=0 || exit_code=$?
+
+  assert_contains '"valid": true' "$output" "validate-stories: valid project fields pass validation"
+  assert_exit_code "0" "$exit_code" "validate-stories: exits 0 for valid projects"
+
+  # Verify no errors reported
+  local error_count
+  error_count=$(echo "$output" | jq '.errors | length')
+  assert_eq "0" "$error_count" "validate-stories: zero errors for valid/missing project fields"
+
+  _teardown_project_fixture
+}
+
+test_validate_stories_with_traversal_project() {
+  echo ""
+  echo "=== Testing validate-stories rejects '..' traversal in project ==="
+
+  "$CLI" clear-state > /dev/null
+  "$CLI" init-session > /dev/null
+
+  _setup_project_fixture '{
+  "schemaVersion": "3.0",
+  "metadata": {
+    "title": "feat: Traversal test",
+    "type": "feat",
+    "branchName": "feat/traversal-test",
+    "createdAt": "2026-03-26",
+    "planPath": null,
+    "maxConcurrency": 2
+  },
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Traversal project",
+      "description": "Project with path traversal",
+      "acceptanceCriteria": ["Passes"],
+      "priority": 1,
+      "status": "pending",
+      "dependsOn": [],
+      "notes": "",
+      "project": "../escape/hack"
+    }
+  ]
+}'
+
+  local output exit_code
+  output=$("$CLI" validate-stories) && exit_code=0 || exit_code=$?
+
+  assert_contains '"valid": false' "$output" "validate-stories: traversal project fails validation"
+  assert_contains "path traversal" "$output" "validate-stories: error mentions path traversal"
+
+  _teardown_project_fixture
+}
+
+test_validate_stories_with_absolute_project() {
+  echo ""
+  echo "=== Testing validate-stories rejects absolute paths in project ==="
+
+  "$CLI" clear-state > /dev/null
+  "$CLI" init-session > /dev/null
+
+  _setup_project_fixture '{
+  "schemaVersion": "3.0",
+  "metadata": {
+    "title": "feat: Absolute path test",
+    "type": "feat",
+    "branchName": "feat/absolute-test",
+    "createdAt": "2026-03-26",
+    "planPath": null,
+    "maxConcurrency": 2
+  },
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Absolute path project",
+      "description": "Project with absolute path",
+      "acceptanceCriteria": ["Passes"],
+      "priority": 1,
+      "status": "pending",
+      "dependsOn": [],
+      "notes": "",
+      "project": "/etc/passwd"
+    }
+  ]
+}'
+
+  local output exit_code
+  output=$("$CLI" validate-stories) && exit_code=0 || exit_code=$?
+
+  assert_contains '"valid": false' "$output" "validate-stories: absolute path project fails validation"
+  assert_contains "absolute path" "$output" "validate-stories: error mentions absolute path"
+
+  _teardown_project_fixture
+}
+
+test_list_ready_brief_includes_project() {
+  echo ""
+  echo "=== Testing list-ready --brief includes project in output ==="
+
+  "$CLI" clear-state > /dev/null
+  "$CLI" init-session > /dev/null
+
+  _setup_project_fixture '{
+  "schemaVersion": "3.0",
+  "metadata": {
+    "title": "feat: Brief project test",
+    "type": "feat",
+    "branchName": "feat/brief-project",
+    "createdAt": "2026-03-26",
+    "planPath": null,
+    "maxConcurrency": 2
+  },
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Story with project",
+      "description": "Has project field",
+      "acceptanceCriteria": ["Passes"],
+      "priority": 1,
+      "status": "pending",
+      "dependsOn": [],
+      "notes": "",
+      "project": "backend"
+    },
+    {
+      "id": "US-002",
+      "title": "Story without project",
+      "description": "No project field",
+      "acceptanceCriteria": ["Passes"],
+      "priority": 2,
+      "status": "pending",
+      "dependsOn": [],
+      "notes": ""
+    }
+  ]
+}'
+
+  local output
+  output=$("$CLI" list-ready --brief)
+
+  # US-001 should have project: "backend"
+  local us001_project
+  us001_project=$(echo "$output" | jq -r '.[] | select(.id == "US-001") | .project')
+  assert_eq "backend" "$us001_project" "list-ready --brief: US-001 project is 'backend'"
+
+  # US-002 should have project: null (field missing in source)
+  local us002_project
+  us002_project=$(echo "$output" | jq -r '.[] | select(.id == "US-002") | .project')
+  assert_eq "null" "$us002_project" "list-ready --brief: US-002 project is null (backwards compat)"
+
+  # Verify project key is present on both stories
+  local has_project_us001 has_project_us002
+  has_project_us001=$(echo "$output" | jq '[.[] | select(.id == "US-001") | has("project")] | .[0]')
+  has_project_us002=$(echo "$output" | jq '[.[] | select(.id == "US-002") | has("project")] | .[0]')
+  assert_eq "true" "$has_project_us001" "list-ready --brief: US-001 has project key"
+  assert_eq "true" "$has_project_us002" "list-ready --brief: US-002 has project key"
+
+  _teardown_project_fixture
+}
+
+# ============================================================================
 # Main
 # ============================================================================
 
@@ -1792,6 +2024,14 @@ main() {
   test_read_global_worktree_cache_tampered
   test_init_session_writes_global_cache
   test_check_version_fix_updates_global_cache
+
+  # Project field validation tests — run with fresh state
+  echo ""
+  echo "--- Project Field Validation Tests ---"
+  test_validate_stories_with_valid_project
+  test_validate_stories_with_traversal_project
+  test_validate_stories_with_absolute_project
+  test_list_ready_brief_includes_project
 
   # CLI output optimization tests — run with fresh fixture each time
   echo ""

--- a/plugins/aimi-engineering/scripts/test-aimi-cli.sh
+++ b/plugins/aimi-engineering/scripts/test-aimi-cli.sh
@@ -34,7 +34,7 @@ setup() {
   # Create v3 test tasks file
   cat > "$TASKS_FILE" << 'EOF'
 {
-  "schemaVersion": "3.0",
+  "schemaVersion": "3.1",
   "metadata": {
     "title": "feat: Test feature",
     "type": "feat",
@@ -282,7 +282,7 @@ test_init_session() {
   output=$("$CLI" init-session)
 
   assert_contains '"pending": 4' "$output" "init-session counts pending by status"
-  assert_contains '"schemaVersion": "3.0"' "$output" "init-session returns schema version"
+  assert_contains '"schemaVersion": "3.1"' "$output" "init-session returns schema version"
   assert_contains "feat/test-feature" "$output" "init-session returns branch"
 
   # Check state files created
@@ -454,7 +454,7 @@ test_validate_deps_circular() {
   local circular_file="$TASKS_DIR/9999-99-97-circular-tasks.json"
   cat > "$circular_file" << 'EOF'
 {
-  "schemaVersion": "3.0",
+  "schemaVersion": "3.1",
   "metadata": {
     "title": "feat: Circular test",
     "type": "feat",
@@ -511,7 +511,7 @@ test_status() {
   local output
   output=$("$CLI" status)
 
-  assert_contains '"schemaVersion": "3.0"' "$output" "status shows schema version"
+  assert_contains '"schemaVersion": "3.1"' "$output" "status shows schema version"
   assert_contains '"maxConcurrency": 4' "$output" "status shows maxConcurrency"
   assert_contains '"dependsOn"' "$output" "status includes dependsOn in stories"
 }
@@ -969,7 +969,7 @@ test_auto_discovery_from_subdirectory() {
   output=$(cd "$TEST_DIR/sub/dir" && "$CLI" status) && exit_code=0 || exit_code=$?
 
   assert_exit_code "0" "$exit_code" "auto-discovery: CLI succeeds from subdirectory"
-  assert_contains '"schemaVersion": "3.0"' "$output" "auto-discovery: status returns schema from subdirectory"
+  assert_contains '"schemaVersion": "3.1"' "$output" "auto-discovery: status returns schema from subdirectory"
   assert_contains '"userStories"' "$output" "auto-discovery: status returns stories from subdirectory"
 }
 
@@ -1000,7 +1000,7 @@ reset_fixture() {
 
   cat > "$TASKS_FILE" << 'EOF'
 {
-  "schemaVersion": "3.0",
+  "schemaVersion": "3.1",
   "metadata": {
     "title": "feat: Test feature",
     "type": "feat",
@@ -1721,7 +1721,7 @@ test_validate_stories_with_valid_project() {
   "$CLI" init-session > /dev/null
 
   _setup_project_fixture '{
-  "schemaVersion": "3.0",
+  "schemaVersion": "3.1",
   "metadata": {
     "title": "feat: Project test",
     "type": "feat",
@@ -1788,7 +1788,7 @@ test_validate_stories_with_traversal_project() {
   "$CLI" init-session > /dev/null
 
   _setup_project_fixture '{
-  "schemaVersion": "3.0",
+  "schemaVersion": "3.1",
   "metadata": {
     "title": "feat: Traversal test",
     "type": "feat",
@@ -1829,7 +1829,7 @@ test_validate_stories_with_absolute_project() {
   "$CLI" init-session > /dev/null
 
   _setup_project_fixture '{
-  "schemaVersion": "3.0",
+  "schemaVersion": "3.1",
   "metadata": {
     "title": "feat: Absolute path test",
     "type": "feat",
@@ -1870,7 +1870,7 @@ test_list_ready_brief_includes_project() {
   "$CLI" init-session > /dev/null
 
   _setup_project_fixture '{
-  "schemaVersion": "3.0",
+  "schemaVersion": "3.1",
   "metadata": {
     "title": "feat: Brief project test",
     "type": "feat",

--- a/plugins/aimi-engineering/scripts/test-aimi-cli.sh
+++ b/plugins/aimi-engineering/scripts/test-aimi-cli.sh
@@ -1221,21 +1221,23 @@ test_list_ready_brief() {
   local output
   output=$("$CLI" list-ready --brief)
 
-  # Brief output should only have {id, title, priority, dependsOn} per story
+  # Brief output should only have {id, title, priority, dependsOn, project} per story
   local key_count
   key_count=$(echo "$output" | jq '.[0] | keys | length')
-  assert_eq "4" "$key_count" "list-ready --brief: each story has exactly 4 keys"
+  assert_eq "5" "$key_count" "list-ready --brief: each story has exactly 5 keys"
 
-  # Verify the 4 expected keys exist
-  local has_id has_title has_priority has_depends
+  # Verify the 5 expected keys exist
+  local has_id has_title has_priority has_depends has_project
   has_id=$(echo "$output" | jq '.[0] | has("id")')
   has_title=$(echo "$output" | jq '.[0] | has("title")')
   has_priority=$(echo "$output" | jq '.[0] | has("priority")')
   has_depends=$(echo "$output" | jq '.[0] | has("dependsOn")')
+  has_project=$(echo "$output" | jq '.[0] | has("project")')
   assert_eq "true" "$has_id" "list-ready --brief has id"
   assert_eq "true" "$has_title" "list-ready --brief has title"
   assert_eq "true" "$has_priority" "list-ready --brief has priority"
   assert_eq "true" "$has_depends" "list-ready --brief has dependsOn"
+  assert_eq "true" "$has_project" "list-ready --brief has project"
 
   # Should NOT have description, acceptanceCriteria, status, or notes
   local has_description has_criteria has_status has_notes

--- a/plugins/aimi-engineering/skills/story-executor/SKILL.md
+++ b/plugins/aimi-engineering/skills/story-executor/SKILL.md
@@ -26,8 +26,8 @@ Execute ONE story from the tasks file:
 
 ## Story Format
 
-> **Schema:** See `task-format-v3.md` in `../task-planner/references/`. Each story is one atomic unit of work completable in a single agent iteration.
-> Key fields: `id`, `title`, `description`, `acceptanceCriteria`, `priority`, `status`, `dependsOn`, `notes`
+> Each story is one atomic unit of work completable in a single agent iteration.
+> Key fields: `id(US-NNN)`, `title(<=200)`, `description(<=500)`, `acceptanceCriteria(each<=600)`, `priority`, `status`, `dependsOn([])`, `notes`, `project(optional, relative path for multi-repo)`
 
 ---
 

--- a/plugins/aimi-engineering/skills/story-executor/SKILL.md
+++ b/plugins/aimi-engineering/skills/story-executor/SKILL.md
@@ -15,7 +15,7 @@ Defines how Task-spawned agents execute individual stories from the tasks file.
 ## The Job
 
 Execute ONE story from the tasks file:
-0. If WORKTREE_PATH is provided, cd to it first
+0. If PROJECT_PATH is provided, cd to it first; if WORKTREE_PATH is also provided, cd to WORKTREE_PATH instead (worktree takes precedence)
 1. Read project guidelines (CLAUDE.md)
 2. Implement the story
 3. Verify acceptance criteria
@@ -41,14 +41,14 @@ The agent spawns fresh with no memory of previous work. If the story is too big,
 
 ## Project Root Boundary (CRITICAL)
 
-**Agents must NOT read or modify files outside the git repository root.**
+**Agents must NOT read or modify files outside the project boundary.**
 
-- All file operations (Read, Write, Edit, Bash) must target paths within the project root directory
-- The project root is the git repository root (where `.git/` lives)
+- The project boundary is PROJECT_PATH when set, otherwise the git repository root (where `.git/` lives)
+- All file operations (Read, Write, Edit, Bash) must target paths within the project boundary
 - Worktree paths under `.worktrees/` inside the git root are explicitly allowed
-- Never use `../` traversal to escape the project root
+- Never use `../` traversal to escape the project boundary
 - Never read system files, home directory configs, or files in parent directories
-- If a task seems to require accessing files outside the project root, report failure instead of proceeding
+- If a task seems to require accessing files outside the project boundary, report failure instead of proceeding
 
 ---
 
@@ -65,18 +65,34 @@ You are executing a single story from the tasks file.
 
 [CLAUDE.md content or default rules]
 
-## Worktree Context (if applicable)
+## Project Context
+
+[PROJECT_PATH]   ← optional, resolved absolute path to the target project
+
+If PROJECT_PATH is provided:
+- cd to PROJECT_PATH before any work
+- Load CLAUDE.md from PROJECT_PATH root
+- All file operations stay within PROJECT_PATH
+
+## Worktree Context
 
 [WORKTREE_PATH]  ← optional, provided by execute.md parallel mode
 
-If WORKTREE_PATH is provided:
+If both PROJECT_PATH and WORKTREE_PATH are provided:
+- cd to WORKTREE_PATH (worktree takes precedence; it is inside the project repo)
+- All file operations happen within the worktree
+- Commit to the worktree's branch (already checked out)
+- Do NOT modify the tasks.json file (leader handles this)
+- Report result (success/failure + details) — the leader processes your report
+
+If only WORKTREE_PATH is provided:
 - cd to WORKTREE_PATH before any work
 - All file operations happen within the worktree
 - Commit to the worktree's branch (already checked out)
 - Do NOT modify the tasks.json file (leader handles this)
 - Report result (success/failure + details) — the leader processes your report
 
-If no WORKTREE_PATH:
+If neither is provided:
 - Work in current directory (standard sequential behavior)
 - Report result — the caller (next.md/execute.md) handles status updates via the CLI
 
@@ -101,16 +117,16 @@ Do NOT invoke these via the Skill tool — "write" is a Write tool, not a skill.
 
 ## Project Root Boundary (CRITICAL)
 
-All file operations MUST stay within the git repository root directory.
-- Do NOT read or modify files outside the project root
+All file operations MUST stay within the project boundary: PROJECT_PATH when set, otherwise the git repository root.
+- Do NOT read or modify files outside the project boundary
 - Worktree paths (.worktrees/ inside git root) are allowed
-- Never use ../ traversal to escape the project root
+- Never use ../ traversal to escape the project boundary
 - If a task requires accessing external files, report failure instead
 
 ## Execution Flow
 
-0. If WORKTREE_PATH is set, cd to WORKTREE_PATH
-1. Read CLAUDE.md for project conventions
+0. If PROJECT_PATH is set, cd to PROJECT_PATH; if WORKTREE_PATH is also set, cd to WORKTREE_PATH instead (takes precedence)
+1. Read CLAUDE.md for project conventions (from PROJECT_PATH root when set)
 2. Implement the story requirements
 3. Verify ALL acceptance criteria are met
 4. Run typecheck: npx tsc --noEmit

--- a/plugins/aimi-engineering/skills/task-planner/SKILL.md
+++ b/plugins/aimi-engineering/skills/task-planner/SKILL.md
@@ -20,8 +20,7 @@ Take a feature description through research, spec analysis, and story decomposit
 
 **Filename:** `.aimi/tasks/YYYY-MM-DD-[feature-name]-tasks.json`
 
-> **Schema:** See `references/task-format-v3.md` for the full v3 specification with status state machine, dependency system, and validation rules.
-> Key fields: `schemaVersion`, `metadata{title,type,branchName,createdAt,planPath,maxConcurrency}`, `userStories[]{id,title,description,acceptanceCriteria,priority,status,dependsOn,notes}`
+> Key fields: `schemaVersion` ("3.0"), `metadata{title,type,branchName,createdAt,planPath(null),maxConcurrency(4)}`, `userStories[]{id(US-NNN),title(≤200),description(≤500),acceptanceCriteria(each≤600),priority,status("pending"),dependsOn([]),notes,project(optional)}`
 
 **Notes:** `planPath` is always `null` (this skill generates tasks.json directly). All stories initialize with `status: "pending"`. `dependsOn` is a string array of story IDs. `maxConcurrency` defaults to `4`.
 
@@ -38,7 +37,7 @@ Take a feature description through research, spec analysis, and story decomposit
 
 ## Pipeline Overview
 
-Execute these phases in order. See `references/pipeline-phases.md` for detailed instructions per phase.
+Execute these phases in order.
 
 ### Phase 0: Idea Refinement
 
@@ -46,7 +45,14 @@ Check `.aimi/brainstorms/` for a matching brainstorm (semantic match, within 14 
 
 ### Phase 1: Local Research (Parallel)
 
-**Auto-scan for git repos:** Before launching research agents, scan immediate child directories for `.git/` directories to discover sub-projects. Exclude `.worktrees/`, `node_modules/`, `.aimi/`, `vendor/`. List discovered repos with their relative paths from the `.aimi/` parent. See `references/pipeline-phases.md` for the scan command.
+**Auto-scan for git repos:** Before launching research agents, scan immediate child directories for `.git/` directories to discover sub-projects:
+```bash
+for dir in */; do
+  case "$dir" in .worktrees/|node_modules/|.aimi/|vendor/) continue;; esac
+  [ -d "$dir/.git" ] && echo "$dir"
+done
+```
+List discovered repos with their relative paths from the `.aimi/` parent.
 
 Run these agents **in parallel**:
 
@@ -95,12 +101,11 @@ Incorporate identified gaps as acceptance criteria or story notes.
 
 ### Phase 3: Story Decomposition
 
-Apply rules from `references/story-decomposition.md`:
 1. Extract requirements from research + spec-flow output
 2. Group by layer (schema → backend → UI → aggregation)
 3. Size check (one context window per story)
 4. Order by dependency (assign priority numbers)
-5. **Generate `dependsOn` arrays** using the inference rules in `references/story-decomposition.md`:
+5. **Generate `dependsOn` arrays**:
    - **Same layer, independent concerns** (different tables, different pages) → `dependsOn: []` between them
    - **Same layer, shared concern** (FK referencing another story's table) → add dependency
    - **Cross-layer**: backend depends on schema stories it reads/writes; UI depends on backend it calls; aggregation depends on what it consumes
@@ -108,7 +113,7 @@ Apply rules from `references/story-decomposition.md`:
 6. **Assign `project` field** when multiple repos were discovered in Phase 1:
    - Set `project` to the repo's relative path (e.g., `backend`, `services/api`)
    - Omit `project` when only one repo exists or the story targets the CWD repo
-   - See `references/pipeline-phases.md` for project assignment rules
+   - Path format: no leading `./`, no `..` components, must match `^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$`
 7. Assign IDs in `US-NNN` zero-padded format (`US-001`, `US-002`, ...) — never `US-1`, `story-1`, `S1`, or any other format
 8. Write descriptions in user story format: "As a [specific role], I want [feature] so that [benefit]" — role must name the actor, never just "user"
 9. Generate verifiable acceptance criteria
@@ -127,8 +132,6 @@ Apply rules from `references/story-decomposition.md`:
 5. Set `maxConcurrency` (optional — default `4`; set to `1` for fully sequential execution)
 6. For each story: set `status: "pending"`, include `dependsOn` array from Phase 3
 7. Write to `.aimi/tasks/YYYY-MM-DD-[feature-name]-tasks.json`
-
-See `references/task-format-v3.md` for the complete v3 schema definition, status state machine, and validation rules.
 
 ### Phase 4.5: Post-Generation Validation
 

--- a/plugins/aimi-engineering/skills/task-planner/SKILL.md
+++ b/plugins/aimi-engineering/skills/task-planner/SKILL.md
@@ -20,7 +20,7 @@ Take a feature description through research, spec analysis, and story decomposit
 
 **Filename:** `.aimi/tasks/YYYY-MM-DD-[feature-name]-tasks.json`
 
-> Key fields: `schemaVersion` ("3.0"), `metadata{title,type,branchName,createdAt,planPath(null),maxConcurrency(4)}`, `userStories[]{id(US-NNN),title(≤200),description(≤500),acceptanceCriteria(each≤600),priority,status("pending"),dependsOn([]),notes,project(optional)}`
+> Key fields: `schemaVersion` ("3.0" or "3.1" when stories use `project`), `metadata{title,type,branchName,createdAt,planPath(null),maxConcurrency(4)}`, `userStories[]{id(US-NNN),title(≤200),description(≤500),acceptanceCriteria(each≤600),priority,status("pending"),dependsOn([]),notes,project(optional)}`
 
 **Notes:** `planPath` is always `null` (this skill generates tasks.json directly). All stories initialize with `status: "pending"`. `dependsOn` is a string array of story IDs. `maxConcurrency` defaults to `4`.
 

--- a/plugins/aimi-engineering/skills/task-planner/SKILL.md
+++ b/plugins/aimi-engineering/skills/task-planner/SKILL.md
@@ -46,11 +46,13 @@ Check `.aimi/brainstorms/` for a matching brainstorm (semantic match, within 14 
 
 ### Phase 1: Local Research (Parallel)
 
+**Auto-scan for git repos:** Before launching research agents, scan immediate child directories for `.git/` directories to discover sub-projects. Exclude `.worktrees/`, `node_modules/`, `.aimi/`, `vendor/`. List discovered repos with their relative paths from the `.aimi/` parent. See `references/pipeline-phases.md` for the scan command.
+
 Run these agents **in parallel**:
 
 ```
 Task subagent_type="aimi-engineering:research:aimi-codebase-researcher"
-  prompt: "[feature description + brainstorm context]"
+  prompt: "[feature description + brainstorm context + discovered repos]"
 
 Task subagent_type="aimi-engineering:research:aimi-learnings-researcher"
   prompt: "[feature description]"
@@ -103,14 +105,18 @@ Apply rules from `references/story-decomposition.md`:
    - **Same layer, shared concern** (FK referencing another story's table) → add dependency
    - **Cross-layer**: backend depends on schema stories it reads/writes; UI depends on backend it calls; aggregation depends on what it consumes
    - **Skip layers when appropriate**: UI reading directly from a new table depends on the schema story, not a non-existent backend story
-6. Assign IDs in `US-NNN` zero-padded format (`US-001`, `US-002`, ...) — never `US-1`, `story-1`, `S1`, or any other format
-7. Write descriptions in user story format: "As a [specific role], I want [feature] so that [benefit]" — role must name the actor, never just "user"
-8. Generate verifiable acceptance criteria
-9. Validate dependency graph:
-   - No circular dependencies (DAG check)
-   - No self-references (no story lists its own ID)
-   - All IDs referenced in `dependsOn` exist as story IDs
-   - No vague acceptance criteria
+6. **Assign `project` field** when multiple repos were discovered in Phase 1:
+   - Set `project` to the repo's relative path (e.g., `backend`, `services/api`)
+   - Omit `project` when only one repo exists or the story targets the CWD repo
+   - See `references/pipeline-phases.md` for project assignment rules
+7. Assign IDs in `US-NNN` zero-padded format (`US-001`, `US-002`, ...) — never `US-1`, `story-1`, `S1`, or any other format
+8. Write descriptions in user story format: "As a [specific role], I want [feature] so that [benefit]" — role must name the actor, never just "user"
+9. Generate verifiable acceptance criteria
+10. Validate dependency graph:
+    - No circular dependencies (DAG check)
+    - No self-references (no story lists its own ID)
+    - All IDs referenced in `dependsOn` exist as story IDs
+    - No vague acceptance criteria
 
 ### Phase 4: Write tasks.json
 
@@ -131,15 +137,16 @@ After writing the tasks.json file, validate the generated output:
 ```bash
 $AIMI_CLI validate-ids
 $AIMI_CLI validate-deps
+$AIMI_CLI validate-stories
 ```
 
-**If either validation fails (non-zero exit):**
+**If any validation fails (non-zero exit):**
 1. Read the error output to identify the issues
-2. Fix the offending story IDs, `dependsOn` references, or dependency cycles
+2. Fix the offending story IDs, `dependsOn` references, dependency cycles, or `project` fields
 3. Re-write the tasks.json file using the Write tool
-4. Re-run both validations until they pass
+4. Re-run all validations until they pass
 
-Do **not** proceed to the report step until both validations succeed.
+Do **not** proceed to the report step until all validations succeed.
 
 ---
 
@@ -179,3 +186,5 @@ Do **not** proceed to the report step until both validations succeed.
 - [ ] No self-references (no story lists its own ID in `dependsOn`)
 - [ ] `priority` values are sequential integers, consistent with dependency depth
 - [ ] `maxConcurrency` (if set) is a positive integer
+- [ ] `project` (if present) is a relative path with no `..` components, matching `^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$`
+- [ ] `project` is omitted when only one repo exists or story targets CWD repo

--- a/plugins/aimi-engineering/skills/task-planner/SKILL.md
+++ b/plugins/aimi-engineering/skills/task-planner/SKILL.md
@@ -20,7 +20,7 @@ Take a feature description through research, spec analysis, and story decomposit
 
 **Filename:** `.aimi/tasks/YYYY-MM-DD-[feature-name]-tasks.json`
 
-> Key fields: `schemaVersion` ("3.0" or "3.1" when stories use `project`), `metadata{title,type,branchName,createdAt,planPath(null),maxConcurrency(4)}`, `userStories[]{id(US-NNN),title(≤200),description(≤500),acceptanceCriteria(each≤600),priority,status("pending"),dependsOn([]),notes,project(optional)}`
+> Key fields: `schemaVersion` ("3.1"), `metadata{title,type,branchName,createdAt,planPath(null),maxConcurrency(4)}`, `userStories[]{id(US-NNN),title(≤200),description(≤500),acceptanceCriteria(each≤600),priority,status("pending"),dependsOn([]),notes,project(optional)}`
 
 **Notes:** `planPath` is always `null` (this skill generates tasks.json directly). All stories initialize with `status: "pending"`. `dependsOn` is a string array of story IDs. `maxConcurrency` defaults to `4`.
 
@@ -126,7 +126,7 @@ Incorporate identified gaps as acceptance criteria or story notes.
 ### Phase 4: Write tasks.json
 
 1. Derive metadata: title, type, branchName (kebab-case), createdAt (today)
-2. Set `schemaVersion: "3.1"` if any story has a `project` field, otherwise `"3.0"`
+2. Set `schemaVersion: "3.1"`
 3. Set `planPath: null`
 4. Set `brainstormPath` if a brainstorm was used
 5. Set `maxConcurrency` (optional — default `4`; set to `1` for fully sequential execution)
@@ -180,7 +180,7 @@ Do **not** proceed to the report step until all validations succeed.
 - [ ] Field lengths: title ≤ 200, description ≤ 500, criterion ≤ 600
 
 ### v3 Schema Validations
-- [ ] `schemaVersion` is `"3.1"` when any story has `project`, otherwise `"3.0"`
+- [ ] `schemaVersion` is `"3.1"`
 - [ ] Every story `id` follows `US-NNN` format (e.g., `US-001`, `US-002`) — not `S1`, `F1`, `TASK-1`, or any other format
 - [ ] Every story has `status` initialized to `"pending"`
 - [ ] Every story has a `dependsOn` array (even if empty `[]`)

--- a/plugins/aimi-engineering/skills/task-planner/SKILL.md
+++ b/plugins/aimi-engineering/skills/task-planner/SKILL.md
@@ -126,7 +126,7 @@ Incorporate identified gaps as acceptance criteria or story notes.
 ### Phase 4: Write tasks.json
 
 1. Derive metadata: title, type, branchName (kebab-case), createdAt (today)
-2. Set `schemaVersion: "3.0"`
+2. Set `schemaVersion: "3.1"` if any story has a `project` field, otherwise `"3.0"`
 3. Set `planPath: null`
 4. Set `brainstormPath` if a brainstorm was used
 5. Set `maxConcurrency` (optional — default `4`; set to `1` for fully sequential execution)
@@ -180,7 +180,7 @@ Do **not** proceed to the report step until all validations succeed.
 - [ ] Field lengths: title ≤ 200, description ≤ 500, criterion ≤ 600
 
 ### v3 Schema Validations
-- [ ] `schemaVersion` is `"3.0"`
+- [ ] `schemaVersion` is `"3.1"` when any story has `project`, otherwise `"3.0"`
 - [ ] Every story `id` follows `US-NNN` format (e.g., `US-001`, `US-002`) — not `S1`, `F1`, `TASK-1`, or any other format
 - [ ] Every story has `status` initialized to `"pending"`
 - [ ] Every story has a `dependsOn` array (even if empty `[]`)

--- a/plugins/aimi-engineering/skills/task-planner/references/pipeline-phases.md
+++ b/plugins/aimi-engineering/skills/task-planner/references/pipeline-phases.md
@@ -48,6 +48,26 @@ During refinement, note for Phase 1.5:
 
 ## Phase 1: Local Research (Always Runs)
 
+### Auto-Scan for Git Repos
+
+Before launching research agents, scan immediate child directories of the `.aimi/` parent folder for git repositories:
+
+```bash
+for dir in */; do
+  case "$dir" in .worktrees/|node_modules/|.aimi/|vendor/) continue;; esac
+  [ -d "$dir/.git" ] && echo "$dir"
+done
+```
+
+**Rules:**
+- Only scan **immediate** children (no recursive search)
+- Exclude: `.worktrees/`, `node_modules/`, `.aimi/`, `vendor/`
+- Record discovered repos with their relative paths (e.g., `backend`, `services/api`, `packages/shared`)
+- If **zero** or **one** repo is found, no multi-repo handling is needed
+- If **multiple** repos are found, pass the list to research agents and use it in Phase 3 for project assignment
+
+### Research Agents
+
 Run two agents **in parallel** using the Task tool:
 
 ### Agent 1: aimi-codebase-researcher
@@ -188,7 +208,30 @@ Using the consolidated research and spec-flow output:
 4. Apply sizing rules (one context window per story)
 5. Assign priority numbers by dependency order
 6. Generate verifiable acceptance criteria per story
-7. Run validation checklist
+7. **Assign `project` field** (multi-repo only)
+8. Run validation checklist
+
+### Project Assignment Rules
+
+When Phase 1 discovered **multiple** git repos, assign the `project` field to each story:
+
+1. **Infer target repo** from the story's feature description, affected file paths, and codebase research results
+2. **Set `project`** to the repo's relative path from the `.aimi/` parent (e.g., `backend`, `services/api`, `packages/shared`)
+3. **Omit `project`** when:
+   - Only one repo was discovered (or zero)
+   - The story targets the CWD repo (the repo where `.aimi/` lives)
+4. **Path format**: Use forward slashes, no leading `./`, no `..` components. Must match `^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$`
+5. **Cross-repo dependencies**: Stories in different repos can still depend on each other via `dependsOn`. The executor handles repo switching.
+
+**Example:**
+```
+Phase 1 discovered: backend/, frontend/, packages/shared/
+
+US-001 → changes packages/shared/types.ts     → project: "packages/shared"
+US-002 → changes backend/src/api/routes.ts    → project: "backend"
+US-003 → changes frontend/src/pages/Home.tsx  → project: "frontend"
+US-004 → changes only CWD files               → project: omitted
+```
 
 ---
 

--- a/plugins/aimi-engineering/skills/task-planner/references/story-decomposition.md
+++ b/plugins/aimi-engineering/skills/task-planner/references/story-decomposition.md
@@ -48,6 +48,29 @@ Earlier stories must NOT depend on later stories.
 
 ---
 
+## Multi-Repo Project Assignment
+
+When the `.aimi/` parent folder contains multiple git repos and stories target different repos, set the `project` field on each story.
+
+### When to set `project`
+
+- The workspace has multiple repos under one parent (monorepo siblings, separate services)
+- Stories target different repos (e.g., US-001 in `backend`, US-002 in `frontend`)
+
+### When to omit `project`
+
+- Only one repo exists in the workspace
+- All stories target the same repo
+
+### Format rules
+
+- Value is a **relative path** from the `.aimi/` parent folder to the target repo (e.g., `backend`, `services/api`)
+- No `..` path components allowed
+- No absolute paths allowed
+- Cross-repo dependencies in `dependsOn` are valid (US-001 in `backend` can depend on US-002 in `frontend`)
+
+---
+
 ## `dependsOn` Generation Rules
 
 Every v3 story MUST include a `dependsOn` array (string array of story IDs). The planner infers dependencies using two strategies: **layer-based** and **cross-layer**.
@@ -245,6 +268,7 @@ As a [specific role], I want [feature] so that [benefit]
 4. **All stories**: `status: "pending"` and empty `notes`
 5. **branchName**: Derive from feature name, kebab-case, prefixed with type
 6. **Always add**: "Typecheck passes" to every story's acceptance criteria
+7. **`project`** (optional): Set only when stories target different repos — see [Multi-Repo Project Assignment](#multi-repo-project-assignment)
 
 ---
 
@@ -298,6 +322,11 @@ Before finalizing stories, verify:
 - [ ] No self-references (no story lists its own ID in `dependsOn`)
 - [ ] Cross-layer dependencies are correct (backend → schema, UI → backend)
 - [ ] Same-layer stories with no shared concerns are independent (`dependsOn` does not link them)
+
+### Project Field
+- [ ] `project` is set only when stories target different repos
+- [ ] `project` value is a valid relative path (no `..` components, no absolute paths)
+- [ ] All stories in a multi-repo plan have `project` set
 
 ### Priority
 - [ ] No duplicate priority numbers

--- a/plugins/aimi-engineering/skills/task-planner/references/task-format-v3.md
+++ b/plugins/aimi-engineering/skills/task-planner/references/task-format-v3.md
@@ -36,7 +36,7 @@ Example: `.aimi/tasks/2026-02-27-dep-graph-tasks.json`
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `schemaVersion` | string | Yes | Must be `"3.0"` |
+| `schemaVersion` | string | Yes | Must be `"3.0"` or `"3.1"` |
 | `metadata` | object | Yes | Project metadata |
 | `userStories` | array | Yes | Array of Story objects |
 
@@ -66,6 +66,7 @@ Each story is ONE atomic unit of work completable in a single agent iteration.
 | `status` | string | Yes | `"pending"` | One of: `"pending"`, `"in_progress"`, `"completed"`, `"failed"`, `"skipped"` |
 | `dependsOn` | string[] | Yes | `[]` | Array of story IDs this story depends on (e.g., `["US-001", "US-002"]`) |
 | `notes` | string | No | `""` | Error details, learnings, or skip reason |
+| `project` | string | No | absent | Relative path to the sub-project directory (relative to the parent folder where `.aimi/` lives). When absent, the story falls back to CWD (backwards compatible). |
 
 ---
 
@@ -294,13 +295,81 @@ In this example, US-002 and US-003 can run in parallel (both depend only on US-0
 
 ---
 
+## Multi-Repo Example (with `project` field)
+
+When a plan spans multiple sub-projects within a monorepo, use the `project` field to indicate which sub-project each story targets. The path is relative to the parent folder where `.aimi/` lives.
+
+```json
+{
+  "schemaVersion": "3.1",
+  "metadata": {
+    "title": "feat: Add cross-service authentication",
+    "type": "feat",
+    "branchName": "feat/cross-service-auth",
+    "createdAt": "2026-03-26",
+    "planPath": null,
+    "maxConcurrency": 2
+  },
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Add auth token schema to shared library",
+      "description": "As a backend developer, I want a shared auth token type so that both services use the same contract.",
+      "acceptanceCriteria": [
+        "AuthToken type exported from shared/types",
+        "Typecheck passes"
+      ],
+      "priority": 1,
+      "status": "pending",
+      "dependsOn": [],
+      "notes": "",
+      "project": "packages/shared"
+    },
+    {
+      "id": "US-002",
+      "title": "Implement token validation middleware in API gateway",
+      "description": "As a platform engineer, I want the API gateway to validate auth tokens so that downstream services receive verified requests.",
+      "acceptanceCriteria": [
+        "Middleware validates token signature and expiry",
+        "Returns 401 on invalid token",
+        "Typecheck passes"
+      ],
+      "priority": 2,
+      "status": "pending",
+      "dependsOn": ["US-001"],
+      "notes": "",
+      "project": "services/api-gateway"
+    },
+    {
+      "id": "US-003",
+      "title": "Add token refresh endpoint to auth service",
+      "description": "As an end user, I want my session to refresh automatically so that I stay logged in.",
+      "acceptanceCriteria": [
+        "POST /auth/refresh returns new token pair",
+        "Old refresh token is invalidated",
+        "Typecheck passes"
+      ],
+      "priority": 3,
+      "status": "pending",
+      "dependsOn": ["US-001"],
+      "notes": "",
+      "project": "services/auth"
+    }
+  ]
+}
+```
+
+In this example, US-001 targets `packages/shared`, while US-002 and US-003 target different services. The executor uses the `project` path to set the working directory for each story. Stories without a `project` field default to CWD.
+
+---
+
 ## Validation Rules
 
 ### Required Fields Check
 
 Before processing, validate:
 
-1. `schemaVersion` must be `"3.0"`
+1. `schemaVersion` must be `"3.0"` or `"3.1"`
 2. `metadata.title` must be non-empty
 3. `metadata.type` must be one of: `feat`, `ref`, `bug`, `chore`
 4. `metadata.branchName` must be non-empty and match `^[a-zA-Z0-9][a-zA-Z0-9/_-]*$`
@@ -313,6 +382,7 @@ Before processing, validate:
 11. No duplicate story IDs
 12. No duplicate priority values
 13. Dependency graph must be a valid DAG (no cycles, no self-refs, all refs exist)
+14. Each story's `project` (if present) must be a relative path with no `..` components and must match `^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$`
 
 ### Validation Error Format
 

--- a/plugins/aimi-engineering/skills/task-planner/references/task-format-v3.md
+++ b/plugins/aimi-engineering/skills/task-planner/references/task-format-v3.md
@@ -14,7 +14,7 @@ Example: `.aimi/tasks/2026-02-27-dep-graph-tasks.json`
 
 ```json
 {
-  "schemaVersion": "3.0",
+  "schemaVersion": "3.1",
   "metadata": {
     "title": "string",
     "type": "feat|ref|bug|chore",
@@ -36,7 +36,7 @@ Example: `.aimi/tasks/2026-02-27-dep-graph-tasks.json`
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `schemaVersion` | string | Yes | Must be `"3.0"` or `"3.1"` |
+| `schemaVersion` | string | Yes | Must be `"3.1"` |
 | `metadata` | object | Yes | Project metadata |
 | `userStories` | array | Yes | Array of Story objects |
 
@@ -217,7 +217,7 @@ The executor picks up to `maxConcurrency` ready stories, ordered by `priority`, 
 
 ```json
 {
-  "schemaVersion": "3.0",
+  "schemaVersion": "3.1",
   "metadata": {
     "title": "feat: Add task status feature",
     "type": "feat",
@@ -369,7 +369,7 @@ In this example, US-001 targets `packages/shared`, while US-002 and US-003 targe
 
 Before processing, validate:
 
-1. `schemaVersion` must be `"3.0"` or `"3.1"`
+1. `schemaVersion` must be `"3.1"`
 2. `metadata.title` must be non-empty
 3. `metadata.type` must be one of: `feat`, `ref`, `bug`, `chore`
 4. `metadata.branchName` must be non-empty and match `^[a-zA-Z0-9][a-zA-Z0-9/_-]*$`


### PR DESCRIPTION
## Summary

- Add optional `project` field to task schema v3.1 — specifies a relative path from AIMI_ROOT to the target git repo, enabling stories to target different repositories in a multi-repo workspace
- Planner auto-scans child directories for `.git/` repos and assigns `project` per story; CLI validates format (no absolute paths, no `..`, no shell metacharacters)
- Executor resolves `PROJECT_PATH` at runtime, loads per-project CLAUDE.md/AGENTS.md, sets up branches per project, and groups worktrees by project for parallel execution
- Inline all broken relative path references (`See references/...`) across commands and skills so agents can resolve CLI path and schema info when plugin is installed outside the repo

