### PR TITLE
fix(commands): Replace relative reference Read with ${CLAUDE_PLUGIN_ROOT} absolute path

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and worktree+team orchestration.",
-      "version": "1.68.2",
+      "version": "1.68.3",
       "author": {
         "name": "Aimi — Autonomous Code Companion",
         "url": "https://github.com/aimi-so"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.68.3] - 2026-04-28
+
+### Fixed
+
+- **commands (CLI path resolution):** Replaced the CWD-relative `Read \`references/cli-path-resolution.md\`` loader with the absolute `Read \`${CLAUDE_PLUGIN_ROOT}/commands/references/cli-path-resolution.md\`` form across the seven commands that resolve `$AIMI_CLI` (init, brainstorm, plan, execute — both CLI and Worktree Manager reads — next, open-pr, status). The relative form failed when commands ran from a project CWD outside the plugin tree, causing the agent to glob the project for `cli-path-resolution.md`.
+- **command (`/aimi:init`):** Widened `allowed-tools` from the scoped `Read(references/cli-path-resolution.md)` to bare `Read`, matching the pattern used by the other six commands. The scoped form prevented the new absolute-path read from being authorized.
+- **install (OpenCode):** `install.sh translate_command_body()` now rewrites `${CLAUDE_PLUGIN_ROOT}` to `${AIMI_PLUGIN_DIR}` so translated commands resolve under OpenCode's plugin layout (where `CLAUDE_PLUGIN_ROOT` is undefined). Mirrors the existing `CLAUDE_CONFIG_DIR` rewrite.
+
 ## [1.68.2] - 2026-04-27
 
 ### Removed

--- a/install.sh
+++ b/install.sh
@@ -188,6 +188,11 @@ translate_command_body() {
   # Replace Claude config dir references with OpenCode config dir
   body="${body//\$\{CLAUDE_CONFIG_DIR:-\$HOME\/.claude\}/\$\{OPENCODE_CONFIG_DIR:-\$HOME\/.config\/opencode\}}"
 
+  # Replace plugin root variable with the OpenCode-side AIMI_PLUGIN_DIR
+  # (CLAUDE_PLUGIN_ROOT is injected by Claude Code only; AIMI_PLUGIN_DIR is
+  # exported by this installer for OpenCode.)
+  body="${body//\$\{CLAUDE_PLUGIN_ROOT\}/\$\{AIMI_PLUGIN_DIR\}}"
+
   # --- Error message rewriting (applies to all commands) ---
   # Replace plugin install instructions with OpenCode installer
   body="${body//\/plugin install aimi-engineering/.\/install.sh --to opencode}"

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.68.2",
+  "version": "1.68.3",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi — Autonomous Code Companion"

--- a/plugins/aimi-engineering/commands/brainstorm.md
+++ b/plugins/aimi-engineering/commands/brainstorm.md
@@ -18,7 +18,7 @@ Do not proceed until you have a feature description from the user.
 
 ## Step 0: Resolve CLI Path
 
-Read `references/cli-path-resolution.md` and follow the **Resolve CLI Path**
+Read `${CLAUDE_PLUGIN_ROOT}/commands/references/cli-path-resolution.md` and follow the **Resolve CLI Path**
 section to set `$AIMI_CLI`. Each layer is a separate Bash call.
 
 If resolution fails, fall back to the legacy prose-only path for questions —

--- a/plugins/aimi-engineering/commands/execute.md
+++ b/plugins/aimi-engineering/commands/execute.md
@@ -17,7 +17,7 @@ Single-story waves run inline (no worktree overhead). Multi-story waves spawn N 
 
 ## Step 0: Resolve CLI Path
 
-Read `references/cli-path-resolution.md` and follow the **Resolve CLI Path** and **Version Check** sections to set `$AIMI_CLI`. Each layer is a separate Bash call.
+Read `${CLAUDE_PLUGIN_ROOT}/commands/references/cli-path-resolution.md` and follow the **Resolve CLI Path** and **Version Check** sections to set `$AIMI_CLI`. Each layer is a separate Bash call.
 
 If resolution fails, report error and STOP.
 
@@ -485,7 +485,7 @@ Beginning wave execution loop...
 
 ## Step 3.1: Resolve Worktree Manager
 
-Read `references/cli-path-resolution.md` and follow the **Resolve Worktree Manager Path** section to set `$WORKTREE_MGR`.
+Read `${CLAUDE_PLUGIN_ROOT}/commands/references/cli-path-resolution.md` and follow the **Resolve Worktree Manager Path** section to set `$WORKTREE_MGR`.
 
 If resolution fails, report error and STOP.
 

--- a/plugins/aimi-engineering/commands/init.md
+++ b/plugins/aimi-engineering/commands/init.md
@@ -2,7 +2,7 @@
 name: aimi:init
 description: Prime the global CLI path cache so all /aimi:* commands resolve instantly without the Layer 2 glob
 disable-model-invocation: true
-allowed-tools: Read(references/cli-path-resolution.md), Bash(cat:*), Bash(bash:*), Bash(printf:*), Bash(mv:*), Bash(chmod:*), Bash($AIMI_CLI:*)
+allowed-tools: Read, Bash(cat:*), Bash(bash:*), Bash(printf:*), Bash(mv:*), Bash(chmod:*), Bash($AIMI_CLI:*)
 ---
 
 # Aimi Init
@@ -11,7 +11,7 @@ Prime (or repair) the global CLI path cache so subsequent `/aimi:*` commands ski
 
 ## Step 0: Resolve CLI Path
 
-Read `references/cli-path-resolution.md` and follow the **Resolve CLI Path** and **Version Check** sections to set `$AIMI_CLI`. Each layer is a separate Bash call.
+Read `${CLAUDE_PLUGIN_ROOT}/commands/references/cli-path-resolution.md` and follow the **Resolve CLI Path** and **Version Check** sections to set `$AIMI_CLI`. Each layer is a separate Bash call.
 
 If resolution fails, report error and STOP.
 

--- a/plugins/aimi-engineering/commands/next.md
+++ b/plugins/aimi-engineering/commands/next.md
@@ -11,7 +11,7 @@ Execute the next pending story using a Task-spawned agent.
 
 ## Step 0: Resolve CLI Path
 
-Read `references/cli-path-resolution.md` and follow the **Resolve CLI Path** and **Version Check** sections to set `$AIMI_CLI`. Each layer is a separate Bash call.
+Read `${CLAUDE_PLUGIN_ROOT}/commands/references/cli-path-resolution.md` and follow the **Resolve CLI Path** and **Version Check** sections to set `$AIMI_CLI`. Each layer is a separate Bash call.
 
 If resolution fails, report error and STOP.
 

--- a/plugins/aimi-engineering/commands/open-pr.md
+++ b/plugins/aimi-engineering/commands/open-pr.md
@@ -21,7 +21,7 @@ Commit-message conventions (Conventional Commits, etc.) are preserved automatica
 
 ## Step 0: Resolve CLI Path
 
-Read `references/cli-path-resolution.md` and follow the **Resolve CLI Path** and **Version Check** sections to set `$AIMI_CLI`. Each layer is a separate Bash call.
+Read `${CLAUDE_PLUGIN_ROOT}/commands/references/cli-path-resolution.md` and follow the **Resolve CLI Path** and **Version Check** sections to set `$AIMI_CLI`. Each layer is a separate Bash call.
 
 If resolution fails, report error and STOP.
 

--- a/plugins/aimi-engineering/commands/plan.md
+++ b/plugins/aimi-engineering/commands/plan.md
@@ -17,7 +17,7 @@ $ARGUMENTS
 
 ### Resolve CLI Path
 
-Read `references/cli-path-resolution.md` and follow the **Resolve CLI Path** and **Version Check** sections to set `$AIMI_CLI`. Each layer is a separate Bash call.
+Read `${CLAUDE_PLUGIN_ROOT}/commands/references/cli-path-resolution.md` and follow the **Resolve CLI Path** and **Version Check** sections to set `$AIMI_CLI`. Each layer is a separate Bash call.
 
 If resolution fails, report error and STOP.
 

--- a/plugins/aimi-engineering/commands/status.md
+++ b/plugins/aimi-engineering/commands/status.md
@@ -10,7 +10,7 @@ Display the current execution progress using the CLI script.
 
 ## Step 0: Resolve CLI Path
 
-Read `references/cli-path-resolution.md` and follow the **Resolve CLI Path** and **Version Check** sections to set `$AIMI_CLI`. Each layer is a separate Bash call.
+Read `${CLAUDE_PLUGIN_ROOT}/commands/references/cli-path-resolution.md` and follow the **Resolve CLI Path** and **Version Check** sections to set `$AIMI_CLI`. Each layer is a separate Bash call.
 
 If resolution fails, report error and STOP.
 


### PR DESCRIPTION
## Summary

Seven `/aimi:*` commands instructed the agent to `Read` `references/cli-path-resolution.md` using a CWD-relative path. From the user's project directory that path does not exist, so the Read failed and the agent fell back to globbing the project tree for the missing `.md` file — leaving CLI resolution unable to start.

Switch every body reference to `${CLAUDE_PLUGIN_ROOT}/commands/references/cli-path-resolution.md`, the env var Claude Code already injects (and that this plugin uses elsewhere in `hooks.json` and `skills/git-worktree`). Widen `init.md`'s frontmatter `allowed-tools` from the scoped `Read(references/cli-path-resolution.md)` to bare `Read`, matching the other six commands; `${CLAUDE_PLUGIN_ROOT}` in a Read permission scope is untested.

The reference file itself (`commands/references/cli-path-resolution.md`) and its four-layer bash logic are unchanged.

Mirrors the `CLAUDE_CONFIG_DIR` rewrite in `install.sh` so command bodies referencing `${CLAUDE_PLUGIN_ROOT}/commands/references/cli-path-resolution.md` resolve under OpenCode where `CLAUDE_PLUGIN_ROOT` is undefined.

Released as 1.68.3.

US-001

## Changes

- fix(commands): Replace relative reference Read with ${CLAUDE_PLUGIN_ROOT} absolute path
- fix(install): Translate ${CLAUDE_PLUGIN_ROOT} to ${AIMI_PLUGIN_DIR} for OpenCode
- chore(release): 1.68.3

## Files Changed

```
 .claude-plugin/marketplace.json                     | 2 +-
 CHANGELOG.md                                        | 8 ++++++++
 install.sh                                          | 5 +++++
 plugins/aimi-engineering/.claude-plugin/plugin.json | 2 +-
 plugins/aimi-engineering/commands/brainstorm.md     | 2 +-
 plugins/aimi-engineering/commands/execute.md        | 4 ++--
 plugins/aimi-engineering/commands/init.md           | 4 ++--
 plugins/aimi-engineering/commands/next.md           | 2 +-
 plugins/aimi-engineering/commands/open-pr.md        | 2 +-
 plugins/aimi-engineering/commands/plan.md           | 2 +-
 plugins/aimi-engineering/commands/status.md         | 2 +-
 11 files changed, 24 insertions(+), 11 deletions(-)
```