### PR TITLE
feat(installer): Full OpenCode compatibility via command body translation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and worktree+team orchestration.",
-      "version": "1.33.0",
+      "version": "1.34.0",
       "author": {
         "name": "Stanley Takamatsu",
         "url": "https://github.com/aimi-so"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.34.0] - 2026-03-31
+
+### Added
+
+- **install.sh**: Full OpenCode command body translation — agent invocations rewritten for OpenCode Task tool compatibility
+- **install.sh**: Skills installation (`install_skills()`) — copies SKILL.md and references to OpenCode skills directory
+- **install.sh**: Nested command directories — commands installed as `commands/aimi/plan.md` for `/aimi:plan` naming
+- **install.sh**: Bash permission auto-approval (`install_permissions()`) — configures opencode.json for autonomous execution
+- **install.sh**: CLI path resolution rewriting — `CLAUDE_CONFIG_DIR` references replaced with `OPENCODE_CONFIG_DIR`
+- **install.sh**: Error message rewriting — recovery instructions point to `./install.sh --to opencode`
+- **install.sh**: AskUserQuestion fallback — replaced with natural conversation prompts
+- **install.sh**: `disable-model-invocation` workaround — side-effect warning prepended to command bodies
+- **install.sh**: Agent model field preservation — `model: haiku` preserved in translated agents
+
+### Fixed
+
+- **install.sh**: Python3 MCP fallback now uses `type: remote` instead of `type: http`
+
 ## [1.33.0] - 2026-03-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -47,11 +47,14 @@ cd aimi-engineering-plugin
 ./install.sh --to opencode
 ```
 
-This installs the plugin into OpenCode's global config directory (`~/.config/opencode/`):
+This installs the plugin into OpenCode's global config directory (`~/.config/opencode/`) with full compatibility translation:
 
-- **Commands** are translated to `~/.config/opencode/commands/aimi-*.md`
-- **Agents** are translated to `~/.config/opencode/agents/aimi-*.md`
-- **Plugin source** (CLI scripts, skills, hooks) is copied to `~/.config/opencode/plugins/aimi-engineering/`
+- **Commands** are translated and installed as nested directories (e.g., `commands/aimi/plan.md`) so they appear as `/aimi:plan`, `/aimi:execute`, etc.
+- **Command bodies** are fully rewritten for OpenCode compatibility — agent invocations use the Task tool, CLI path references use `OPENCODE_CONFIG_DIR`, and error messages point to the OpenCode installer
+- **Skills** are copied to `~/.config/opencode/skills/` with SKILL.md and reference files preserved
+- **Agents** are translated to `~/.config/opencode/agents/aimi-*.md` with model fields preserved
+- **Permissions** are auto-configured in `opencode.json` for autonomous Bash execution
+- **Plugin source** (CLI scripts, hooks) is copied to `~/.config/opencode/plugins/aimi-engineering/`
 - **context7 MCP** server is added to `opencode.json`
 - **`AIMI_PLUGIN_DIR`** is set in your shell profile
 
@@ -60,6 +63,12 @@ After installation, restart your shell or run:
 ```bash
 export AIMI_PLUGIN_DIR="$HOME/.config/opencode/plugins/aimi-engineering"
 ```
+
+#### Known Limitations
+
+- **`disable-model-invocation`** is not supported in OpenCode. The installer prepends a side-effect warning to command bodies as a workaround, instructing the model not to invoke sub-agents autonomously.
+- **`AskUserQuestion`** tool is not available in OpenCode. Commands that use it are rewritten to use natural conversation prompts instead (asking the user directly in the response).
+- **Custom `subagent_type`** (e.g., `subagent_type: researcher`) is not yet supported in OpenCode. Agents are installed as general-purpose with the agent prompt inlined into the Task tool invocation.
 
 #### Project-Level Install
 
@@ -580,9 +589,17 @@ Invalid characters (spaces, semicolons, quotes) trigger validation errors.
 
 ## Version History
 
-**Current Version:** 1.33.0
+**Current Version:** 1.34.0
 
 ### Recent Changes
+
+**v1.34.0** - Full OpenCode Compatibility
+- Full command body translation for OpenCode Task tool compatibility
+- Skills installation to OpenCode's skills directory
+- Nested command directories for `/aimi:plan` naming convention
+- Bash permission auto-approval for autonomous execution
+- CLI path resolution, error message, and AskUserQuestion rewriting
+- `disable-model-invocation` workaround and agent model field preservation
 
 **v1.30.0** - Per-Story Project Field for Multi-Repo Execution
 - Optional `project` field on stories for targeting specific git repositories in multi-repo setups

--- a/install.sh
+++ b/install.sh
@@ -252,7 +252,7 @@ install_plugin_source() {
 install_commands() {
   local src="$1"
   local target_dir="$2"
-  local cmd_dir="$target_dir/commands"
+  local cmd_dir="$target_dir/commands/aimi"
   local count=0
 
   if [ "$DRY_RUN" -eq 1 ]; then
@@ -267,20 +267,19 @@ install_commands() {
     local basename
     basename=$(basename "$src_file")
 
-    # Derive OpenCode filename: aimi:plan.md -> aimi-plan.md
-    local dst_name
-    dst_name=$(printf '%s' "$basename" | sed 's/://g')
-    # Prefix with aimi- if not already
-    case "$dst_name" in
-      aimi-*|aimi*) ;; # already prefixed via name
-    esac
-    dst_name="aimi-${dst_name#aimi}"
-    # Normalize: aimi-aimi -> aimi, handle edge cases
-    dst_name=$(printf '%s' "$dst_name" | sed 's/^aimi-aimi/aimi/')
+    # Derive command name from frontmatter "name:" field (e.g., "aimi:plan" -> "plan")
+    local cmd_name
+    cmd_name=$(sed -n 's/^name:[[:space:]]*aimi:\(.*\)/\1/p' "$src_file" | head -1)
+    # Fallback to filename without extension if frontmatter parsing fails
+    if [ -z "$cmd_name" ]; then
+      cmd_name="${basename%.md}"
+    fi
+
+    local dst_name="${cmd_name}.md"
 
     translate_command "$src_file" "$cmd_dir/$dst_name"
     count=$((count + 1))
-    [ "$VERBOSE" -eq 1 ] && log "  Command: $dst_name"
+    [ "$VERBOSE" -eq 1 ] && log "  Command: aimi/$dst_name"
   done
 
   ok "Installed $count commands to $cmd_dir"
@@ -453,7 +452,7 @@ install_opencode() {
   ok "Installation complete!"
   echo
   log "Plugin source: $plugin_dir"
-  log "Commands:      $target_dir/commands/aimi-*.md"
+  log "Commands:      $target_dir/commands/aimi/*.md"
   log "Agents:        $target_dir/agents/aimi-*.md"
   log "MCP:           $target_dir/opencode.json"
   echo
@@ -471,7 +470,7 @@ uninstall_opencode() {
   log "Uninstalling $PLUGIN_NAME from OpenCode..."
 
   if [ "$DRY_RUN" -eq 1 ]; then
-    log "[dry-run] Would remove $target_dir/commands/aimi-*.md"
+    log "[dry-run] Would remove $target_dir/commands/aimi/"
     log "[dry-run] Would remove $target_dir/agents/aimi-*.md"
     log "[dry-run] Would remove $target_dir/plugins/$PLUGIN_NAME/"
     log "[dry-run] Would remove context7 from $target_dir/opencode.json"
@@ -481,11 +480,14 @@ uninstall_opencode() {
 
   # Remove commands
   local count=0
-  for f in "$target_dir/commands/"aimi-*.md; do
-    [ -f "$f" ] || continue
-    rm "$f"
-    count=$((count + 1))
-  done
+  if [ -d "$target_dir/commands/aimi" ]; then
+    for f in "$target_dir/commands/aimi/"*.md; do
+      [ -f "$f" ] || continue
+      rm "$f"
+      count=$((count + 1))
+    done
+    rmdir "$target_dir/commands/aimi" 2>/dev/null
+  fi
   [ "$count" -gt 0 ] && ok "Removed $count commands"
 
   # Remove agents

--- a/install.sh
+++ b/install.sh
@@ -184,18 +184,31 @@ fm_get() {
 translate_command_body() {
   local body="$1"
 
-  # If the body does not reference named agents, return unchanged
+  # --- CLI path rewriting (applies to all commands) ---
+  # Replace Claude config dir references with OpenCode config dir
+  body="${body//\$\{CLAUDE_CONFIG_DIR:-\$HOME\/.claude\}/\$\{OPENCODE_CONFIG_DIR:-\$HOME\/.config\/opencode\}}"
+
+  # --- Error message rewriting (applies to all commands) ---
+  # Replace plugin install instructions with OpenCode installer
+  body="${body//\/plugin install aimi-engineering/.\/install.sh --to opencode}"
+
+  # --- AskUserQuestion rewriting (applies to all commands) ---
+  # Replace various AskUserQuestion references with natural conversation note
+  # Order matters: match longer/more-specific patterns first
+  body="${body//Use \*\*AskUserQuestion\*\*/Ask the user by outputting your question directly in the conversation}"
+  body="${body//Use AskUserQuestion/Ask the user by outputting your question directly in the conversation}"
+  body="${body//via AskUserQuestion/by outputting your question directly in the conversation}"
+  body="${body//AskUserQuestion/ask the user by outputting your question directly in the conversation}"
+
+  # --- Agent invocation preamble (only for commands referencing named agents) ---
   case "$body" in
-    *'subagent_type="aimi-engineering:'*) ;;
-    *) printf '%s' "$body"; return 0 ;;
-  esac
+    *'subagent_type="aimi-engineering:'*)
+      # Replace general-purpose with general
+      body="${body//general-purpose/general}"
 
-  # Replace general-purpose with general
-  body="${body//general-purpose/general}"
-
-  # Prepend the OpenCode agent invocation preamble
-  local preamble
-  preamble='## OpenCode Agent Invocation
+      # Prepend the OpenCode agent invocation preamble
+      local preamble
+      preamble='## OpenCode Agent Invocation
 
 When this command references agents via `Task subagent_type="aimi-engineering:CATEGORY:NAME"`, follow this pattern instead:
 
@@ -210,8 +223,11 @@ Run all agent Tasks in parallel as instructed by the command below.
 ---
 
 '
+      body="${preamble}${body}"
+      ;;
+  esac
 
-  printf '%s%s' "$preamble" "$body"
+  printf '%s' "$body"
 }
 
 # ---------------------------------------------------------------------------

--- a/install.sh
+++ b/install.sh
@@ -324,6 +324,71 @@ install_agents() {
 }
 
 # ---------------------------------------------------------------------------
+# install_skills — copy skills to OpenCode's skill discovery directory
+# ---------------------------------------------------------------------------
+install_skills() {
+  local src="$1"
+  local target_dir="$2"
+  local skill_dir="$target_dir/skills"
+  local count=0
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "[dry-run] Would install skills to $skill_dir"
+    for src_skill in "$src/skills/"*/SKILL.md; do
+      [ -f "$src_skill" ] || continue
+      local skillname
+      skillname=$(basename "$(dirname "$src_skill")")
+      log "[dry-run]   Would install skill: aimi-$skillname"
+      local skill_parent
+      skill_parent=$(dirname "$src_skill")
+      [ -d "$skill_parent/references" ] && log "[dry-run]     + references/"
+      [ -d "$skill_parent/scripts" ]    && log "[dry-run]     + scripts/"
+      [ -d "$skill_parent/templates" ]  && log "[dry-run]     + templates/"
+    done
+    return 0
+  fi
+
+  mkdir -p "$skill_dir"
+
+  for src_skill in "$src/skills/"*/SKILL.md; do
+    [ -f "$src_skill" ] || continue
+    local skillname
+    skillname=$(basename "$(dirname "$src_skill")")
+    local dst="$skill_dir/aimi-$skillname"
+
+    mkdir -p "$dst"
+    cp "$src_skill" "$dst/SKILL.md"
+
+    local skill_parent
+    skill_parent=$(dirname "$src_skill")
+
+    # Copy references/ if present
+    if [ -d "$skill_parent/references" ]; then
+      cp -R "$skill_parent/references" "$dst/"
+      [ "$VERBOSE" -eq 1 ] && log "    + references/"
+    fi
+
+    # Copy scripts/ if present, mark .sh files executable
+    if [ -d "$skill_parent/scripts" ]; then
+      cp -R "$skill_parent/scripts" "$dst/"
+      find "$dst/scripts" -name '*.sh' -exec chmod +x {} +
+      [ "$VERBOSE" -eq 1 ] && log "    + scripts/ (executables marked)"
+    fi
+
+    # Copy templates/ if present
+    if [ -d "$skill_parent/templates" ]; then
+      cp -R "$skill_parent/templates" "$dst/"
+      [ "$VERBOSE" -eq 1 ] && log "    + templates/"
+    fi
+
+    count=$((count + 1))
+    [ "$VERBOSE" -eq 1 ] && log "  Skill: aimi-$skillname"
+  done
+
+  ok "Installed $count skills to $skill_dir"
+}
+
+# ---------------------------------------------------------------------------
 # install_mcp — add context7 to opencode.json
 # ---------------------------------------------------------------------------
 install_mcp() {
@@ -444,6 +509,7 @@ install_opencode() {
   install_plugin_source "$src" "$target_dir"
   install_commands "$src" "$target_dir"
   install_agents "$src" "$target_dir"
+  install_skills "$src" "$target_dir"
   install_mcp "$target_dir"
 
   local plugin_dir="$target_dir/plugins/$PLUGIN_NAME"
@@ -455,6 +521,7 @@ install_opencode() {
   log "Plugin source: $plugin_dir"
   log "Commands:      $target_dir/commands/aimi-*.md"
   log "Agents:        $target_dir/agents/aimi-*.md"
+  log "Skills:        $target_dir/skills/aimi-*/"
   log "MCP:           $target_dir/opencode.json"
   echo
   log "Restart your shell or run:"
@@ -473,6 +540,7 @@ uninstall_opencode() {
   if [ "$DRY_RUN" -eq 1 ]; then
     log "[dry-run] Would remove $target_dir/commands/aimi-*.md"
     log "[dry-run] Would remove $target_dir/agents/aimi-*.md"
+    log "[dry-run] Would remove $target_dir/skills/aimi-*/"
     log "[dry-run] Would remove $target_dir/plugins/$PLUGIN_NAME/"
     log "[dry-run] Would remove context7 from $target_dir/opencode.json"
     log "[dry-run] Would remove AIMI_PLUGIN_DIR from shell profiles"
@@ -496,6 +564,15 @@ uninstall_opencode() {
     count=$((count + 1))
   done
   [ "$count" -gt 0 ] && ok "Removed $count agents"
+
+  # Remove skills
+  count=0
+  for d in "$target_dir/skills/"aimi-*/; do
+    [ -d "$d" ] || continue
+    rm -rf "$d"
+    count=$((count + 1))
+  done
+  [ "$count" -gt 0 ] && ok "Removed $count skills"
 
   # Remove plugin source
   if [ -d "$target_dir/plugins/$PLUGIN_NAME" ]; then

--- a/install.sh
+++ b/install.sh
@@ -686,6 +686,7 @@ uninstall_opencode() {
 
   if [ "$DRY_RUN" -eq 1 ]; then
     log "[dry-run] Would remove $target_dir/commands/aimi/"
+    log "[dry-run] Would remove $target_dir/commands/aimi-*.md (legacy flat files)"
     log "[dry-run] Would remove $target_dir/agents/aimi-*.md"
     log "[dry-run] Would remove $target_dir/skills/aimi-*/"
     log "[dry-run] Would remove $target_dir/plugins/$PLUGIN_NAME/"
@@ -705,7 +706,16 @@ uninstall_opencode() {
     done
     rmdir "$target_dir/commands/aimi" 2>/dev/null
   fi
-  [ "$count" -gt 0 ] && ok "Removed $count commands"
+  [ "$count" -gt 0 ] && ok "Removed $count commands (nested)"
+
+  # Remove legacy flat command files (backwards compat with older installs)
+  count=0
+  for f in "$target_dir/commands/"aimi-*.md; do
+    [ -f "$f" ] || continue
+    rm "$f"
+    count=$((count + 1))
+  done
+  [ "$count" -gt 0 ] && ok "Removed $count legacy command files"
 
   # Remove agents
   count=0

--- a/install.sh
+++ b/install.sh
@@ -178,6 +178,43 @@ fm_get() {
 }
 
 # ---------------------------------------------------------------------------
+# translate_command_body — rewrite command body for OpenCode compatibility
+# Prepends agent invocation preamble and fixes subagent_type references
+# ---------------------------------------------------------------------------
+translate_command_body() {
+  local body="$1"
+
+  # If the body does not reference named agents, return unchanged
+  case "$body" in
+    *'subagent_type="aimi-engineering:'*) ;;
+    *) printf '%s' "$body"; return 0 ;;
+  esac
+
+  # Replace general-purpose with general
+  body="${body//general-purpose/general}"
+
+  # Prepend the OpenCode agent invocation preamble
+  local preamble
+  preamble='## OpenCode Agent Invocation
+
+When this command references agents via `Task subagent_type="aimi-engineering:CATEGORY:NAME"`, follow this pattern instead:
+
+1. Extract CATEGORY and NAME from the reference (e.g., `aimi-engineering:review:aimi-security-sentinel` -> category=review, name=aimi-security-sentinel)
+2. Read the agent definition file: `$AIMI_PLUGIN_DIR/agents/CATEGORY/NAME.md`
+3. Strip the YAML frontmatter (everything between the first two `---` lines)
+4. Use the remaining body as the agent'"'"'s system prompt
+5. Spawn: `Task(subagent_type="general", prompt="[agent system prompt]\n\n[original task prompt]")`
+
+Run all agent Tasks in parallel as instructed by the command below.
+
+---
+
+'
+
+  printf '%s%s' "$preamble" "$body"
+}
+
+# ---------------------------------------------------------------------------
 # translate_command — convert Claude command .md to OpenCode command .md
 # ---------------------------------------------------------------------------
 translate_command() {
@@ -189,11 +226,14 @@ translate_command() {
   local desc
   desc=$(fm_get "description") || desc=""
 
+  local translated_body
+  translated_body=$(translate_command_body "$FM_BODY")
+
   {
     printf '%s\n' "---"
     printf 'description: %s\n' "$desc"
     printf '%s\n' "---"
-    printf '%s' "$FM_BODY"
+    printf '%s' "$translated_body"
   } > "$dst_file"
 }
 

--- a/install.sh
+++ b/install.sh
@@ -242,8 +242,28 @@ translate_command() {
   local desc
   desc=$(fm_get "description") || desc=""
 
+  # Append argument-hint to description if present
+  local arg_hint
+  arg_hint=$(fm_get "argument-hint") || arg_hint=""
+  if [ -n "$arg_hint" ]; then
+    desc="$desc $arg_hint"
+  fi
+
+  # Check for disable-model-invocation
+  local disable_invoke
+  disable_invoke=$(fm_get "disable-model-invocation") || disable_invoke=""
+
   local translated_body
   translated_body=$(translate_command_body "$FM_BODY")
+
+  # Prepend side-effect warning if disable-model-invocation: true
+  if [ "$disable_invoke" = "true" ]; then
+    local warning
+    warning='## WARNING: This command has side effects. Only invoke when explicitly requested by the user.
+
+'
+    translated_body="${warning}${translated_body}"
+  fi
 
   {
     printf '%s\n' "---"

--- a/install.sh
+++ b/install.sh
@@ -209,10 +209,16 @@ translate_agent() {
   local desc
   desc=$(fm_get "description") || desc=""
 
+  local model
+  model=$(fm_get "model") || model=""
+
   {
     printf '%s\n' "---"
     printf '%s\n' "mode: subagent"
     printf 'description: %s\n' "$desc"
+    if [ -n "$model" ] && [ "$model" != "inherit" ]; then
+      printf 'model: %s\n' "$model"
+    fi
     printf '%s\n' "---"
     printf '%s' "$FM_BODY"
   } > "$dst_file"

--- a/install.sh
+++ b/install.sh
@@ -454,6 +454,107 @@ JSON
 }
 
 # ---------------------------------------------------------------------------
+# install_permissions — add Bash auto-approval rules to opencode.json
+# ---------------------------------------------------------------------------
+install_permissions() {
+  local target_dir="$1"
+  local plugin_dir="$target_dir/plugins/$PLUGIN_NAME"
+  local config_file="$target_dir/opencode.json"
+
+  local aimi_cli="$plugin_dir/scripts/aimi-cli.sh *"
+  local worktree_mgr="$plugin_dir/skills/git-worktree/scripts/worktree-manager.sh *"
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "[dry-run] Would add permissions to $config_file:"
+    log "[dry-run]   bash: git * -> allow"
+    log "[dry-run]   bash: $aimi_cli -> allow"
+    log "[dry-run]   bash: $worktree_mgr -> allow"
+    log "[dry-run]   bash: docker version * -> allow"
+    log "[dry-run]   bash: docker run --rm --name aimi-swarm-* -> allow"
+    log "[dry-run]   bash: docker container ls * -> allow"
+    log "[dry-run]   bash: docker container prune * -> allow"
+    log "[dry-run]   bash: docker ps * -> allow"
+    log "[dry-run]   bash: docker rm -f aimi-* -> allow"
+    log "[dry-run]   bash: jq * -> allow"
+    log "[dry-run]   bash: ls * -> allow"
+    log "[dry-run]   bash: test * -> allow"
+    log "[dry-run]   bash: id * -> allow"
+    return 0
+  fi
+
+  mkdir -p "$target_dir"
+
+  # Build the permissions JSON fragment
+  local perms_json
+  perms_json=$(cat <<PERMS
+{
+  "permissions": {
+    "bash": {
+      "git *": "allow",
+      "$aimi_cli": "allow",
+      "$worktree_mgr": "allow",
+      "docker version *": "allow",
+      "docker run --rm --name aimi-swarm-*": "allow",
+      "docker container ls *": "allow",
+      "docker container prune *": "allow",
+      "docker ps *": "allow",
+      "docker rm -f aimi-*": "allow",
+      "jq *": "allow",
+      "ls *": "allow",
+      "test *": "allow",
+      "id *": "allow"
+    }
+  }
+}
+PERMS
+)
+
+  if [ -f "$config_file" ]; then
+    # Check if permissions.bash already has our rules
+    if grep -q '"git \*"' "$config_file" 2>/dev/null; then
+      [ "$VERBOSE" -eq 1 ] && log "Permissions already in $config_file, skipping"
+      return 0
+    fi
+
+    backup_file "$config_file"
+
+    if command -v jq >/dev/null 2>&1; then
+      local tmp
+      tmp=$(mktemp)
+      jq --argjson perms "$perms_json" '.permissions = ((.permissions // {}) * $perms.permissions)' "$config_file" > "$tmp" && mv "$tmp" "$config_file"
+    elif command -v python3 >/dev/null 2>&1; then
+      python3 -c "
+import json, sys
+
+perms = json.loads('''$perms_json''')
+
+with open('$config_file') as f:
+    try: cfg = json.load(f)
+    except: cfg = {}
+
+existing = cfg.get('permissions', {})
+for section, rules in perms['permissions'].items():
+    existing.setdefault(section, {}).update(rules)
+cfg['permissions'] = existing
+
+with open('$config_file', 'w') as f:
+    json.dump(cfg, f, indent=2)
+    f.write('\n')
+"
+    else
+      warn "Neither jq nor python3 found. Add permissions manually to $config_file"
+      return 0
+    fi
+  else
+    # Create new opencode.json with permissions
+    mkdir -p "$target_dir"
+    printf '%s\n' "$perms_json" > "$config_file"
+  fi
+
+  ok "Added Bash auto-approval permissions to $config_file"
+}
+
+# ---------------------------------------------------------------------------
 # set_env_var — add AIMI_PLUGIN_DIR export to shell profiles
 # ---------------------------------------------------------------------------
 set_env_var() {
@@ -516,6 +617,7 @@ install_opencode() {
   install_agents "$src" "$target_dir"
   install_skills "$src" "$target_dir"
   install_mcp "$target_dir"
+  install_permissions "$target_dir"
 
   local plugin_dir="$target_dir/plugins/$PLUGIN_NAME"
   set_env_var "$plugin_dir"
@@ -548,6 +650,7 @@ uninstall_opencode() {
     log "[dry-run] Would remove $target_dir/skills/aimi-*/"
     log "[dry-run] Would remove $target_dir/plugins/$PLUGIN_NAME/"
     log "[dry-run] Would remove context7 from $target_dir/opencode.json"
+    log "[dry-run] Would remove permissions from $target_dir/opencode.json"
     log "[dry-run] Would remove AIMI_PLUGIN_DIR from shell profiles"
     return 0
   fi
@@ -610,6 +713,29 @@ with open('$config_file', 'w') as f:
       ok "Removed context7 MCP from $config_file"
     else
       warn "Remove context7 from $config_file manually (no jq or python3)"
+    fi
+  fi
+
+  # Remove permissions from opencode.json
+  if [ -f "$config_file" ] && grep -q '"permissions"' "$config_file" 2>/dev/null; then
+    if command -v jq >/dev/null 2>&1; then
+      local tmp
+      tmp=$(mktemp)
+      jq 'del(.permissions)' "$config_file" > "$tmp" && mv "$tmp" "$config_file"
+      ok "Removed permissions from $config_file"
+    elif command -v python3 >/dev/null 2>&1; then
+      python3 -c "
+import json
+with open('$config_file') as f:
+    cfg = json.load(f)
+cfg.pop('permissions', None)
+with open('$config_file', 'w') as f:
+    json.dump(cfg, f, indent=2)
+    f.write('\n')
+"
+      ok "Removed permissions from $config_file"
+    else
+      warn "Remove permissions from $config_file manually (no jq or python3)"
     fi
   fi
 

--- a/install.sh
+++ b/install.sh
@@ -357,7 +357,7 @@ import json, sys
 with open('$config_file') as f:
     try: cfg = json.load(f)
     except: cfg = {}
-cfg.setdefault('mcp', {})['context7'] = {'type': 'http', 'url': 'https://mcp.context7.com/mcp'}
+cfg.setdefault('mcp', {})['context7'] = {'type': 'remote', 'url': 'https://mcp.context7.com/mcp'}
 with open('$config_file', 'w') as f:
     json.dump(cfg, f, indent=2)
     f.write('\n')

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.33.0",
+  "version": "1.34.0",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi"


### PR DESCRIPTION
## Summary

- Enhances `install.sh` to fully translate Claude Code commands for OpenCode runtime compatibility
- Adds skills installation, nested command directories, permission auto-configuration, and agent invocation rewriting
- Fixes python3 MCP fallback using wrong type (`http` → `remote`)

## Changes

### Command Body Translation
- **Agent invocation rewriting**: Prepends OpenCode preamble instructing LLM to read agent definitions from `$AIMI_PLUGIN_DIR` and spawn with `subagent_type="general"` (OpenCode limitation: custom subagent_type not yet supported)
- **CLI path rewriting**: `${CLAUDE_CONFIG_DIR:-$HOME/.claude}` → `${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}`
- **Error message rewriting**: Recovery instructions point to `./install.sh --to opencode`
- **AskUserQuestion fallback**: Replaced with natural conversation prompts
- **`general-purpose` → `general`**: Maps Claude Code subagent type to OpenCode equivalent

### Installer Enhancements
- **`install_skills()`**: Copies `skills/*/SKILL.md`, `references/`, `scripts/`, `templates/` to OpenCode skills directory
- **`install_permissions()`**: Configures `opencode.json` with Bash auto-approval rules for AIMI CLI, worktree manager, git, and Docker commands
- **Nested command directories**: `commands/aimi/plan.md` → `/aimi:plan` (preserves Claude Code naming)
- **Agent model field**: Preserves `model: haiku` in translated agents
- **Frontmatter translation**: `disable-model-invocation` → side-effect warning; `argument-hint` → description suffix
- **Uninstall updated**: Handles nested dirs, skills, and permissions cleanup

### Bug Fix
- Python3 MCP fallback now uses `type: remote` instead of `type: http`

## Known Limitations

- OpenCode Task tool only accepts `subagent_type: "explore" | "general"` — custom agents invoked via preamble workaround (tracking [anomalyco/opencode#20059](https://github.com/anomalyco/opencode/issues/20059))
- `disable-model-invocation` not supported in OpenCode — uses body warning as workaround
- `AskUserQuestion` not built-in in OpenCode — replaced with natural conversation

