### PR TITLE
chore(plugin): Surface AGENTS.md output rules + hedge token-reduction claims

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and worktree+team orchestration.",
-      "version": "1.60.2",
+      "version": "1.60.3",
       "author": {
         "name": "Aimi — Autonomous Code Companion",
         "url": "https://github.com/aimi-so"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.60.3] - 2026-04-16
+
+### Changed
+
+- **skill (story-executor):** Worker prompt template (both full and compact variants) now explicitly instructs the spawned agent to apply output compression rules from `AGENTS.md`. Previously the rules were only loaded passively through project guidelines; the new `<output_rules>` section in the full template and the appended sentence in the compact template ensure the directive reaches the agent even when `AGENTS.md` is missing or in edge-case multi-repo scenarios.
+- **docs (plugin CLAUDE.md):** Hedge unverified token-reduction claims (~33% inline-story savings, ~60% compact-template savings) — replaced with qualitative descriptions noting the savings have not been benchmarked. Applies to both `plugins/aimi-engineering/CLAUDE.md` Performance Guidelines and the Compact Template blockquote in `skills/story-executor/SKILL.md`.
+
 ## [1.60.2] - 2026-04-16
 
 ### Removed

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.60.2",
+  "version": "1.60.3",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi — Autonomous Code Companion"

--- a/plugins/aimi-engineering/CLAUDE.md
+++ b/plugins/aimi-engineering/CLAUDE.md
@@ -93,14 +93,14 @@ Learnings are stored in project files (not separate progress log):
 
 1. **Inline story data** - Pass story content directly in Task prompts
    - Don't tell agents to re-read the tasks file
-   - Reduces file I/O by ~33%
+   - Avoids a per-story file read; actual token impact not benchmarked
 
 2. **Use CLAUDE.md/AGENTS.md** - Project conventions inline or referenced
    - Small files (<2KB) are inlined in prompt
    - Larger files are referenced for agent to read
 
 3. **Compact prompts** - First story in a session gets the full template (SKILL.md "Prompt Template"); subsequent stories get the condensed variant (SKILL.md "Compact Template") where static sections (`<project_guidelines>`, `<execution_flow>`, `<tools>`, `<on_failure>`, `<project_root_boundary>`) are condensed to one-line summaries — NOT omitted, since each agent has fresh context. Story-specific and context-varying sections remain in full
-   - ~60% token reduction
+   - Reduces prompt size by collapsing static sections; actual savings depend on story content and have not been benchmarked
 
 4. **Fresh context per story** - Each Task agent starts with clean context
    - No memory carryover between stories

--- a/plugins/aimi-engineering/skills/story-executor/SKILL.md
+++ b/plugins/aimi-engineering/skills/story-executor/SKILL.md
@@ -67,6 +67,12 @@ You are executing a single story from the tasks file.
 
 </project_guidelines>
 
+<output_rules>
+
+Apply output compression rules from `AGENTS.md` (spawned-agent status updates: fragments over sentences, drop filler, preserve safety escapes).
+
+</output_rules>
+
 <project_context>
 
 [PROJECT_PATH]   ← optional, resolved absolute path to the target project
@@ -285,7 +291,7 @@ If you cannot complete the story:
 
 ## Compact Template
 
-> Condensed variant for subsequent stories in a wave session. Each Task agent gets fresh context (no memory carryover), so static sections are condensed to one-line summaries — NOT omitted. Story-specific and context-varying sections remain in full. Saves ~60% tokens compared to the full template.
+> Condensed variant for subsequent stories in a wave session. Each Task agent gets fresh context (no memory carryover), so static sections are condensed to one-line summaries — NOT omitted. Story-specific and context-varying sections remain in full. Reduces prompt size by collapsing static sections; actual savings vary with story content and have not been benchmarked.
 
 When spawning a Task agent for subsequent stories (after the first story in a session):
 
@@ -293,7 +299,7 @@ When spawning a Task agent for subsequent stories (after the first story in a se
 You are executing a single story from the tasks file.
 
 <project_guidelines>
-Follow project guidelines from CLAUDE.md/AGENTS.md.
+Follow project guidelines from CLAUDE.md/AGENTS.md. Apply output compression rules from AGENTS.md.
 </project_guidelines>
 
 <project_context>


### PR DESCRIPTION
## Summary

Apply two P3 findings from a recent review of how well the plugin implements the [caveman token-reduction technique](https://raw.githubusercontent.com/JuliusBrussee/caveman/refs/heads/main/caveman/SKILL.md).

### 1. Surface `AGENTS.md` output rules in the worker prompt

Spawned Task agents previously picked up `AGENTS.md` only *passively*, through the project-guidelines load. When `AGENTS.md` was missing (multi-repo edge cases, new projects), the caveman-style output compression silently stopped applying.

- **Full template** (`skills/story-executor/SKILL.md` "Prompt Template") gains a dedicated `<output_rules>` section with a one-line directive: `Apply output compression rules from AGENTS.md (spawned-agent status updates: fragments over sentences, drop filler, preserve safety escapes).`
- **Compact template** appends the same directive to the condensed `<project_guidelines>` line.

### 2. Hedge unverified token-reduction percentages

The `~33%` (inline story data) and `~60%` (Compact Template) numbers in `plugins/aimi-engineering/CLAUDE.md` Performance Guidelines had no measurement behind them — and the Compact Template blockquote in `skills/story-executor/SKILL.md` carried the same `~60%` claim.

Replaced both with qualitative descriptions noting the savings depend on story content and have not been benchmarked.

## Test plan

- [x] `bash plugins/aimi-engineering/scripts/test-aimi-cli.sh` — 268/268 passing
- [x] Version bumped: `plugin.json` / `marketplace.json` → `1.60.3`
- [x] `CHANGELOG.md` entry added under `## [1.60.3] - 2026-04-16`
- [x] No behavior change to commands, skills, or CLI — prompt wording + docs only