### PR TITLE
feat: Cross-platform plugin installation via AIMI_PLUGIN_DIR and install.sh

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and worktree+team orchestration.",
-      "version": "1.32.0",
+      "version": "1.33.0",
       "author": {
         "name": "Stanley Takamatsu",
         "url": "https://github.com/aimi-so"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and worktree+team orchestration.",
-      "version": "1.31.0",
+      "version": "1.32.0",
       "author": {
         "name": "Stanley Takamatsu",
         "url": "https://github.com/aimi-so"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.32.0] - 2026-03-30
+
+### Added
+
+- **cross-platform**: Cross-platform installation via compound-plugin converter for OpenCode, Codex, Copilot, and auto-detect
+- **AIMI_PLUGIN_DIR**: Environment variable support for custom plugin directory resolution in all CLI commands
+- **Layer 0**: CLI path resolution in all commands using AIMI_PLUGIN_DIR as Layer 0
+- **auto-approve**: Hook patterns for Layer 0 resolution
+- **tests**: Coverage for AIMI_PLUGIN_DIR paths
+
 ## [1.31.0] - 2026-03-30
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.33.0] - 2026-03-30
+
+### Added
+
+- **install.sh**: Self-contained installer script for OpenCode cross-platform installation (no external dependencies)
+- **install.sh**: Translates Claude Code commands and agents to OpenCode-native format
+- **install.sh**: Automatic context7 MCP configuration in opencode.json
+- **install.sh**: Uninstall support with `--uninstall` flag
+
+### Changed
+
+- **README.md**: Replaced compound-plugin converter instructions with install.sh usage
+
 ## [1.32.0] - 2026-03-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -53,26 +53,20 @@ Install the Aimi Engineering Plugin in OpenCode using the built-in installer. No
 # Clone and install
 git clone https://github.com/aimi-so/aimi-engineering-plugin
 cd aimi-engineering-plugin
-./install.sh
-```
-
-Or install directly:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/aimi-so/aimi-engineering-plugin/main/install.sh -o /tmp/aimi-install.sh && bash /tmp/aimi-install.sh
+./install.sh --to opencode
 ```
 
 ### Project-Level Install
 
 ```bash
 # Install into .opencode/ in your project directory
-./install.sh --project
+./install.sh --to opencode --project
 ```
 
 ### Uninstall
 
 ```bash
-./install.sh --uninstall
+./install.sh --uninstall --from opencode
 ```
 
 ### What the Installer Does

--- a/README.md
+++ b/README.md
@@ -45,39 +45,47 @@ claude /plugin list
 
 ## Cross-Platform Installation
 
-Install the Aimi Engineering Plugin in AI coding tools other than Claude Code using the compound-plugin converter.
+Install the Aimi Engineering Plugin in OpenCode using the built-in installer. No external dependencies required.
 
 ### OpenCode
 
 ```bash
-# Install for OpenCode
-bunx @every-env/compound-plugin install aimi-engineering --to opencode
+# Clone and install
+git clone https://github.com/aimi-so/aimi-engineering-plugin
+cd aimi-engineering-plugin
+./install.sh
 ```
 
-### Codex
+Or install directly:
 
 ```bash
-# Install for Codex
-bunx @every-env/compound-plugin install aimi-engineering --to codex
+curl -fsSL https://raw.githubusercontent.com/aimi-so/aimi-engineering-plugin/main/install.sh -o /tmp/aimi-install.sh && bash /tmp/aimi-install.sh
 ```
 
-### Copilot
+### Project-Level Install
 
 ```bash
-# Install for Copilot
-bunx @every-env/compound-plugin install aimi-engineering --to copilot
+# Install into .opencode/ in your project directory
+./install.sh --project
 ```
 
-### Auto-Detect
+### Uninstall
 
 ```bash
-# Install for all detected AI coding tools
-bunx @every-env/compound-plugin install aimi-engineering --to all
+./install.sh --uninstall
 ```
+
+### What the Installer Does
+
+1. Copies plugin source to `~/.config/opencode/plugins/aimi-engineering/`
+2. Translates commands to `~/.config/opencode/commands/aimi-*.md`
+3. Translates agents to `~/.config/opencode/agents/aimi-*.md`
+4. Adds context7 MCP server to `opencode.json`
+5. Sets `AIMI_PLUGIN_DIR` in shell profile
 
 ### Environment Variable
 
-The `AIMI_PLUGIN_DIR` environment variable controls where the plugin resolves its internal files (CLI scripts, skill references, agent definitions). The compound-plugin converter sets this variable automatically during installation so that commands work outside the Claude Code plugin directory structure. Do not set this variable manually unless you have a custom installation layout.
+The `AIMI_PLUGIN_DIR` environment variable points to the installed plugin directory so that commands can locate CLI scripts, skill references, and agent definitions. The installer sets this automatically. Do not set this variable manually unless you have a custom installation layout.
 
 ## Quick Start
 
@@ -574,7 +582,7 @@ Invalid characters (spaces, semicolons, quotes) trigger validation errors.
 
 ## Version History
 
-**Current Version:** 1.32.0
+**Current Version:** 1.33.0
 
 ### Recent Changes
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Transform implementation plans into executable user stories, then run them auton
 ## Table of Contents
 
 - [Installation](#installation)
-- [Cross-Platform Installation](#cross-platform-installation)
 - [Quick Start](#quick-start)
 - [Commands](#commands)
 - [Skills](#skills)
@@ -21,61 +20,66 @@ Transform implementation plans into executable user stories, then run them auton
 
 ## Installation
 
-### Prerequisites
+### Claude Code
 
-No external plugin dependencies. This plugin is fully standalone.
-
-### Install Steps
+No external dependencies. This plugin is fully standalone.
 
 ```bash
-# Install aimi-engineering plugin
+# Add marketplace and install
 claude /plugin marketplace add https://github.com/aimi-so/aimi-engineering-plugin
 claude /plugin install aimi-engineering
 ```
 
-### Verify Installation
+Verify installation:
 
 ```bash
-# Check plugin is installed
 claude /plugin list
-
-# Test aimi commands are available
 /aimi:status
 ```
 
-## Cross-Platform Installation
-
-Install the Aimi Engineering Plugin in OpenCode using the built-in installer. No external dependencies required.
-
 ### OpenCode
 
+Install using the built-in installer script. No external dependencies required.
+
 ```bash
-# Clone and install
 git clone https://github.com/aimi-so/aimi-engineering-plugin
 cd aimi-engineering-plugin
 ./install.sh --to opencode
 ```
 
-### Project-Level Install
+This installs the plugin into OpenCode's global config directory (`~/.config/opencode/`):
+
+- **Commands** are translated to `~/.config/opencode/commands/aimi-*.md`
+- **Agents** are translated to `~/.config/opencode/agents/aimi-*.md`
+- **Plugin source** (CLI scripts, skills, hooks) is copied to `~/.config/opencode/plugins/aimi-engineering/`
+- **context7 MCP** server is added to `opencode.json`
+- **`AIMI_PLUGIN_DIR`** is set in your shell profile
+
+After installation, restart your shell or run:
 
 ```bash
-# Install into .opencode/ in your project directory
+export AIMI_PLUGIN_DIR="$HOME/.config/opencode/plugins/aimi-engineering"
+```
+
+#### Project-Level Install
+
+To install into `.opencode/` in your project directory instead of globally:
+
+```bash
 ./install.sh --to opencode --project
 ```
 
-### Uninstall
+#### Uninstall
 
 ```bash
 ./install.sh --uninstall --from opencode
 ```
 
-### What the Installer Does
+#### Preview Changes
 
-1. Copies plugin source to `~/.config/opencode/plugins/aimi-engineering/`
-2. Translates commands to `~/.config/opencode/commands/aimi-*.md`
-3. Translates agents to `~/.config/opencode/agents/aimi-*.md`
-4. Adds context7 MCP server to `opencode.json`
-5. Sets `AIMI_PLUGIN_DIR` in shell profile
+```bash
+./install.sh --to opencode --dry-run
+```
 
 ### Environment Variable
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Transform implementation plans into executable user stories, then run them auton
 ## Table of Contents
 
 - [Installation](#installation)
+- [Cross-Platform Installation](#cross-platform-installation)
 - [Quick Start](#quick-start)
 - [Commands](#commands)
 - [Skills](#skills)
@@ -41,6 +42,42 @@ claude /plugin list
 # Test aimi commands are available
 /aimi:status
 ```
+
+## Cross-Platform Installation
+
+Install the Aimi Engineering Plugin in AI coding tools other than Claude Code using the compound-plugin converter.
+
+### OpenCode
+
+```bash
+# Install for OpenCode
+bunx @every-env/compound-plugin install aimi-engineering --to opencode
+```
+
+### Codex
+
+```bash
+# Install for Codex
+bunx @every-env/compound-plugin install aimi-engineering --to codex
+```
+
+### Copilot
+
+```bash
+# Install for Copilot
+bunx @every-env/compound-plugin install aimi-engineering --to copilot
+```
+
+### Auto-Detect
+
+```bash
+# Install for all detected AI coding tools
+bunx @every-env/compound-plugin install aimi-engineering --to all
+```
+
+### Environment Variable
+
+The `AIMI_PLUGIN_DIR` environment variable controls where the plugin resolves its internal files (CLI scripts, skill references, agent definitions). The compound-plugin converter sets this variable automatically during installation so that commands work outside the Claude Code plugin directory structure. Do not set this variable manually unless you have a custom installation layout.
 
 ## Quick Start
 
@@ -537,7 +574,7 @@ Invalid characters (spaces, semicolons, quotes) trigger validation errors.
 
 ## Version History
 
-**Current Version:** 1.30.0
+**Current Version:** 1.32.0
 
 ### Recent Changes
 

--- a/install.sh
+++ b/install.sh
@@ -332,7 +332,7 @@ install_mcp() {
     if command -v jq >/dev/null 2>&1; then
       local tmp
       tmp=$(mktemp)
-      jq '.mcp = (.mcp // {}) + {"context7": {"type": "http", "url": "https://mcp.context7.com/mcp"}}' "$config_file" > "$tmp" && mv "$tmp" "$config_file"
+      jq '.mcp = (.mcp // {}) + {"context7": {"type": "remote", "url": "https://mcp.context7.com/mcp"}}' "$config_file" > "$tmp" && mv "$tmp" "$config_file"
     # Try python3 fallback
     elif command -v python3 >/dev/null 2>&1; then
       python3 -c "
@@ -355,7 +355,7 @@ with open('$config_file', 'w') as f:
 {
   "mcp": {
     "context7": {
-      "type": "http",
+      "type": "remote",
       "url": "https://mcp.context7.com/mcp"
     }
   }

--- a/install.sh
+++ b/install.sh
@@ -194,7 +194,7 @@ translate_agent() {
 
   {
     printf '%s\n' "---"
-    printf '%s\n' "mode: agent"
+    printf '%s\n' "mode: subagent"
     printf 'description: %s\n' "$desc"
     printf '%s\n' "---"
     printf '%s' "$FM_BODY"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,538 @@
+#!/usr/bin/env bash
+# install.sh — Install aimi-engineering plugin for OpenCode
+# Usage: ./install.sh [--project] [--uninstall] [--dry-run]
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_NAME="aimi-engineering"
+DRY_RUN=0
+PROJECT_MODE=0
+UNINSTALL=0
+VERBOSE=0
+
+log()  { printf '\033[0;34m%s\033[0m\n' "$*"; }
+ok()   { printf '\033[0;32m%s\033[0m\n' "$*"; }
+warn() { printf '\033[1;33m%s\033[0m\n' "$*" >&2; }
+die()  { printf '\033[0;31mError: %s\033[0m\n' "$*" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Argument parsing (no getopt — portable)
+# ---------------------------------------------------------------------------
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --project)   PROJECT_MODE=1 ;;
+    --uninstall) UNINSTALL=1 ;;
+    --dry-run)   DRY_RUN=1 ;;
+    --verbose)   VERBOSE=1 ;;
+    --help|-h)
+      cat <<'USAGE'
+Usage: ./install.sh [OPTIONS]
+
+Install aimi-engineering plugin for OpenCode.
+
+Options:
+  --project     Install into .opencode/ in current directory (project-level)
+  --uninstall   Remove installed files
+  --dry-run     Show what would be done without doing it
+  --verbose     Print detailed progress
+  --help        Show this help
+
+Examples:
+  ./install.sh                  # Global install to ~/.config/opencode/
+  ./install.sh --project        # Project install to .opencode/
+  ./install.sh --uninstall      # Remove global install
+  ./install.sh --dry-run        # Preview changes
+USAGE
+      exit 0
+      ;;
+    *) die "Unknown option: $1. Use --help for usage." ;;
+  esac
+  shift
+done
+
+# ---------------------------------------------------------------------------
+# detect_plugin_source — find plugins/aimi-engineering/ relative to script
+# ---------------------------------------------------------------------------
+detect_plugin_source() {
+  local src="$SCRIPT_DIR/plugins/$PLUGIN_NAME"
+  if [ -d "$src" ] && [ -f "$src/.claude-plugin/plugin.json" ]; then
+    printf '%s\n' "$src"
+    return 0
+  fi
+  die "Plugin source not found at $src. Run this script from the repository root."
+}
+
+# ---------------------------------------------------------------------------
+# resolve_target_dir — determine where to install
+# ---------------------------------------------------------------------------
+resolve_target_dir() {
+  if [ "$PROJECT_MODE" -eq 1 ]; then
+    printf '%s\n' "$(pwd)/.opencode"
+  else
+    printf '%s\n' "${XDG_CONFIG_HOME:-$HOME/.config}/opencode"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# backup_file — timestamped backup before modifying
+# ---------------------------------------------------------------------------
+backup_file() {
+  local path="$1"
+  if [ -f "$path" ]; then
+    local ts
+    ts=$(date +%Y%m%d-%H%M%S)
+    local bak="${path}.bak.${ts}"
+    if [ "$DRY_RUN" -eq 1 ]; then
+      log "[dry-run] Would backup $path -> $bak"
+    else
+      cp "$path" "$bak"
+      [ "$VERBOSE" -eq 1 ] && log "Backed up $path -> $bak"
+    fi
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# parse_frontmatter — extract YAML frontmatter from .md file
+# Returns via global vars: FM_KEYS[], FM_VALS[], FM_BODY
+# Uses parallel arrays (bash 3 compat — no associative arrays)
+# ---------------------------------------------------------------------------
+FM_KEYS=()
+FM_VALS=()
+FM_BODY=""
+
+parse_frontmatter() {
+  local file="$1"
+  FM_KEYS=()
+  FM_VALS=()
+  FM_BODY=""
+
+  local in_fm=0
+  local fm_started=0
+  local body=""
+  local line
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    if [ "$line" = "---" ]; then
+      if [ "$fm_started" -eq 0 ]; then
+        fm_started=1
+        in_fm=1
+        continue
+      else
+        in_fm=0
+        continue
+      fi
+    fi
+    if [ "$in_fm" -eq 1 ]; then
+      # Parse "key: value" or 'key: "value"'
+      local key val
+      key="${line%%:*}"
+      val="${line#*: }"
+      # Strip leading/trailing quotes
+      val="${val#\"}"
+      val="${val%\"}"
+      FM_KEYS+=("$key")
+      FM_VALS+=("$val")
+    else
+      body="${body}${line}
+"
+    fi
+  done < "$file"
+
+  FM_BODY="$body"
+}
+
+# ---------------------------------------------------------------------------
+# fm_get — get frontmatter value by key
+# ---------------------------------------------------------------------------
+fm_get() {
+  local target="$1"
+  local i=0
+  while [ "$i" -lt "${#FM_KEYS[@]}" ]; do
+    if [ "${FM_KEYS[$i]}" = "$target" ]; then
+      printf '%s' "${FM_VALS[$i]}"
+      return 0
+    fi
+    i=$((i + 1))
+  done
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# translate_command — convert Claude command .md to OpenCode command .md
+# ---------------------------------------------------------------------------
+translate_command() {
+  local src_file="$1"
+  local dst_file="$2"
+
+  parse_frontmatter "$src_file"
+
+  local desc
+  desc=$(fm_get "description") || desc=""
+
+  {
+    printf '%s\n' "---"
+    printf 'description: %s\n' "$desc"
+    printf '%s\n' "---"
+    printf '%s' "$FM_BODY"
+  } > "$dst_file"
+}
+
+# ---------------------------------------------------------------------------
+# translate_agent — convert Claude agent .md to OpenCode agent .md
+# ---------------------------------------------------------------------------
+translate_agent() {
+  local src_file="$1"
+  local dst_file="$2"
+
+  parse_frontmatter "$src_file"
+
+  local desc
+  desc=$(fm_get "description") || desc=""
+
+  {
+    printf '%s\n' "---"
+    printf '%s\n' "mode: agent"
+    printf 'description: %s\n' "$desc"
+    printf '%s\n' "---"
+    printf '%s' "$FM_BODY"
+  } > "$dst_file"
+}
+
+# ---------------------------------------------------------------------------
+# install_plugin_source — copy full plugin to plugins/aimi-engineering/
+# ---------------------------------------------------------------------------
+install_plugin_source() {
+  local src="$1"
+  local target_dir="$2"
+  local plugin_dst="$target_dir/plugins/$PLUGIN_NAME"
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "[dry-run] Would copy plugin source to $plugin_dst"
+    return 0
+  fi
+
+  mkdir -p "$plugin_dst"
+  # Copy everything except .git
+  cp -R "$src/." "$plugin_dst/"
+
+  # Ensure scripts are executable
+  find "$plugin_dst" -name '*.sh' -exec chmod +x {} +
+
+  # Write version marker
+  local version
+  version=$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$src/.claude-plugin/plugin.json" | head -1)
+  printf '%s\n' "$version" > "$plugin_dst/.installed-version"
+
+  ok "Plugin source installed to $plugin_dst (v$version)"
+}
+
+# ---------------------------------------------------------------------------
+# install_commands — translate and write commands
+# ---------------------------------------------------------------------------
+install_commands() {
+  local src="$1"
+  local target_dir="$2"
+  local cmd_dir="$target_dir/commands"
+  local count=0
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "[dry-run] Would install commands to $cmd_dir"
+    return 0
+  fi
+
+  mkdir -p "$cmd_dir"
+
+  for src_file in "$src/commands/"*.md; do
+    [ -f "$src_file" ] || continue
+    local basename
+    basename=$(basename "$src_file")
+
+    # Derive OpenCode filename: aimi:plan.md -> aimi-plan.md
+    local dst_name
+    dst_name=$(printf '%s' "$basename" | sed 's/://g')
+    # Prefix with aimi- if not already
+    case "$dst_name" in
+      aimi-*|aimi*) ;; # already prefixed via name
+    esac
+    dst_name="aimi-${dst_name#aimi}"
+    # Normalize: aimi-aimi -> aimi, handle edge cases
+    dst_name=$(printf '%s' "$dst_name" | sed 's/^aimi-aimi/aimi/')
+
+    translate_command "$src_file" "$cmd_dir/$dst_name"
+    count=$((count + 1))
+    [ "$VERBOSE" -eq 1 ] && log "  Command: $dst_name"
+  done
+
+  ok "Installed $count commands to $cmd_dir"
+}
+
+# ---------------------------------------------------------------------------
+# install_agents — translate and write agents
+# ---------------------------------------------------------------------------
+install_agents() {
+  local src="$1"
+  local target_dir="$2"
+  local agent_dir="$target_dir/agents"
+  local count=0
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "[dry-run] Would install agents to $agent_dir"
+    return 0
+  fi
+
+  mkdir -p "$agent_dir"
+
+  # Find all agent .md files (they're in subdirs: design/, review/, etc.)
+  for src_file in "$src/agents/"*/*.md; do
+    [ -f "$src_file" ] || continue
+    local basename
+    basename=$(basename "$src_file")
+
+    # Prefix with aimi- if not already
+    local dst_name="$basename"
+    case "$dst_name" in
+      aimi-*) ;; # already prefixed
+      *) dst_name="aimi-$dst_name" ;;
+    esac
+
+    translate_agent "$src_file" "$agent_dir/$dst_name"
+    count=$((count + 1))
+    [ "$VERBOSE" -eq 1 ] && log "  Agent: $dst_name"
+  done
+
+  ok "Installed $count agents to $agent_dir"
+}
+
+# ---------------------------------------------------------------------------
+# install_mcp — add context7 to opencode.json
+# ---------------------------------------------------------------------------
+install_mcp() {
+  local target_dir="$1"
+  local config_file="$target_dir/opencode.json"
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "[dry-run] Would add context7 MCP to $config_file"
+    return 0
+  fi
+
+  mkdir -p "$target_dir"
+
+  # Check if context7 already configured
+  if [ -f "$config_file" ] && grep -q '"context7"' "$config_file" 2>/dev/null; then
+    [ "$VERBOSE" -eq 1 ] && log "MCP context7 already in $config_file, skipping"
+    return 0
+  fi
+
+  if [ -f "$config_file" ]; then
+    backup_file "$config_file"
+    # Try jq first
+    if command -v jq >/dev/null 2>&1; then
+      local tmp
+      tmp=$(mktemp)
+      jq '.mcp = (.mcp // {}) + {"context7": {"type": "http", "url": "https://mcp.context7.com/mcp"}}' "$config_file" > "$tmp" && mv "$tmp" "$config_file"
+    # Try python3 fallback
+    elif command -v python3 >/dev/null 2>&1; then
+      python3 -c "
+import json, sys
+with open('$config_file') as f:
+    try: cfg = json.load(f)
+    except: cfg = {}
+cfg.setdefault('mcp', {})['context7'] = {'type': 'http', 'url': 'https://mcp.context7.com/mcp'}
+with open('$config_file', 'w') as f:
+    json.dump(cfg, f, indent=2)
+    f.write('\n')
+"
+    else
+      warn "Neither jq nor python3 found. Add context7 MCP manually to $config_file"
+      return 0
+    fi
+  else
+    # Create new opencode.json
+    cat > "$config_file" <<'JSON'
+{
+  "mcp": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp"
+    }
+  }
+}
+JSON
+  fi
+
+  ok "Added context7 MCP to $config_file"
+}
+
+# ---------------------------------------------------------------------------
+# set_env_var — add AIMI_PLUGIN_DIR export to shell profiles
+# ---------------------------------------------------------------------------
+set_env_var() {
+  local plugin_dir="$1"
+  local marker="# aimi-engineering"
+  local export_line="export AIMI_PLUGIN_DIR=\"$plugin_dir\" $marker"
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "[dry-run] Would add to shell profiles: $export_line"
+    return 0
+  fi
+
+  local updated=0
+  for rc in "$HOME/.bashrc" "$HOME/.zshrc" "$HOME/.profile"; do
+    if [ -f "$rc" ]; then
+      if grep -q "$marker" "$rc" 2>/dev/null; then
+        # Update existing line
+        local tmp
+        tmp=$(mktemp)
+        grep -v "$marker" "$rc" > "$tmp"
+        printf '%s\n' "$export_line" >> "$tmp"
+        mv "$tmp" "$rc"
+        [ "$VERBOSE" -eq 1 ] && log "Updated AIMI_PLUGIN_DIR in $rc"
+        updated=1
+      else
+        printf '\n%s\n' "$export_line" >> "$rc"
+        [ "$VERBOSE" -eq 1 ] && log "Added AIMI_PLUGIN_DIR to $rc"
+        updated=1
+      fi
+    fi
+  done
+
+  # If no rc files exist, create .bashrc
+  if [ "$updated" -eq 0 ]; then
+    printf '%s\n' "$export_line" >> "$HOME/.bashrc"
+    log "Created $HOME/.bashrc with AIMI_PLUGIN_DIR"
+  fi
+
+  ok "AIMI_PLUGIN_DIR=$plugin_dir added to shell profile"
+}
+
+# ---------------------------------------------------------------------------
+# install_opencode — orchestrator
+# ---------------------------------------------------------------------------
+install_opencode() {
+  local src
+  src=$(detect_plugin_source)
+  local target_dir
+  target_dir=$(resolve_target_dir)
+
+  log "Installing $PLUGIN_NAME for OpenCode..."
+  if [ "$PROJECT_MODE" -eq 1 ]; then
+    log "Mode: project (.opencode/)"
+  else
+    log "Mode: global ($target_dir)"
+  fi
+
+  install_plugin_source "$src" "$target_dir"
+  install_commands "$src" "$target_dir"
+  install_agents "$src" "$target_dir"
+  install_mcp "$target_dir"
+
+  local plugin_dir="$target_dir/plugins/$PLUGIN_NAME"
+  set_env_var "$plugin_dir"
+
+  echo
+  ok "Installation complete!"
+  echo
+  log "Plugin source: $plugin_dir"
+  log "Commands:      $target_dir/commands/aimi-*.md"
+  log "Agents:        $target_dir/agents/aimi-*.md"
+  log "MCP:           $target_dir/opencode.json"
+  echo
+  log "Restart your shell or run:"
+  log "  export AIMI_PLUGIN_DIR=\"$plugin_dir\""
+}
+
+# ---------------------------------------------------------------------------
+# uninstall_opencode — remove installed files
+# ---------------------------------------------------------------------------
+uninstall_opencode() {
+  local target_dir
+  target_dir=$(resolve_target_dir)
+
+  log "Uninstalling $PLUGIN_NAME from OpenCode..."
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "[dry-run] Would remove $target_dir/commands/aimi-*.md"
+    log "[dry-run] Would remove $target_dir/agents/aimi-*.md"
+    log "[dry-run] Would remove $target_dir/plugins/$PLUGIN_NAME/"
+    log "[dry-run] Would remove context7 from $target_dir/opencode.json"
+    log "[dry-run] Would remove AIMI_PLUGIN_DIR from shell profiles"
+    return 0
+  fi
+
+  # Remove commands
+  local count=0
+  for f in "$target_dir/commands/"aimi-*.md; do
+    [ -f "$f" ] || continue
+    rm "$f"
+    count=$((count + 1))
+  done
+  [ "$count" -gt 0 ] && ok "Removed $count commands"
+
+  # Remove agents
+  count=0
+  for f in "$target_dir/agents/"aimi-*.md; do
+    [ -f "$f" ] || continue
+    rm "$f"
+    count=$((count + 1))
+  done
+  [ "$count" -gt 0 ] && ok "Removed $count agents"
+
+  # Remove plugin source
+  if [ -d "$target_dir/plugins/$PLUGIN_NAME" ]; then
+    rm -rf "$target_dir/plugins/$PLUGIN_NAME"
+    ok "Removed plugin source"
+  fi
+
+  # Remove MCP from opencode.json
+  local config_file="$target_dir/opencode.json"
+  if [ -f "$config_file" ] && grep -q '"context7"' "$config_file" 2>/dev/null; then
+    backup_file "$config_file"
+    if command -v jq >/dev/null 2>&1; then
+      local tmp
+      tmp=$(mktemp)
+      jq 'del(.mcp.context7)' "$config_file" > "$tmp" && mv "$tmp" "$config_file"
+      ok "Removed context7 MCP from $config_file"
+    elif command -v python3 >/dev/null 2>&1; then
+      python3 -c "
+import json
+with open('$config_file') as f:
+    cfg = json.load(f)
+cfg.get('mcp', {}).pop('context7', None)
+with open('$config_file', 'w') as f:
+    json.dump(cfg, f, indent=2)
+    f.write('\n')
+"
+      ok "Removed context7 MCP from $config_file"
+    else
+      warn "Remove context7 from $config_file manually (no jq or python3)"
+    fi
+  fi
+
+  # Remove AIMI_PLUGIN_DIR from shell profiles
+  local marker="# aimi-engineering"
+  for rc in "$HOME/.bashrc" "$HOME/.zshrc" "$HOME/.profile"; do
+    if [ -f "$rc" ] && grep -q "$marker" "$rc" 2>/dev/null; then
+      local tmp
+      tmp=$(mktemp)
+      grep -v "$marker" "$rc" > "$tmp"
+      mv "$tmp" "$rc"
+      [ "$VERBOSE" -eq 1 ] && log "Removed AIMI_PLUGIN_DIR from $rc"
+    fi
+  done
+  ok "Removed AIMI_PLUGIN_DIR from shell profiles"
+
+  echo
+  ok "Uninstall complete!"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+if [ "$UNINSTALL" -eq 1 ]; then
+  uninstall_opencode
+else
+  install_opencode
+fi

--- a/install.sh
+++ b/install.sh
@@ -12,6 +12,7 @@ DRY_RUN=0
 PROJECT_MODE=0
 UNINSTALL=0
 VERBOSE=0
+TARGET=""
 
 log()  { printf '\033[0;34m%s\033[0m\n' "$*"; }
 ok()   { printf '\033[0;32m%s\033[0m\n' "$*"; }
@@ -23,28 +24,35 @@ die()  { printf '\033[0;31mError: %s\033[0m\n' "$*" >&2; exit 1; }
 # ---------------------------------------------------------------------------
 while [ $# -gt 0 ]; do
   case "$1" in
+    --to)        shift; TARGET="$1" ;;
+    --from)      shift; TARGET="$1"; UNINSTALL=1 ;;
     --project)   PROJECT_MODE=1 ;;
     --uninstall) UNINSTALL=1 ;;
     --dry-run)   DRY_RUN=1 ;;
     --verbose)   VERBOSE=1 ;;
     --help|-h)
       cat <<'USAGE'
-Usage: ./install.sh [OPTIONS]
+Usage: ./install.sh --to opencode [OPTIONS]
+       ./install.sh --uninstall --from opencode [OPTIONS]
 
-Install aimi-engineering plugin for OpenCode.
+Install aimi-engineering plugin for AI coding tools.
 
 Options:
-  --project     Install into .opencode/ in current directory (project-level)
+  --to TARGET   Install for target tool (required for install)
+  --from TARGET Uninstall from target tool (implies --uninstall)
+  --project     Install into project directory instead of global
   --uninstall   Remove installed files
   --dry-run     Show what would be done without doing it
   --verbose     Print detailed progress
   --help        Show this help
 
+Supported targets: opencode
+
 Examples:
-  ./install.sh                  # Global install to ~/.config/opencode/
-  ./install.sh --project        # Project install to .opencode/
-  ./install.sh --uninstall      # Remove global install
-  ./install.sh --dry-run        # Preview changes
+  ./install.sh --to opencode              # Global install
+  ./install.sh --to opencode --project    # Project install to .opencode/
+  ./install.sh --uninstall --from opencode  # Remove install
+  ./install.sh --to opencode --dry-run    # Preview changes
 USAGE
       exit 0
       ;;
@@ -52,6 +60,15 @@ USAGE
   esac
   shift
 done
+
+# Validate target
+if [ -z "$TARGET" ]; then
+  die "Missing --to flag. Usage: ./install.sh --to opencode"
+fi
+case "$TARGET" in
+  opencode) ;;
+  *) die "Unsupported target: $TARGET. Supported: opencode" ;;
+esac
 
 # ---------------------------------------------------------------------------
 # detect_plugin_source — find plugins/aimi-engineering/ relative to script

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.31.0",
+  "version": "1.32.0",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi"

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi"

--- a/plugins/aimi-engineering/commands/execute.md
+++ b/plugins/aimi-engineering/commands/execute.md
@@ -17,11 +17,16 @@ Single-story waves run inline (no worktree overhead). Multi-story waves spawn N 
 
 ## Step 0: Resolve CLI Path
 
-Resolve `$AIMI_CLI` path using the three-layer strategy below. Each command is a separate Bash call (no compound operators).
+Resolve `$AIMI_CLI` path using the four-layer strategy below. Each command is a separate Bash call (no compound operators).
+
+**Layer 0 — AIMI_PLUGIN_DIR (env var override):**
+```bash
+if [ -n "$AIMI_PLUGIN_DIR" ] && [ "${AIMI_PLUGIN_DIR#/}" != "$AIMI_PLUGIN_DIR" ] && [ -d "$AIMI_PLUGIN_DIR" ] && [ -x "$AIMI_PLUGIN_DIR/scripts/aimi-cli.sh" ]; then AIMI_CLI="$AIMI_PLUGIN_DIR/scripts/aimi-cli.sh"; fi
+```
 
 **Layer 1 — Global cache (fast path):**
 ```bash
-AIMI_CLI=$(cat ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path 2>/dev/null)
+if [ -z "$AIMI_CLI" ]; then AIMI_CLI=$(cat ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path 2>/dev/null); fi
 ```
 
 **Layer 1 validation:**
@@ -44,7 +49,9 @@ if [ -n "$AIMI_CLI" ]; then printf '%s\n' "$AIMI_CLI" > "${CLAUDE_CONFIG_DIR:-$H
 if [ -z "$AIMI_CLI" ] && [ -f .aimi/cli-path ] && [ -x "$(cat .aimi/cli-path)" ]; then AIMI_CLI=$(cat .aimi/cli-path); fi
 ```
 
-If empty, report: "aimi-cli.sh not found. Reinstall plugin: `/plugin install aimi-engineering`" and STOP.
+If empty, report error and STOP:
+- If `$AIMI_PLUGIN_DIR` is set: "aimi-cli.sh not found. Check AIMI_PLUGIN_DIR path: $AIMI_PLUGIN_DIR"
+- Otherwise: "aimi-cli.sh not found. Reinstall plugin: `/plugin install aimi-engineering`"
 
 **Version check:**
 ```bash
@@ -199,15 +206,41 @@ Beginning wave execution loop...
 
 ## Step 3.1: Resolve Worktree Manager
 
+Resolve `$WORKTREE_MGR` path using the same four-layer strategy. Each command is a separate Bash call (no compound operators).
+
+**Layer 0 — AIMI_PLUGIN_DIR (env var override):**
 ```bash
-WORKTREE_MGR=$(ls ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/cache/*/aimi-engineering/*/skills/git-worktree/scripts/worktree-manager.sh 2>/dev/null | tail -1)
+if [ -n "$AIMI_PLUGIN_DIR" ] && [ "${AIMI_PLUGIN_DIR#/}" != "$AIMI_PLUGIN_DIR" ] && [ -d "$AIMI_PLUGIN_DIR" ] && [ -x "$AIMI_PLUGIN_DIR/skills/git-worktree/scripts/worktree-manager.sh" ]; then WORKTREE_MGR="$AIMI_PLUGIN_DIR/skills/git-worktree/scripts/worktree-manager.sh"; fi
 ```
 
-If empty, report:
+**Layer 1 — Global cache (fast path):**
+```bash
+if [ -z "$WORKTREE_MGR" ]; then WORKTREE_MGR=$(cat ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-worktree-path 2>/dev/null); fi
 ```
-worktree-manager.sh not found. Reinstall plugin: `/plugin install aimi-engineering`
+
+**Layer 1 validation:**
+```bash
+if [ -n "$WORKTREE_MGR" ] && [ ! -x "$WORKTREE_MGR" ]; then WORKTREE_MGR=""; fi
 ```
-STOP execution.
+
+**Layer 2 — Glob fallback (zsh-safe, only if Layer 1 failed):**
+```bash
+if [ -z "$WORKTREE_MGR" ]; then WORKTREE_MGR=$(bash -c 'ls ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/cache/*/aimi-engineering/*/skills/git-worktree/scripts/worktree-manager.sh 2>/dev/null | tail -1'); fi
+```
+
+**Layer 2 cache update:**
+```bash
+if [ -n "$WORKTREE_MGR" ]; then printf '%s\n' "$WORKTREE_MGR" > "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-worktree-path.tmp" && mv "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-worktree-path.tmp" "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-worktree-path" && chmod 600 "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-worktree-path"; fi
+```
+
+**Layer 3 — Per-project fallback (last resort):**
+```bash
+if [ -z "$WORKTREE_MGR" ] && [ -f .aimi/cli-path ]; then WORKTREE_MGR=$(dirname "$(cat .aimi/cli-path)")/worktree-manager.sh; if [ ! -x "$WORKTREE_MGR" ]; then WORKTREE_MGR=""; fi; fi
+```
+
+If empty, report error and STOP:
+- If `$AIMI_PLUGIN_DIR` is set: "worktree-manager.sh not found. Check AIMI_PLUGIN_DIR path: $AIMI_PLUGIN_DIR"
+- Otherwise: "worktree-manager.sh not found. Reinstall plugin: `/plugin install aimi-engineering`"
 
 ## Step 3.2: Read Concurrency Setting
 

--- a/plugins/aimi-engineering/commands/next.md
+++ b/plugins/aimi-engineering/commands/next.md
@@ -11,11 +11,16 @@ Execute the next pending story using a Task-spawned agent.
 
 ## Step 0: Resolve CLI Path
 
-Resolve `$AIMI_CLI` path using the three-layer strategy below. Each command is a separate Bash call (no compound operators).
+Resolve `$AIMI_CLI` path using the four-layer strategy below. Each command is a separate Bash call (no compound operators).
+
+**Layer 0 — AIMI_PLUGIN_DIR (env var override):**
+```bash
+if [ -n "$AIMI_PLUGIN_DIR" ] && [ "${AIMI_PLUGIN_DIR#/}" != "$AIMI_PLUGIN_DIR" ] && [ -d "$AIMI_PLUGIN_DIR" ] && [ -x "$AIMI_PLUGIN_DIR/scripts/aimi-cli.sh" ]; then AIMI_CLI="$AIMI_PLUGIN_DIR/scripts/aimi-cli.sh"; fi
+```
 
 **Layer 1 — Global cache (fast path):**
 ```bash
-AIMI_CLI=$(cat ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path 2>/dev/null)
+if [ -z "$AIMI_CLI" ]; then AIMI_CLI=$(cat ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path 2>/dev/null); fi
 ```
 
 **Layer 1 validation:**
@@ -38,7 +43,9 @@ if [ -n "$AIMI_CLI" ]; then printf '%s\n' "$AIMI_CLI" > "${CLAUDE_CONFIG_DIR:-$H
 if [ -z "$AIMI_CLI" ] && [ -f .aimi/cli-path ] && [ -x "$(cat .aimi/cli-path)" ]; then AIMI_CLI=$(cat .aimi/cli-path); fi
 ```
 
-If empty, report: "aimi-cli.sh not found. Reinstall plugin: `/plugin install aimi-engineering`" and STOP.
+If empty, report error and STOP:
+- If `$AIMI_PLUGIN_DIR` is set: "aimi-cli.sh not found. Check AIMI_PLUGIN_DIR path: $AIMI_PLUGIN_DIR"
+- Otherwise: "aimi-cli.sh not found. Reinstall plugin: `/plugin install aimi-engineering`"
 
 **Version check:**
 ```bash

--- a/plugins/aimi-engineering/commands/references/cli-path-resolution.md
+++ b/plugins/aimi-engineering/commands/references/cli-path-resolution.md
@@ -4,12 +4,20 @@ Shared reference for resolving `$AIMI_CLI` and `$WORKTREE_MGR` across all comman
 
 ## Resolve CLI Path
 
-**CRITICAL:** The CLI script lives in the plugin install directory, NOT the project directory. Resolve it using the three-layer strategy below. Each command is a separate Bash call (no compound operators).
+**CRITICAL:** The CLI script lives in the plugin install directory, NOT the project directory. Resolve it using the four-layer strategy below. Each command is a separate Bash call (no compound operators).
+
+### Layer 0: AIMI_PLUGIN_DIR (env var override)
+
+```bash
+if [ -n "$AIMI_PLUGIN_DIR" ] && [ "${AIMI_PLUGIN_DIR#/}" != "$AIMI_PLUGIN_DIR" ] && [ -d "$AIMI_PLUGIN_DIR" ] && [ -x "$AIMI_PLUGIN_DIR/scripts/aimi-cli.sh" ]; then AIMI_CLI="$AIMI_PLUGIN_DIR/scripts/aimi-cli.sh"; fi
+```
+
+Layer 0 validates AIMI_PLUGIN_DIR with four checks: (1) env var is non-empty, (2) path starts with `/` (absolute), (3) directory exists, (4) target script is executable. If any check fails, silently falls through to Layer 1. Layer 0 does NOT write to global cache — env var check is negligible cost, no side effects.
 
 ### Layer 1: Global cache (fast path)
 
 ```bash
-AIMI_CLI=$(cat ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path 2>/dev/null)
+if [ -z "$AIMI_CLI" ]; then AIMI_CLI=$(cat ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path 2>/dev/null); fi
 ```
 
 ### Layer 1 validation: verify cached path exists and is executable
@@ -38,16 +46,26 @@ if [ -n "$AIMI_CLI" ]; then printf '%s\n' "$AIMI_CLI" > "${CLAUDE_CONFIG_DIR:-$H
 if [ -z "$AIMI_CLI" ] && [ -f .aimi/cli-path ] && [ -x "$(cat .aimi/cli-path)" ]; then AIMI_CLI=$(cat .aimi/cli-path); fi
 ```
 
-If empty, report: "aimi-cli.sh not found. Reinstall plugin: `/plugin install aimi-engineering`" and STOP.
+If empty, report error and STOP:
+- If `$AIMI_PLUGIN_DIR` is set: "aimi-cli.sh not found. Check AIMI_PLUGIN_DIR path: $AIMI_PLUGIN_DIR"
+- Otherwise: "aimi-cli.sh not found. Reinstall plugin: `/plugin install aimi-engineering`"
 
 ## Resolve Worktree Manager Path
 
-**CRITICAL:** The worktree manager script lives alongside the CLI. Resolve `$WORKTREE_MGR` using the same three-layer strategy.
+**CRITICAL:** The worktree manager script lives alongside the CLI. Resolve `$WORKTREE_MGR` using the same four-layer strategy.
+
+### Layer 0: AIMI_PLUGIN_DIR (env var override)
+
+```bash
+if [ -n "$AIMI_PLUGIN_DIR" ] && [ "${AIMI_PLUGIN_DIR#/}" != "$AIMI_PLUGIN_DIR" ] && [ -d "$AIMI_PLUGIN_DIR" ] && [ -x "$AIMI_PLUGIN_DIR/skills/git-worktree/scripts/worktree-manager.sh" ]; then WORKTREE_MGR="$AIMI_PLUGIN_DIR/skills/git-worktree/scripts/worktree-manager.sh"; fi
+```
+
+Layer 0 validates AIMI_PLUGIN_DIR with four checks: (1) env var is non-empty, (2) path starts with `/` (absolute), (3) directory exists, (4) target script is executable. If any check fails, silently falls through to Layer 1. Layer 0 does NOT write to global cache — env var check is negligible cost, no side effects.
 
 ### Layer 1: Global cache (fast path)
 
 ```bash
-WORKTREE_MGR=$(cat ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-worktree-path 2>/dev/null)
+if [ -z "$WORKTREE_MGR" ]; then WORKTREE_MGR=$(cat ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-worktree-path 2>/dev/null); fi
 ```
 
 ### Layer 1 validation: verify cached path exists and is executable
@@ -76,7 +94,9 @@ if [ -n "$WORKTREE_MGR" ]; then printf '%s\n' "$WORKTREE_MGR" > "${CLAUDE_CONFIG
 if [ -z "$WORKTREE_MGR" ] && [ -f .aimi/cli-path ]; then WORKTREE_MGR=$(dirname "$(cat .aimi/cli-path)")/worktree-manager.sh; if [ ! -x "$WORKTREE_MGR" ]; then WORKTREE_MGR=""; fi; fi
 ```
 
-If empty, report: "worktree-manager.sh not found. Reinstall plugin: `/plugin install aimi-engineering`" and STOP.
+If empty, report error and STOP:
+- If `$AIMI_PLUGIN_DIR` is set: "worktree-manager.sh not found. Check AIMI_PLUGIN_DIR path: $AIMI_PLUGIN_DIR"
+- Otherwise: "worktree-manager.sh not found. Reinstall plugin: `/plugin install aimi-engineering`"
 
 ## Version Check
 

--- a/plugins/aimi-engineering/commands/status.md
+++ b/plugins/aimi-engineering/commands/status.md
@@ -10,11 +10,16 @@ Display the current execution progress using the CLI script.
 
 ## Step 0: Resolve CLI Path
 
-Resolve `$AIMI_CLI` path using the three-layer strategy below. Each command is a separate Bash call (no compound operators).
+Resolve `$AIMI_CLI` path using the four-layer strategy below. Each command is a separate Bash call (no compound operators).
+
+**Layer 0 — AIMI_PLUGIN_DIR (env var override):**
+```bash
+if [ -n "$AIMI_PLUGIN_DIR" ] && [ "${AIMI_PLUGIN_DIR#/}" != "$AIMI_PLUGIN_DIR" ] && [ -d "$AIMI_PLUGIN_DIR" ] && [ -x "$AIMI_PLUGIN_DIR/scripts/aimi-cli.sh" ]; then AIMI_CLI="$AIMI_PLUGIN_DIR/scripts/aimi-cli.sh"; fi
+```
 
 **Layer 1 — Global cache (fast path):**
 ```bash
-AIMI_CLI=$(cat ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path 2>/dev/null)
+if [ -z "$AIMI_CLI" ]; then AIMI_CLI=$(cat ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path 2>/dev/null); fi
 ```
 
 **Layer 1 validation:**
@@ -37,7 +42,9 @@ if [ -n "$AIMI_CLI" ]; then printf '%s\n' "$AIMI_CLI" > "${CLAUDE_CONFIG_DIR:-$H
 if [ -z "$AIMI_CLI" ] && [ -f .aimi/cli-path ] && [ -x "$(cat .aimi/cli-path)" ]; then AIMI_CLI=$(cat .aimi/cli-path); fi
 ```
 
-If empty, report: "aimi-cli.sh not found. Reinstall plugin: `/plugin install aimi-engineering`" and STOP.
+If empty, report error and STOP:
+- If `$AIMI_PLUGIN_DIR` is set: "aimi-cli.sh not found. Check AIMI_PLUGIN_DIR path: $AIMI_PLUGIN_DIR"
+- Otherwise: "aimi-cli.sh not found. Reinstall plugin: `/plugin install aimi-engineering`"
 
 **Version check:**
 ```bash

--- a/plugins/aimi-engineering/commands/swarm.md
+++ b/plugins/aimi-engineering/commands/swarm.md
@@ -27,11 +27,16 @@ User runs /aimi:swarm
 
 ### AIMI CLI
 
-Resolve `$AIMI_CLI` path using the three-layer strategy below. Each command is a separate Bash call (no compound operators).
+Resolve `$AIMI_CLI` path using the four-layer strategy below. Each command is a separate Bash call (no compound operators).
+
+**Layer 0 — AIMI_PLUGIN_DIR (env var override):**
+```bash
+if [ -n "$AIMI_PLUGIN_DIR" ] && [ "${AIMI_PLUGIN_DIR#/}" != "$AIMI_PLUGIN_DIR" ] && [ -d "$AIMI_PLUGIN_DIR" ] && [ -x "$AIMI_PLUGIN_DIR/scripts/aimi-cli.sh" ]; then AIMI_CLI="$AIMI_PLUGIN_DIR/scripts/aimi-cli.sh"; fi
+```
 
 **Layer 1 — Global cache (fast path):**
 ```bash
-AIMI_CLI=$(cat ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path 2>/dev/null)
+if [ -z "$AIMI_CLI" ]; then AIMI_CLI=$(cat ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path 2>/dev/null); fi
 ```
 
 **Layer 1 validation:**
@@ -54,7 +59,9 @@ if [ -n "$AIMI_CLI" ]; then printf '%s\n' "$AIMI_CLI" > "${CLAUDE_CONFIG_DIR:-$H
 if [ -z "$AIMI_CLI" ] && [ -f .aimi/cli-path ] && [ -x "$(cat .aimi/cli-path)" ]; then AIMI_CLI=$(cat .aimi/cli-path); fi
 ```
 
-If empty, report: "aimi-cli.sh not found. Reinstall plugin: `/plugin install aimi-engineering`" and STOP.
+If empty, report error and STOP:
+- If `$AIMI_PLUGIN_DIR` is set: "aimi-cli.sh not found. Check AIMI_PLUGIN_DIR path: $AIMI_PLUGIN_DIR"
+- Otherwise: "aimi-cli.sh not found. Reinstall plugin: `/plugin install aimi-engineering`"
 
 **Version check:**
 ```bash
@@ -63,11 +70,41 @@ $AIMI_CLI check-version --quiet --fix
 
 ### Worktree Manager
 
+Resolve `$WORKTREE_MGR` path using the same four-layer strategy. Each command is a separate Bash call (no compound operators).
+
+**Layer 0 — AIMI_PLUGIN_DIR (env var override):**
 ```bash
-WORKTREE_MGR=$(ls ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/cache/*/aimi-engineering/*/skills/git-worktree/scripts/worktree-manager.sh 2>/dev/null | tail -1)
+if [ -n "$AIMI_PLUGIN_DIR" ] && [ "${AIMI_PLUGIN_DIR#/}" != "$AIMI_PLUGIN_DIR" ] && [ -d "$AIMI_PLUGIN_DIR" ] && [ -x "$AIMI_PLUGIN_DIR/skills/git-worktree/scripts/worktree-manager.sh" ]; then WORKTREE_MGR="$AIMI_PLUGIN_DIR/skills/git-worktree/scripts/worktree-manager.sh"; fi
 ```
 
-If empty, report: "worktree-manager.sh not found. Reinstall plugin: `/plugin install aimi-engineering`" and STOP.
+**Layer 1 — Global cache (fast path):**
+```bash
+if [ -z "$WORKTREE_MGR" ]; then WORKTREE_MGR=$(cat ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-worktree-path 2>/dev/null); fi
+```
+
+**Layer 1 validation:**
+```bash
+if [ -n "$WORKTREE_MGR" ] && [ ! -x "$WORKTREE_MGR" ]; then WORKTREE_MGR=""; fi
+```
+
+**Layer 2 — Glob fallback (zsh-safe, only if Layer 1 failed):**
+```bash
+if [ -z "$WORKTREE_MGR" ]; then WORKTREE_MGR=$(bash -c 'ls ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/cache/*/aimi-engineering/*/skills/git-worktree/scripts/worktree-manager.sh 2>/dev/null | tail -1'); fi
+```
+
+**Layer 2 cache update:**
+```bash
+if [ -n "$WORKTREE_MGR" ]; then printf '%s\n' "$WORKTREE_MGR" > "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-worktree-path.tmp" && mv "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-worktree-path.tmp" "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-worktree-path" && chmod 600 "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-worktree-path"; fi
+```
+
+**Layer 3 — Per-project fallback (last resort):**
+```bash
+if [ -z "$WORKTREE_MGR" ] && [ -f .aimi/cli-path ]; then WORKTREE_MGR=$(dirname "$(cat .aimi/cli-path)")/worktree-manager.sh; if [ ! -x "$WORKTREE_MGR" ]; then WORKTREE_MGR=""; fi; fi
+```
+
+If empty, report error and STOP:
+- If `$AIMI_PLUGIN_DIR` is set: "worktree-manager.sh not found. Check AIMI_PLUGIN_DIR path: $AIMI_PLUGIN_DIR"
+- Otherwise: "worktree-manager.sh not found. Reinstall plugin: `/plugin install aimi-engineering`"
 
 **Use `$AIMI_CLI` and `$WORKTREE_MGR` for ALL subsequent script calls.**
 

--- a/plugins/aimi-engineering/hooks/auto-approve-cli.sh
+++ b/plugins/aimi-engineering/hooks/auto-approve-cli.sh
@@ -44,6 +44,21 @@ has_metacharacters() {
   return 1
 }
 
+# --- Pattern 0a: Layer 0 AIMI_CLI assignment via AIMI_PLUGIN_DIR ---
+# Approves: if [ -n "$AIMI_PLUGIN_DIR" ] && [ -x "$AIMI_PLUGIN_DIR/scripts/aimi-cli.sh" ]; then AIMI_CLI="$AIMI_PLUGIN_DIR/scripts/aimi-cli.sh"; fi
+# The path inside AIMI_PLUGIN_DIR must be free of shell metacharacters.
+if echo "$COMMAND" | grep -qE '^if \[ -n "\$AIMI_PLUGIN_DIR" \] && \[ -x "\$AIMI_PLUGIN_DIR/scripts/aimi-cli\.sh" \]; then AIMI_CLI="\$AIMI_PLUGIN_DIR/scripts/aimi-cli\.sh"; fi$'; then
+  echo "$ALLOW"
+  exit 0
+fi
+
+# --- Pattern 0b: Layer 0 WORKTREE_MGR assignment via AIMI_PLUGIN_DIR ---
+# Approves: if [ -n "$AIMI_PLUGIN_DIR" ] && [ -x "$AIMI_PLUGIN_DIR/skills/git-worktree/scripts/worktree-manager.sh" ]; then WORKTREE_MGR="$AIMI_PLUGIN_DIR/skills/git-worktree/scripts/worktree-manager.sh"; fi
+if echo "$COMMAND" | grep -qE '^if \[ -n "\$AIMI_PLUGIN_DIR" \] && \[ -x "\$AIMI_PLUGIN_DIR/skills/git-worktree/scripts/worktree-manager\.sh" \]; then WORKTREE_MGR="\$AIMI_PLUGIN_DIR/skills/git-worktree/scripts/worktree-manager\.sh"; fi$'; then
+  echo "$ALLOW"
+  exit 0
+fi
+
 # --- Pattern 1: AIMI_CLI= assignment ---
 # Validates the assigned path matches the expected plugin cache pattern.
 # Accepts config dir as ~/.claude, ${CLAUDE_CONFIG_DIR:-$HOME/.claude}, or resolved absolute path.

--- a/plugins/aimi-engineering/scripts/aimi-cli.sh
+++ b/plugins/aimi-engineering/scripts/aimi-cli.sh
@@ -205,6 +205,26 @@ _claude_config_dir() {
   printf '%s\n' "${dir%/}"
 }
 
+# Validate and resolve AIMI_PLUGIN_DIR when set by compound-plugin converter.
+# Returns stripped path on success, empty string when unset; exits 1 on invalid.
+_validate_plugin_dir() {
+  if [ -z "${AIMI_PLUGIN_DIR:-}" ]; then
+    return 0
+  fi
+  # Must be an absolute path
+  if [ "${AIMI_PLUGIN_DIR#/}" = "$AIMI_PLUGIN_DIR" ]; then
+    echo "Error: AIMI_PLUGIN_DIR must be an absolute path, got: $AIMI_PLUGIN_DIR" >&2
+    exit 1
+  fi
+  # Directory must exist
+  if [ ! -d "$AIMI_PLUGIN_DIR" ]; then
+    echo "Error: AIMI_PLUGIN_DIR directory does not exist: $AIMI_PLUGIN_DIR" >&2
+    exit 1
+  fi
+  # Strip trailing slash
+  printf '%s\n' "${AIMI_PLUGIN_DIR%/}"
+}
+
 # Return the global cache file path for aimi-cli.sh
 _global_cache_path() {
   local config_dir
@@ -244,7 +264,15 @@ read_global_cli_cache() {
   cached_path=$(cat "$cache_file" 2>/dev/null) || return 0
   # Validate path matches expected pattern
   # Expected: */plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh
+  # Or: $AIMI_PLUGIN_DIR/scripts/aimi-cli.sh (compound-plugin converter)
+  local plugin_dir
+  plugin_dir=$(_validate_plugin_dir)
   case "$cached_path" in
+    "${plugin_dir}"/scripts/aimi-cli.sh)
+      if [ -n "$plugin_dir" ]; then
+        printf '%s\n' "$cached_path"
+      fi
+      ;;
     */plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh)
       printf '%s\n' "$cached_path"
       ;;
@@ -276,7 +304,15 @@ read_global_worktree_cache() {
   cached_path=$(cat "$cache_file" 2>/dev/null) || return 0
   # Validate path matches expected pattern
   # Expected: */plugins/cache/*/aimi-engineering/*/skills/git-worktree/scripts/worktree-manager.sh
+  # Or: $AIMI_PLUGIN_DIR/skills/git-worktree/scripts/worktree-manager.sh (compound-plugin converter)
+  local plugin_dir
+  plugin_dir=$(_validate_plugin_dir)
   case "$cached_path" in
+    "${plugin_dir}"/skills/git-worktree/scripts/worktree-manager.sh)
+      if [ -n "$plugin_dir" ]; then
+        printf '%s\n' "$cached_path"
+      fi
+      ;;
     */plugins/cache/*/aimi-engineering/*/skills/git-worktree/scripts/worktree-manager.sh)
       printf '%s\n' "$cached_path"
       ;;
@@ -958,6 +994,14 @@ cmd_check_version() {
   local config_dir
   config_dir=$(_claude_config_dir)
 
+  # When AIMI_PLUGIN_DIR is set, the converter manages the lifecycle — skip glob
+  local plugin_dir
+  plugin_dir=$(_validate_plugin_dir)
+  if [ -n "$plugin_dir" ]; then
+    printf '{"status":"ok","path":"%s/scripts/aimi-cli.sh","message":"managed by compound-plugin converter"}\n' "$plugin_dir"
+    return 0
+  fi
+
   # Resolve the latest installed path via glob
   latest_path=$(ls "$config_dir"/plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh 2>/dev/null | tail -1)
 
@@ -1015,6 +1059,14 @@ cmd_check_version() {
 # Scans <config_dir>/plugins/cache/*/aimi-engineering/*/ for version dirs
 # Outputs JSON {"removed":<count>,"kept":"<version>"} to stdout
 cmd_cleanup_versions() {
+  # When AIMI_PLUGIN_DIR is set, the converter manages the lifecycle — skip cleanup
+  local plugin_dir
+  plugin_dir=$(_validate_plugin_dir)
+  if [ -n "$plugin_dir" ]; then
+    printf '{"removed":0,"skipped":true,"message":"converter manages lifecycle"}\n'
+    return 0
+  fi
+
   local latest_path latest_version latest_version_dir
   local removed=0
   local config_dir
@@ -1118,6 +1170,8 @@ STATE FILES (.aimi/):
 ENVIRONMENT:
     CLAUDE_CONFIG_DIR  Override Claude config directory (default: ~/.claude)
                        Must be an absolute path when set.
+    AIMI_PLUGIN_DIR    Plugin install directory set by compound-plugin converter;
+                       bypasses Claude cache resolution.
 
 EXAMPLES:
     # Resolve CLI path first (honors CLAUDE_CONFIG_DIR)

--- a/plugins/aimi-engineering/scripts/test-aimi-cli.sh
+++ b/plugins/aimi-engineering/scripts/test-aimi-cli.sh
@@ -1413,10 +1413,35 @@ teardown_global_cache_env() {
   unset MOCK_WORKTREE_PATH
 }
 
+# Helper: set up an isolated AIMI_PLUGIN_DIR environment with stub scripts
+# so Layer 0 resolution finds executable aimi-cli.sh and worktree-manager.sh.
+# Sets AIMI_PLUGIN_DIR and PLUGIN_DIR_TMPDIR globals.
+setup_aimi_plugin_dir_env() {
+  PLUGIN_DIR_TMPDIR=$(mktemp -d)
+  export AIMI_PLUGIN_DIR="$PLUGIN_DIR_TMPDIR/aimi-engineering"
+  mkdir -p "$AIMI_PLUGIN_DIR/scripts"
+  mkdir -p "$AIMI_PLUGIN_DIR/skills/git-worktree/scripts"
+
+  # Create executable stubs
+  echo '#!/usr/bin/env bash' > "$AIMI_PLUGIN_DIR/scripts/aimi-cli.sh"
+  chmod +x "$AIMI_PLUGIN_DIR/scripts/aimi-cli.sh"
+
+  echo '#!/usr/bin/env bash' > "$AIMI_PLUGIN_DIR/skills/git-worktree/scripts/worktree-manager.sh"
+  chmod +x "$AIMI_PLUGIN_DIR/skills/git-worktree/scripts/worktree-manager.sh"
+}
+
+# Helper: tear down the AIMI_PLUGIN_DIR environment
+teardown_aimi_plugin_dir_env() {
+  rm -rf "$PLUGIN_DIR_TMPDIR"
+  unset AIMI_PLUGIN_DIR
+  unset PLUGIN_DIR_TMPDIR
+}
+
 # Source the global cache functions from aimi-cli.sh for direct testing.
 # We extract the needed functions using sed so we can call them directly.
 source_cache_functions() {
   eval "$(sed -n '/^_claude_config_dir()/,/^}/p' "$CLI")"
+  eval "$(sed -n '/^_validate_plugin_dir()/,/^}/p' "$CLI")"
   eval "$(sed -n '/^_global_cache_path()/,/^}/p' "$CLI")"
   eval "$(sed -n '/^_global_worktree_cache_path()/,/^}/p' "$CLI")"
   eval "$(sed -n '/^write_global_cli_cache()/,/^}/p' "$CLI")"
@@ -1928,6 +1953,127 @@ test_list_ready_brief_includes_project() {
 }
 
 # ============================================================================
+# AIMI_PLUGIN_DIR Tests
+# ============================================================================
+
+test_aimi_plugin_dir_valid() {
+  echo ""
+  echo "=== Testing read_global_cli_cache accepts AIMI_PLUGIN_DIR-prefixed path ==="
+
+  setup_aimi_plugin_dir_env
+  setup_global_cache_env
+  source_cache_functions
+
+  # Write a path prefixed with AIMI_PLUGIN_DIR
+  write_global_cli_cache "$AIMI_PLUGIN_DIR/scripts/aimi-cli.sh"
+
+  local result
+  result=$(read_global_cli_cache)
+
+  assert_eq "$AIMI_PLUGIN_DIR/scripts/aimi-cli.sh" "$result" \
+    "read_global_cli_cache: accepts AIMI_PLUGIN_DIR-prefixed path"
+
+  teardown_global_cache_env
+  teardown_aimi_plugin_dir_env
+}
+
+test_aimi_plugin_dir_invalid() {
+  echo ""
+  echo "=== Testing read_global_cli_cache with non-existent AIMI_PLUGIN_DIR ==="
+
+  setup_global_cache_env
+  source_cache_functions
+
+  # Set AIMI_PLUGIN_DIR to a non-existent directory
+  export AIMI_PLUGIN_DIR="/tmp/nonexistent-plugin-dir-$$"
+
+  # Write a path that would match if the dir existed
+  write_global_cli_cache "$AIMI_PLUGIN_DIR/scripts/aimi-cli.sh"
+
+  # _validate_plugin_dir exits 1 for non-existent dir, so read_global_cli_cache
+  # should fail in a subshell
+  local result
+  result=$(read_global_cli_cache 2>/dev/null) || true
+
+  assert_eq "" "$result" \
+    "read_global_cli_cache: returns empty for non-existent AIMI_PLUGIN_DIR"
+
+  unset AIMI_PLUGIN_DIR
+  teardown_global_cache_env
+}
+
+test_aimi_plugin_dir_unset() {
+  echo ""
+  echo "=== Testing read_global_cli_cache with AIMI_PLUGIN_DIR unset ==="
+
+  unset AIMI_PLUGIN_DIR 2>/dev/null || true
+  setup_global_cache_env
+  source_cache_functions
+
+  # Write a valid Claude cache path
+  write_global_cli_cache "$MOCK_CLI_PATH"
+
+  local result
+  result=$(read_global_cli_cache)
+
+  assert_eq "$MOCK_CLI_PATH" "$result" \
+    "read_global_cli_cache: accepts Claude cache pattern when AIMI_PLUGIN_DIR unset"
+
+  teardown_global_cache_env
+}
+
+test_check_version_plugin_dir() {
+  echo ""
+  echo "=== Testing check-version with AIMI_PLUGIN_DIR set ==="
+
+  setup_aimi_plugin_dir_env
+
+  local output
+  output=$("$CLI" check-version 2>/dev/null)
+
+  assert_contains '"status":"ok"' "$output" \
+    "check-version: returns ok status when AIMI_PLUGIN_DIR set"
+
+  teardown_aimi_plugin_dir_env
+}
+
+test_cleanup_versions_plugin_dir() {
+  echo ""
+  echo "=== Testing cleanup-versions with AIMI_PLUGIN_DIR set ==="
+
+  setup_aimi_plugin_dir_env
+
+  local output
+  output=$("$CLI" cleanup-versions 2>/dev/null)
+
+  assert_contains '"skipped":true' "$output" \
+    "cleanup-versions: returns skipped when AIMI_PLUGIN_DIR set"
+
+  teardown_aimi_plugin_dir_env
+}
+
+test_read_global_cli_cache_rejects_arbitrary() {
+  echo ""
+  echo "=== Testing read_global_cli_cache rejects arbitrary paths with AIMI_PLUGIN_DIR set ==="
+
+  setup_aimi_plugin_dir_env
+  setup_global_cache_env
+  source_cache_functions
+
+  # Write an arbitrary path that matches neither AIMI_PLUGIN_DIR nor Claude cache pattern
+  write_global_cli_cache "/tmp/evil/scripts/aimi-cli.sh"
+
+  local result
+  result=$(read_global_cli_cache 2>/dev/null)
+
+  assert_eq "" "$result" \
+    "read_global_cli_cache: rejects arbitrary path with AIMI_PLUGIN_DIR set"
+
+  teardown_global_cache_env
+  teardown_aimi_plugin_dir_env
+}
+
+# ============================================================================
 # Main
 # ============================================================================
 
@@ -2005,6 +2151,16 @@ main() {
   test_claude_config_dir_default
   test_claude_config_dir_custom_absolute
   test_claude_config_dir_relative_path_error
+
+  # AIMI_PLUGIN_DIR tests
+  echo ""
+  echo "--- AIMI_PLUGIN_DIR Tests ---"
+  test_aimi_plugin_dir_valid
+  test_aimi_plugin_dir_invalid
+  test_aimi_plugin_dir_unset
+  test_check_version_plugin_dir
+  test_cleanup_versions_plugin_dir
+  test_read_global_cli_cache_rejects_arbitrary
 
   # Auto-discovery tests
   echo ""


### PR DESCRIPTION
## Summary

- Add `AIMI_PLUGIN_DIR` environment variable as Layer 0 in the CLI path resolution strategy across all commands, enabling the plugin to work outside Claude Code's cache directory
- Add self-contained `install.sh` script for OpenCode installation — translates commands/agents frontmatter, configures MCP, sets env var. Zero external dependencies
- Update `aimi-cli.sh` with cross-platform support: early-return guards in `check-version`/`cleanup-versions`, relaxed cache validation for `AIMI_PLUGIN_DIR` paths
- Add auto-approve hook patterns for Layer 0 resolution and 6 new test cases (198 total, 0 failures)

## Test plan

- [x] `bash -n install.sh` passes
- [x] `./install.sh --to opencode --dry-run` shows correct operations
- [x] `./install.sh --to opencode` installs 8 commands + 28 agents + MCP + env var
- [x] `./install.sh --uninstall --from opencode` cleanly removes all files
- [x] Idempotent re-run produces no errors
- [x] `test-aimi-cli.sh` passes 198/198 tests
- [x] OpenCode validates config without errors (mode: subagent, type: remote)