### PR TITLE
US-001: add validate-tasks subcommand skeleton with schemaVersion guard

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and worktree+team orchestration.",
-      "version": "1.78.0",
+      "version": "1.79.0",
       "author": {
         "name": "Aimi — Autonomous Code Companion",
         "url": "https://github.com/aimi-so"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and worktree+team orchestration.",
-      "version": "1.79.0",
+      "version": "1.80.0",
       "author": {
         "name": "Aimi — Autonomous Code Companion",
         "url": "https://github.com/aimi-so"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.80.0] - 2026-05-11
+
+### Added
+
+- **Pre-Save Blocking Gate for Open Questions in `/aimi:brainstorm` (US-001):** The Pre-Save Checklist at `plugins/aimi-engineering/commands/brainstorm.md` is strengthened with a `### Pre-Save Blocking Gate — Open Questions` block that counts entries under `## Open Questions` lacking a `[resolved: <choice>]` or `[deferred: <reason>]` sentinel suffix, loops `AskUserQuestion` until every OQ carries one, and writes the sentinel back to the OQ line as the idempotency marker. Bundle-sourced OQs (lines originating from `BusinessSpec § 11` or `DesignSpec § 8`) are NOT exempt — `bundleAddressedTopics` covers chat-question categories, not spec pendencies. Agent-mode fallback auto-marks every unresolved OQ as `[deferred: agent-mode auto-defer]` before save.
+- **Defensive Phase 0.5 Open Questions Resolution Gate in `/aimi:plan` (US-002):** New `### Phase 0.5: Open Questions Resolution Gate` section inserted between Phase 0 and Phase 1 of `plugins/aimi-engineering/commands/plan.md`. Parses the brainstorm `## Open Questions` section; for each line without a `[resolved: ...]` or `[deferred: ...]` sentinel, calls `AskUserQuestion`, appends the sentinel via `Edit`, records the choice in working memory `oqDecisions: { <oqId>: <choice> }` for use in Phase 4 `metadata.decisions[]`, and blocks Phase 1 until every OQ is sentinelled. Agent-mode fallback: auto-defer (do not block). Catches stale brainstorms that bypassed the upstream save-gate.
+- **`validate-stories` gate-schema enforcement in `aimi-cli.sh` (US-003):** `cmd_validate_stories` now rejects the plural `gates` field with `<id>: gate: 'gates' field is invalid; use singular 'gate' (see plan.md L687-692)` and validates the singular `gate` object shape by requiring `type`, `status`, and `prompt` keys (emits `<id>: gate: missing required field <name>` per missing key). Errors flow through the existing `{valid, errors[]}` output channel — no `ERROR:` prefix, no exit-per-error. Three new fixtures registered in `test-aimi-cli.sh` (`test_validate_stories_gate_field`): plural `gates` (fail), singular `gate` missing `type` (fail), well-formed singular `gate` (pass).
+
+### Changed
+
+- **`/aimi:plan` Phase 4.5 validator note extended (US-004):** The existing note around `validate-stories (US-001) catches malformed skills[]` is extended to also document the new gate-schema enforcement — both `gates` plural rejection and singular `gate` shape validation.
+
 ## [1.79.0] - 2026-05-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.79.0] - 2026-05-11
+
+### Added
+
+- **`validate-tasks` subcommand in `aimi-cli.sh` (US-006, gap-analysis case 6):** New CLI subcommand that mechanically enforces citation contracts in a tasks.json file before execution. Reads `acceptanceCriteria[]` entries flagged as visual and verifies each contains at least one verbatim DesignSpec citation anchored as `"<literal>" (DesignSpec § N.N L<line>)`. Exits non-zero with a structured error report on first violation, preventing story execution from proceeding with uncited visual ACs.
+- **Rule 19a in `/aimi:plan` Phase 3 (US-001, US-002, US-003, gap-analysis cases 1, 2, 3):** Verbatim DesignSpec citation requirement for visual acceptance criteria. Any AC that describes a visual element (layout, copy, label, badge, header, footer, column header, KPI label, button text, subtitle) must embed the exact literal string from the DesignSpec section followed by a citation anchor in the form `"<literal>" (DesignSpec § N.N L<line>)`. Applies to H1 text, subtitles, KPI labels, column headers, button labels, footer text, and badge copy. Planner must resolve the section number and line number from the attached DesignSpec before emitting the story.
+- **`source` field requirement on `backendSpec.endpoints[]` and `responseShape` (US-007, gap-analysis case 7):** Every entry in `backendSpec.endpoints[]` must carry a `source` field citing the spec document and section that mandates the endpoint (e.g., `"source": "BusinessSpec § 3.2"`). Every `responseShape` field in frontend-only plans must likewise declare its provenance. A `derived:` escape hatch is available for legitimately computed shapes whose structure is not directly specified in any spec document (e.g., `"source": "derived: aggregated from /users and /roles responses"`).
+- Gap-analysis cases 4, 5, 8 are deferred to v1.80.
+
 ## [1.78.0] - 2026-05-11
 
 ### Added

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.79.0",
+  "version": "1.80.0",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi — Autonomous Code Companion"

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.78.0",
+  "version": "1.79.0",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi — Autonomous Code Companion"

--- a/plugins/aimi-engineering/commands/brainstorm.md
+++ b/plugins/aimi-engineering/commands/brainstorm.md
@@ -1019,7 +1019,21 @@ If neither variant prototypes were saved nor bundle prototypes are available (ne
 Before writing the document, verify **all** of the following criteria. If any criterion fails, pause and ask the user before saving — do not silently skip.
 
 - [ ] All critical topics addressed (Purpose, Users, Success at minimum)
-- [ ] Open Questions resolved or explicitly deferred
+- [ ] Open Questions resolved or explicitly deferred (see gate below)
+
+### Pre-Save Blocking Gate — Open Questions
+
+Before writing the brainstorm document, count entries under `## Open Questions` that lack one of:
+
+- a `[resolved: <choice>]` suffix
+- a `[deferred: <reason>]` suffix
+
+If count > 0: STOP. Loop AskUserQuestion until count == 0. Each answer appends `[resolved: <choice>]` (or `[deferred: <reason>]`) to the OQ line. Re-running save on a file whose OQ lines already carry `[resolved: ...]` or `[deferred: ...]` sentinels does not re-prompt — the sentinel suffix acts as the idempotency marker.
+
+**Bundle-source clarification:** Bundle-sourced OQs (lines that originated from `BusinessSpec § 11` or `DesignSpec § 8`) are NOT exempt — `bundleAddressedTopics` covers question categories from chat, not spec pendencies.
+
+**Agent-mode fallback:** When running in agent-mode, auto-mark every unresolved OQ as `[deferred: agent-mode auto-defer]` before save instead of blocking on AskUserQuestion.
+
 - [ ] At least 2 approaches compared in the "Why This Approach" section **OR** explicit justification that only one viable approach exists (e.g., "Single obvious approach: [reason]")
 - [ ] Document uses correct frontmatter (date, topic)
 - [ ] Next Steps references `/aimi:plan`

--- a/plugins/aimi-engineering/commands/plan.md
+++ b/plugins/aimi-engineering/commands/plan.md
@@ -789,7 +789,7 @@ $AIMI_CLI validate-tasks
 3. Re-write the tasks.json file using the Write tool
 4. Re-run all validations until they pass
 
-**Note:** `validate-stories` (US-001) catches malformed `skills[]` — entries that fail the `^[a-zA-Z0-9][a-zA-Z0-9_-]*$` regex, lists exceeding 10 entries, or an explicitly empty `skills: []` array (field must be omitted when no skills apply).
+**Note:** `validate-stories` (US-001) catches malformed `skills[]` — entries that fail the `^[a-zA-Z0-9][a-zA-Z0-9_-]*$` regex, lists exceeding 10 entries, or an explicitly empty `skills: []` array (field must be omitted when no skills apply). It also enforces the **gate schema** (US-003): the plural `gates` field is rejected outright (use singular `gate`, see L687-692 above), and any singular `gate` object must carry all three required keys — `type`, `status`, and `prompt`.
 
 Do **not** proceed to the report step until all validations succeed.
 

--- a/plugins/aimi-engineering/commands/plan.md
+++ b/plugins/aimi-engineering/commands/plan.md
@@ -721,11 +721,13 @@ $AIMI_CLI init-session --file .aimi/tasks/YYYY-MM-DD-[feature-name]-frontend-tas
 $AIMI_CLI validate-ids
 $AIMI_CLI validate-deps
 $AIMI_CLI validate-stories
+$AIMI_CLI validate-tasks
 
 $AIMI_CLI init-session --file .aimi/tasks/YYYY-MM-DD-[feature-name]-backend-tasks.json
 $AIMI_CLI validate-ids
 $AIMI_CLI validate-deps
 $AIMI_CLI validate-stories
+$AIMI_CLI validate-tasks
 ```
 
 **For single file (frontend-only or legacy):**
@@ -735,6 +737,7 @@ $AIMI_CLI init-session --file .aimi/tasks/YYYY-MM-DD-[feature-name]-frontend-tas
 $AIMI_CLI validate-ids
 $AIMI_CLI validate-deps
 $AIMI_CLI validate-stories
+$AIMI_CLI validate-tasks
 ```
 
 **If any validation fails (non-zero exit):**

--- a/plugins/aimi-engineering/commands/plan.md
+++ b/plugins/aimi-engineering/commands/plan.md
@@ -556,8 +556,10 @@ Write the same `prototypePaths`, `designBundle`, and `designTokens` arrays/objec
 1. Set `metadata.frontendOnly: true`
 2. **Generate `metadata.backendSpec`**:
    - **When `businessSpecPath` is non-null** (spec-driven path — takes precedence over inference):
-     - `endpoints`: populate from `BusinessSpec § 5` (endpoints/API contracts)
-     - `dataModels`: populate from `BusinessSpec § 4` (data models / entities)
+     - `endpoints`: populate from `BusinessSpec § 5` (endpoints/API contracts). Every entry MUST carry a `source` field matching `"BusinessSpec § N[.N] L<line>"` citing the exact line in § 5 that defines the endpoint. Every `responseShape` field MUST also carry a `source` field in the same format, citing the line that defines that field.
+       - **Do NOT invent fields**: if a `responseShape` field is required by an acceptance criterion but absent from `BusinessSpec § 5`, do NOT add it to `responseShape`. Instead, emit a `gate` of type `decision` on the story asking the user how to source the field, and leave the `responseShape` entry out until the gate resolves.
+       - Fields whose value is derived from multiple spec lines (aggregations, computed values) MUST use the `"derived: <explanation>"` prefix in their `source` value instead of a literal citation. The `derived:` prefix is accepted as a manual-review marker; it does not allow inventing fields.
+     - `dataModels`: populate from `BusinessSpec § 4` (data models / entities). Every entry MUST carry a `source` field matching `"BusinessSpec § N[.N] L<line>"` citing the line in § 4 that defines the model. Individual fields within `fields[]` that are derived MUST use `"derived: <explanation>"`.
      - `businessRules`: populate from `BusinessSpec § 3` (business rules)
      - `businessContext.userRoles`: populate from `BusinessSpec § 7` (user roles / personas)
      - `businessContext.successCriteria`: populate from `BusinessSpec § 9` (acceptance criteria)
@@ -627,8 +629,27 @@ Write JSON using the Write tool. Validate JSON is well-formed before writing.
     "maxConcurrency": "number (optional, default 5)",
     "frontendOnly": "boolean (optional, true when frontend-only scope)",
     "backendSpec": {
-      "endpoints": [{"method": "string", "path": "string", "description": "string"}],
-      "dataModels": [{"name": "string", "fields": ["string"]}],
+      "endpoints": [
+        {
+          "method": "string",
+          "path": "string",
+          "description": "string",
+          "source": "BusinessSpec § N[.N] L<line> (required when businessSpecPath non-null; or 'derived: <explanation>' for computed endpoints)",
+          "responseShape": {
+            "<fieldName>": {
+              "type": "string",
+              "source": "BusinessSpec § N[.N] L<line> (required when businessSpecPath non-null; or 'derived: <explanation>')"
+            }
+          }
+        }
+      ],
+      "dataModels": [
+        {
+          "name": "string",
+          "fields": ["string"],
+          "source": "BusinessSpec § N[.N] L<line> (required when businessSpecPath non-null; or 'derived: <explanation>')"
+        }
+      ],
       "businessRules": ["string"],
       "businessContext": {
         "summary": "string",

--- a/plugins/aimi-engineering/commands/plan.md
+++ b/plugins/aimi-engineering/commands/plan.md
@@ -221,6 +221,19 @@ After the brainstorm check, determine the implementation scope:
 
 3. **Store the result** as `implementationScope: "frontend-only" | "full-stack"` for use in Phase 4 metadata.
 
+### Phase 0.5: Open Questions Resolution Gate
+
+After Phase 0 produces (or reuses) a brainstorm, parse its `## Open Questions` section.
+
+For each line that does NOT carry a `[resolved: ...]` or `[deferred: ...]` suffix:
+- Call AskUserQuestion with the OQ as the question text.
+- Append `[resolved: <choice>]` to the OQ line in the brainstorm file (via Edit), so subsequent re-runs skip it.
+- Record the resolution in working memory `oqDecisions: { <oqId>: <choice> }` for use in Phase 4 when authoring `metadata.decisions[]`.
+
+Block Phase 1 until every OQ has a `[resolved: ...]` or `[deferred: ...]` suffix.
+
+Agent-mode fallback: auto-defer (do not block).
+
 ## Phase 1: Local Research (Parallel)
 
 ### Prepare Research Directory

--- a/plugins/aimi-engineering/commands/plan.md
+++ b/plugins/aimi-engineering/commands/plan.md
@@ -470,9 +470,17 @@ directly when describing UI acceptance criteria, component structure, and visual
     - **Heading citation** (preferred): `(prototype: <relative-path> §<heading-text>)` — where `<heading-text>` is the text of the nearest preceding `<h1>`–`<h6>` element in the prototype HTML that covers the cited region (e.g., `(prototype: draives-monitor/project/Monitoramento.html §Visão Geral)`).
     - **Line-range fallback**: when the cited region has no preceding heading element, use `(prototype: <relative-path>:L<start>-L<end>)` with the line numbers from the prototype HTML (e.g., `(prototype: draives-monitor/project/Monitoramento.html:L42-L67)`).
 
-    **No double-deriving**: when a prototype covers a layout region, AC must cite the prototype — not re-derive layout from `DesignSpec.md`. The prototype is canonical for visual layout; `DesignSpec.md` remains canonical for design tokens, component prop types, and interaction states. A story may hold both a prototype citation and a spec reference when they cover different concerns (e.g., layout from prototype, color tokens from spec).
+    **No double-deriving** (spatial layout only): when a prototype covers a layout region, AC must cite the prototype — not re-derive spatial layout (positioning, sizing, stacking, alignment) from `DesignSpec.md`. The prototype is canonical for visual layout; `DesignSpec.md` remains canonical for design tokens, component prop types, and interaction states. A story may hold both a prototype citation and a spec reference when they cover different concerns (e.g., layout from prototype, color tokens from spec). Literal string content (labels, headings, copy) is always governed by Rule 19a regardless of which artifact covers the region.
 
     The decomposition LLM authors citations; they are never auto-injected. Violations surface at the post-decomposition checklist stage.
+
+19a. **Verbatim DesignSpec citations for visual ACs** (when `designSpecContent` is non-null AND `verification.strategy` is `visual` for a story): every visible-text element in the cited region MUST be extracted verbatim from the DesignSpec § N.N subsection — including page H1, subtitle, KPI/metric card labels, table column headers, filter/dropdown/button labels, footer/disclaimer text, and badge text. Do not paraphrase, translate, abbreviate, or reorder. Wrap each literal in double quotes and follow it with the anchor `(DesignSpec § N.N L<line>)`.
+
+    Example (correct):
+    - `"Benchmark do portfolio" (DesignSpec § 3.1 L42) MUST appear as the page H1.`
+
+    Example (wrong — paraphrase):
+    - `The page header shows the portfolio benchmark name.`
 
 20. **Mock-sync AC injection for schema-extending stories**: after all stories are drafted, scan each story's `implementation.files` array against the following globs:
     - `**/schemas/**/*.{ts,js,py,rb}`
@@ -698,6 +706,7 @@ Write JSON using the Write tool. Validate JSON is well-formed before writing.
 - [ ] `gate` (if present) has `type` (`verify`, `decision`, or `action`), `status` (`"pending"`), and `prompt`
 - [ ] Gates only attached when heuristics clearly match
 - [ ] Every story with `verification.strategy == "visual"` and non-empty `metadata.prototypePaths` has at least one `(prototype: ...)` citation in its acceptance criteria (either `(prototype: <path> §<heading>)` or `(prototype: <path>:L<start>-L<end>)`)
+- [ ] Rule 19a compliance (when `designSpecContent` is non-null): every visual story's `acceptanceCriteria` wraps each visible-text literal in double quotes followed by a `(DesignSpec § N.N L<line>)` anchor; no paraphrasing, translation, abbreviation, or reordering of the cited text
 
 ### Split-File Checks (when `implementationScope` is set)
 - [ ] Full-stack: two files generated (`*-frontend-tasks.json` and `*-backend-tasks.json`)

--- a/plugins/aimi-engineering/scripts/aimi-cli.sh
+++ b/plugins/aimi-engineering/scripts/aimi-cli.sh
@@ -898,6 +898,10 @@ cmd_validate_stories() {
              [$s.tasks[] | select(type == "string" and length > 5000) | "\($s.id): tasks[] entry exceeds 5000 chars"] +
              [$s.tasks[] | select(type == "string" and test("ignore previous|system:|INSTRUCTIONS|```|\\$\\(|`"; "i")) | "\($s.id): tasks[] entry contains suspicious content"]
            end)
+         else [] end) +
+        (if has("gates") then ["\($s.id): gate: 'gates' field is invalid; use singular 'gate' (see plan.md L687-692)"] else [] end) +
+        (if ($s.gate != null) then
+          (["type","status","prompt"] | map(. as $k | if ($s.gate | has($k) | not) then ["\($s.id): gate: missing required field \($k)"] else [] end) | add // [])
          else [] end)
       ) | .[]
     ] |

--- a/plugins/aimi-engineering/scripts/aimi-cli.sh
+++ b/plugins/aimi-engineering/scripts/aimi-cli.sh
@@ -2375,6 +2375,103 @@ cmd_validate_tasks() {
     fi
   fi
 
+  # BusinessSpec scan: only when metadata.frontendOnly is true AND metadata.designBundle.businessSpec is non-null
+  local frontend_only
+  frontend_only=$(jq -r '.metadata.frontendOnly // false' "$tasks_file" 2>/dev/null)
+
+  local business_spec_rel
+  business_spec_rel=$(jq -r '.metadata.designBundle.businessSpec // empty' "$tasks_file" 2>/dev/null)
+
+  if [ "$frontend_only" = "true" ] && [ -n "$business_spec_rel" ]; then
+    # Resolve BusinessSpec path relative to PROJECT_ROOT
+    local business_spec_path
+    business_spec_path="${PROJECT_ROOT}/${business_spec_rel}"
+
+    if [ ! -f "$business_spec_path" ]; then
+      errors+=("${tasks_file}: BusinessSpec file not found: ${business_spec_rel}")
+    else
+      # Iterate every endpoints[] entry
+      local endpoint_count
+      endpoint_count=$(jq '.metadata.backendSpec.endpoints | if type == "array" then length else 0 end' "$tasks_file" 2>/dev/null)
+      endpoint_count="${endpoint_count:-0}"
+
+      local ep_index=0
+      while [ "$ep_index" -lt "$endpoint_count" ]; do
+        # Get source value for this endpoint
+        local ep_source
+        ep_source=$(jq -r --argjson idx "$ep_index" '.metadata.backendSpec.endpoints[$idx].source // empty' "$tasks_file" 2>/dev/null)
+
+        if [ -z "$ep_source" ]; then
+          errors+=("${tasks_file}: backendSpec.endpoints[${ep_index}]: missing source field")
+          ep_index=$((ep_index + 1))
+          continue
+        fi
+
+        # Check if source uses derived: prefix
+        if printf '%s' "$ep_source" | grep -q '^derived:'; then
+          # Warn to stderr, do not add to errors
+          printf '%s: backendSpec.endpoints[%s]: derived source — manual review required\n' \
+            "$tasks_file" "$ep_index" >&2
+          ep_index=$((ep_index + 1))
+          continue
+        fi
+
+        # Validate literal source format: "BusinessSpec § N[.N] L<line>"
+        if ! printf '%s' "$ep_source" | grep -qE '^BusinessSpec § [0-9]+(\.[0-9]+)? L[0-9]+$'; then
+          errors+=("${tasks_file}: backendSpec.endpoints[${ep_index}]: malformed source \"${ep_source}\" (expected 'BusinessSpec § N[.N] L<line>' or 'derived: ...')")
+          ep_index=$((ep_index + 1))
+          continue
+        fi
+
+        # Extract section from source
+        local ep_section
+        ep_section=$(printf '%s' "$ep_source" | grep -oE '§ [0-9]+(\.[0-9]+)?' | sed 's/§ //')
+
+        # Iterate every field in responseShape
+        local field_names
+        field_names=$(jq -r --argjson idx "$ep_index" \
+          '.metadata.backendSpec.endpoints[$idx].responseShape | if type == "object" then keys[] else empty end' \
+          "$tasks_file" 2>/dev/null)
+
+        while IFS= read -r field_name; do
+          [ -z "$field_name" ] && continue
+
+          # Get per-field source if it exists (responseShape field can be {type, source} or a scalar)
+          local field_source
+          field_source=$(jq -r --argjson idx "$ep_index" --arg fn "$field_name" \
+            '.metadata.backendSpec.endpoints[$idx].responseShape[$fn] | if type == "object" then .source // empty else empty end' \
+            "$tasks_file" 2>/dev/null)
+
+          # If field has its own source, validate it too
+          if [ -n "$field_source" ]; then
+            if printf '%s' "$field_source" | grep -q '^derived:'; then
+              printf '%s: backendSpec.endpoints[%s].responseShape.%s: derived source — manual review required\n' \
+                "$tasks_file" "$ep_index" "$field_name" >&2
+              continue
+            fi
+            if ! printf '%s' "$field_source" | grep -qE '^BusinessSpec § [0-9]+(\.[0-9]+)? L[0-9]+$'; then
+              errors+=("${tasks_file}: backendSpec.endpoints[${ep_index}].responseShape.${field_name}: malformed source \"${field_source}\"")
+              continue
+            fi
+            # Use the field-level section for subsection lookup
+            local field_section
+            field_section=$(printf '%s' "$field_source" | grep -oE '§ [0-9]+(\.[0-9]+)?' | sed 's/§ //')
+            if ! _validate_businessspec_field "$business_spec_path" "$field_name" "$field_section"; then
+              errors+=("${tasks_file}: backendSpec.endpoints[${ep_index}].responseShape.${field_name}: field name not found in BusinessSpec § ${field_section}")
+            fi
+          else
+            # No per-field source: check field name against the endpoint-level cited section
+            if ! _validate_businessspec_field "$business_spec_path" "$field_name" "$ep_section"; then
+              errors+=("${tasks_file}: backendSpec.endpoints[${ep_index}].responseShape.${field_name}: field name not found in BusinessSpec § ${ep_section}")
+            fi
+          fi
+        done <<< "$field_names"
+
+        ep_index=$((ep_index + 1))
+      done
+    fi
+  fi
+
   # Emit result JSON
   if [ ${#errors[@]} -eq 0 ]; then
     echo '{"valid": true, "errors": []}'
@@ -2476,6 +2573,59 @@ _validate_designspec_citation() {
 
   # Check if normalized literal is a substring of normalized body
   if printf '%s' "$normalized_body" | grep -qF "$normalized_literal"; then
+    return 0
+  fi
+  return 1
+}
+
+# Helper: validate that a field name appears as a literal substring in the cited BusinessSpec subsection.
+# Reuses the same subsection-boundary algorithm as _validate_designspec_citation.
+# Usage: _validate_businessspec_field <spec_file> <field_name> <section>
+# Returns 0 if found, 1 if not found.
+_validate_businessspec_field() {
+  local spec_file="$1"
+  local field_name="$2"
+  local section="$3"
+
+  # Extract subsection body from the spec file using the same awk strategy
+  local subsection_body
+  subsection_body=$(awk -v section="$section" '
+    BEGIN { in_section = 0; heading_level = 0 }
+    {
+      if (/^#+[[:space:]]/) {
+        level = 0
+        line_copy = $0
+        while (substr(line_copy, 1, 1) == "#") {
+          level++
+          line_copy = substr(line_copy, 2)
+        }
+        if (!in_section) {
+          heading_text = substr($0, level + 1)
+          gsub(/^[[:space:]]+/, "", heading_text)
+          if (heading_text ~ ("^(§[[:space:]]*)?" section "([[:space:]]|$)") || \
+              heading_text ~ ("§[[:space:]]*" section "([[:space:]]|$)")) {
+            in_section = 1
+            heading_level = level
+            next
+          }
+        } else {
+          if (level <= heading_level) {
+            exit
+          }
+        }
+      }
+      if (in_section) {
+        print $0
+      }
+    }
+  ' "$spec_file")
+
+  if [ -z "$subsection_body" ]; then
+    return 1
+  fi
+
+  # Check if field name appears as a literal substring in the subsection body
+  if printf '%s' "$subsection_body" | grep -qF "$field_name"; then
     return 0
   fi
   return 1

--- a/plugins/aimi-engineering/scripts/aimi-cli.sh
+++ b/plugins/aimi-engineering/scripts/aimi-cli.sh
@@ -2294,9 +2294,10 @@ cmd_validate_waves() {
   ' "$tasks_file"
 }
 
-# Validate tasks file citation fields (skeleton: schemaVersion guard only)
-# For schemaVersion >= 3.3: emits {valid: true, errors: []} — no checks yet
+# Validate tasks file citation fields
+# For schemaVersion >= 3.3: validates DesignSpec verbatim citations for visual stories
 # For schemaVersion < 3.3: emits skip-info to stderr and exits 0
+# stdout: {valid, errors[]} JSON; exits non-zero when invalid
 cmd_validate_tasks() {
   local tasks_file
   tasks_file=$(get_tasks_file)
@@ -2311,8 +2312,173 @@ cmd_validate_tasks() {
     return 0
   fi
 
-  echo '{"valid": true, "errors": []}'
-  return 0
+  # Collect errors as a bash array
+  local errors=()
+
+  # DesignSpec scan: only when metadata.designBundle.designSpec is non-null
+  # AND metadata.prototypePaths is non-empty
+  local design_spec_rel
+  design_spec_rel=$(jq -r '.metadata.designBundle.designSpec // empty' "$tasks_file" 2>/dev/null)
+
+  local prototype_count
+  prototype_count=$(jq '.metadata.prototypePaths | if type == "array" then length else 0 end' "$tasks_file" 2>/dev/null)
+  prototype_count="${prototype_count:-0}"
+
+  if [ -n "$design_spec_rel" ] && [ "$prototype_count" -gt 0 ]; then
+    # Resolve DesignSpec path relative to PROJECT_ROOT
+    local design_spec_path
+    design_spec_path="${PROJECT_ROOT}/${design_spec_rel}"
+
+    if [ ! -f "$design_spec_path" ]; then
+      errors+=("${tasks_file}: DesignSpec file not found: ${design_spec_rel}")
+    else
+      # Extract visual stories: id + acceptanceCriteria entries as TSV lines
+      # Format: <story_id>\t<ac_index>\t<ac_text>
+      local visual_ac_data
+      visual_ac_data=$(jq -r '
+        .userStories[] |
+        select(.verification.strategy == "visual") |
+        . as $s |
+        .acceptanceCriteria | to_entries[] |
+        [$s.id, (.key | tostring), .value] | @tsv
+      ' "$tasks_file" 2>/dev/null)
+
+      if [ -n "$visual_ac_data" ]; then
+        # Process each AC entry
+        while IFS=$'\t' read -r story_id ac_index ac_text; do
+          [ -z "$story_id" ] && continue
+
+          # Extract all "literal" (DesignSpec § N.N L<line>) patterns from the AC
+          # Pattern: "some literal" (DesignSpec § N.N L<line>)
+          # Use grep to find all matches in the ac_text
+          local matches
+          matches=$(printf '%s' "$ac_text" | grep -oE '"[^"]+" \(DesignSpec § [0-9]+\.[0-9]+ L[0-9]+\)' 2>/dev/null || true)
+
+          [ -z "$matches" ] && continue
+
+          while IFS= read -r match; do
+            [ -z "$match" ] && continue
+
+            # Extract the literal string (between double quotes)
+            local literal section line_num
+            literal=$(printf '%s' "$match" | sed 's/^"\(.*\)" (DesignSpec § .*)$/\1/')
+            section=$(printf '%s' "$match" | grep -oE '§ [0-9]+\.[0-9]+' | sed 's/§ //')
+            line_num=$(printf '%s' "$match" | grep -oE 'L[0-9]+' | head -1 | sed 's/L//')
+
+            # Locate subsection in DesignSpec and check verbatim presence
+            if ! _validate_designspec_citation "$design_spec_path" "$literal" "$section"; then
+              errors+=("${tasks_file}: ${story_id} AC[${ac_index}]: missing DesignSpec citation for \"${literal}\" in section § ${section}")
+            fi
+          done <<< "$matches"
+        done <<< "$visual_ac_data"
+      fi
+    fi
+  fi
+
+  # Emit result JSON
+  if [ ${#errors[@]} -eq 0 ]; then
+    echo '{"valid": true, "errors": []}'
+    return 0
+  else
+    # Build JSON errors array
+    local errors_json
+    errors_json=$(printf '%s\n' "${errors[@]}" | jq -R . | jq -s .)
+    printf '{"valid": false, "errors": %s}\n' "$errors_json"
+    return 1
+  fi
+}
+
+# Helper: validate that a literal string appears verbatim in the cited DesignSpec subsection.
+# Subsection boundary: lines from "## N.N <heading>" (or "### N.N") to next heading of equal/higher level.
+# Normalizes Unicode quotes, em-dashes, non-breaking spaces, and HTML entities on both sides.
+# Usage: _validate_designspec_citation <spec_file> <literal> <section>
+# Returns 0 if found, 1 if not found.
+_validate_designspec_citation() {
+  local spec_file="$1"
+  local literal="$2"
+  local section="$3"
+
+  # Normalize a string: Unicode quotes → ASCII, em-dash → hyphen,
+  # non-breaking space → space, HTML entities to literal chars.
+  _normalize_text() {
+    local text="$1"
+    # Curly double quotes → straight double quote
+    text=$(printf '%s' "$text" | sed \
+      -e 's/\xe2\x80\x9c/"/g' \
+      -e 's/\xe2\x80\x9d/"/g' \
+      -e "s/\xe2\x80\x98/'/g" \
+      -e "s/\xe2\x80\x99/'/g" \
+      -e 's/\xe2\x80\x94/-/g' \
+      -e 's/\xc2\xa0/ /g' \
+      -e 's/&amp;/\&/g' \
+      -e 's/&nbsp;/ /g' \
+      -e 's/&lt;/</g' \
+      -e 's/&gt;/>/g' \
+      -e 's/&quot;/"/g')
+    printf '%s' "$text"
+  }
+
+  # Determine heading level for section N.N (always "##" — subsection level)
+  # Section like "3.1" is a sub-heading; we look for "## 3.1" or "### 3.1" etc.
+  # We scan for the section heading and collect lines until the next equal/higher heading.
+
+  local normalized_literal
+  normalized_literal=$(_normalize_text "$literal")
+
+  # Extract subsection body from the spec file
+  # Strategy: use awk to find the heading containing the section number,
+  # then collect lines until a heading of equal or higher level.
+  local subsection_body
+  subsection_body=$(awk -v section="$section" '
+    BEGIN { in_section = 0; heading_level = 0 }
+    {
+      # Detect markdown headings: count leading # characters
+      if (/^#+[[:space:]]/) {
+        level = 0
+        line_copy = $0
+        while (substr(line_copy, 1, 1) == "#") {
+          level++
+          line_copy = substr(line_copy, 2)
+        }
+        # Check if this heading contains the section number
+        if (!in_section) {
+          # Look for pattern like "§ N.N" or "N.N " at start of heading text
+          heading_text = substr($0, level + 1)
+          # Strip leading spaces
+          gsub(/^[[:space:]]+/, "", heading_text)
+          if (heading_text ~ ("^(§[[:space:]]*)?" section "([[:space:]]|$)") || \
+              heading_text ~ ("§[[:space:]]*" section "([[:space:]]|$)")) {
+            in_section = 1
+            heading_level = level
+            next
+          }
+        } else {
+          # We are in the section — stop at equal or higher level heading
+          if (level <= heading_level) {
+            exit
+          }
+        }
+      }
+      if (in_section) {
+        print $0
+      }
+    }
+  ' "$spec_file")
+
+  if [ -z "$subsection_body" ]; then
+    # Section not found in spec — treat as missing
+    return 1
+  fi
+
+  # Normalize the subsection body
+  local normalized_body
+  normalized_body=$(_normalize_text "$subsection_body")
+
+  # Check if normalized literal is a substring of normalized body
+  if printf '%s' "$normalized_body" | grep -qF "$normalized_literal"; then
+    return 0
+  fi
+  return 1
 }
 
 # List task files where all stories have terminal status (completed or skipped)

--- a/plugins/aimi-engineering/scripts/aimi-cli.sh
+++ b/plugins/aimi-engineering/scripts/aimi-cli.sh
@@ -2294,6 +2294,27 @@ cmd_validate_waves() {
   ' "$tasks_file"
 }
 
+# Validate tasks file citation fields (skeleton: schemaVersion guard only)
+# For schemaVersion >= 3.3: emits {valid: true, errors: []} — no checks yet
+# For schemaVersion < 3.3: emits skip-info to stderr and exits 0
+cmd_validate_tasks() {
+  local tasks_file
+  tasks_file=$(get_tasks_file)
+
+  local schema_version
+  schema_version=$(jq -r '.metadata.schemaVersion // .schemaVersion // "0"' "$tasks_file" 2>/dev/null)
+
+  # Compare versions: below 3.3 → skip with info message
+  # Use sort -V to determine version ordering
+  if [ "$(printf '%s\n' "$schema_version" "3.3" | sort -V | head -n1)" != "3.3" ]; then
+    echo "skipping citation validation (schemaVersion ${schema_version} pre-dates citation enforcement)" >&2
+    return 0
+  fi
+
+  echo '{"valid": true, "errors": []}'
+  return 0
+}
+
 # List task files where all stories have terminal status (completed or skipped)
 # Returns a JSON array of file paths
 cmd_list_archivable() {
@@ -2503,6 +2524,7 @@ COMMANDS:
     update-field <id> <field.path> <value>
                               Update a nested field on a story (e.g., verification.status passed)
     validate-waves            Compute waves from dependsOn, compare to stored wave, report mismatches
+    validate-tasks            Validate tasks file citation fields (schemaVersion guard, no checks yet)
     cascade-skip <id>         Skip all stories depending on failed story
     reset-orphaned            Reset all in_progress stories to failed
     get-branch                Get branchName from metadata
@@ -2655,6 +2677,7 @@ main() {
     gate-fail)         cmd_gate_fail "${2:-}" ;;
     update-field)      cmd_update_field "${2:-}" "${3:-}" "${4:-}" ;;
     validate-waves)    cmd_validate_waves ;;
+    validate-tasks)    cmd_validate_tasks ;;
     cascade-skip)      cmd_cascade_skip "${2:-}" ;;
     reset-orphaned)    cmd_reset_orphaned ;;
     get-branch)        cmd_get_branch ;;

--- a/plugins/aimi-engineering/scripts/test-aimi-cli.sh
+++ b/plugins/aimi-engineering/scripts/test-aimi-cli.sh
@@ -1628,6 +1628,7 @@ source_cache_functions() {
   eval "$(sed -n '/^write_global_worktree_cache()/,/^}/p' "$CLI")"
   eval "$(sed -n '/^read_global_worktree_cache()/,/^}/p' "$CLI")"
   eval "$(sed -n '/^cmd_prime_cache()/,/^}/p' "$CLI")"
+  eval "$(sed -n '/^cmd_validate_tasks()/,/^}/p' "$CLI")"
 }
 
 test_write_global_cli_cache() {
@@ -3282,6 +3283,102 @@ WAVEOF
   assert_contains "US-002" "$output" "validate-waves: identifies US-002 as mismatched"
 
   rm -f "$wave_fixture"
+  echo "$TASKS_FILE" > "$AIMI_DIR/current-tasks"
+}
+
+test_validate_tasks_skeleton_exits_zero() {
+  echo ""
+  echo "=== Testing validate-tasks skeleton: v3.3 tasks.json exits 0 with valid=true ==="
+
+  local tasks_fixture="$TASKS_DIR/9999-99-95-validate-tasks-v33.json"
+  cat > "$tasks_fixture" << 'VALIDATETASKSEOF'
+{
+  "schemaVersion": "3.3",
+  "metadata": {
+    "title": "feat: Citation test",
+    "type": "feat",
+    "branchName": "feat/citation-test",
+    "createdAt": "2026-05-11",
+    "planPath": null,
+    "maxConcurrency": 2
+  },
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "A simple story",
+      "description": "No citations yet",
+      "acceptanceCriteria": ["Passes"],
+      "priority": 1,
+      "status": "pending",
+      "dependsOn": [],
+      "notes": "",
+      "wave": 0
+    }
+  ]
+}
+VALIDATETASKSEOF
+
+  "$CLI" clear-state > /dev/null 2>&1 || true
+  echo "$tasks_fixture" > "$AIMI_DIR/current-tasks"
+  "$CLI" init-session > /dev/null 2>&1 || true
+  echo "$tasks_fixture" > "$AIMI_DIR/current-tasks"
+
+  local output exit_code
+  output=$("$CLI" validate-tasks) && exit_code=0 || exit_code=$?
+
+  assert_contains '"valid": true' "$output" "validate-tasks: v3.3 returns valid=true"
+  assert_contains '"errors": []' "$output" "validate-tasks: v3.3 returns empty errors array"
+  assert_exit_code "0" "$exit_code" "validate-tasks: v3.3 exits 0"
+
+  rm -f "$tasks_fixture"
+  echo "$TASKS_FILE" > "$AIMI_DIR/current-tasks"
+}
+
+test_validate_tasks_skips_pre_v33() {
+  echo ""
+  echo "=== Testing validate-tasks skeleton: v3.2 tasks.json emits skip-info and exits 0 ==="
+
+  local tasks_fixture="$TASKS_DIR/9999-99-94-validate-tasks-v32.json"
+  cat > "$tasks_fixture" << 'VALIDATETASKSV32EOF'
+{
+  "schemaVersion": "3.2",
+  "metadata": {
+    "title": "feat: Pre-citation test",
+    "type": "feat",
+    "branchName": "feat/pre-citation-test",
+    "createdAt": "2026-05-11",
+    "planPath": null,
+    "maxConcurrency": 2
+  },
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "A legacy story",
+      "description": "Pre-citation schema",
+      "acceptanceCriteria": ["Passes"],
+      "priority": 1,
+      "status": "pending",
+      "dependsOn": [],
+      "notes": "",
+      "wave": 0
+    }
+  ]
+}
+VALIDATETASKSV32EOF
+
+  "$CLI" clear-state > /dev/null 2>&1 || true
+  echo "$tasks_fixture" > "$AIMI_DIR/current-tasks"
+  "$CLI" init-session > /dev/null 2>&1 || true
+  echo "$tasks_fixture" > "$AIMI_DIR/current-tasks"
+
+  local stderr_output exit_code
+  stderr_output=$("$CLI" validate-tasks 2>&1 >/dev/null) && exit_code=0 || exit_code=$?
+
+  assert_contains "skipping citation validation (schemaVersion 3.2 pre-dates citation enforcement)" "$stderr_output" \
+    "validate-tasks: v3.2 emits skip-info to stderr"
+  assert_exit_code "0" "$exit_code" "validate-tasks: v3.2 exits 0"
+
+  rm -f "$tasks_fixture"
   echo "$TASKS_FILE" > "$AIMI_DIR/current-tasks"
 }
 
@@ -4955,6 +5052,8 @@ main() {
   test_list_ready_verify_gate_non_blocking
   test_validate_waves_correct
   test_validate_waves_mismatch
+  test_validate_tasks_skeleton_exits_zero
+  test_validate_tasks_skips_pre_v33
   test_mark_complete_preserves_new_fields
 
   # CLI output optimization tests — run with fresh fixture each time

--- a/plugins/aimi-engineering/scripts/test-aimi-cli.sh
+++ b/plugins/aimi-engineering/scripts/test-aimi-cli.sh
@@ -1629,6 +1629,7 @@ source_cache_functions() {
   eval "$(sed -n '/^read_global_worktree_cache()/,/^}/p' "$CLI")"
   eval "$(sed -n '/^cmd_prime_cache()/,/^}/p' "$CLI")"
   eval "$(sed -n '/^cmd_validate_tasks()/,/^}/p' "$CLI")"
+  eval "$(sed -n '/^_validate_designspec_citation()/,/^}/p' "$CLI")"
 }
 
 test_write_global_cli_cache() {
@@ -3382,6 +3383,313 @@ VALIDATETASKSV32EOF
   echo "$TASKS_FILE" > "$AIMI_DIR/current-tasks"
 }
 
+test_validate_tasks_designspec_passing_case() {
+  echo ""
+  echo "=== Testing validate-tasks: DesignSpec passing case (literal found in cited subsection) ==="
+
+  local tasks_fixture="$TASKS_DIR/9999-99-93-validate-tasks-ds-pass.json"
+  local spec_file="$TASKS_DIR/DesignSpec-pass.md"
+
+  # Write a minimal DesignSpec with section 3.1
+  cat > "$spec_file" << 'SPECEOF'
+# DesignSpec
+
+## 3.1 Portfolio Overview
+
+The page title is Benchmark do portfolio and shows KPI cards.
+
+### Details
+
+Some extra content here.
+SPECEOF
+
+  cat > "$tasks_fixture" << 'TASKEOF'
+{
+  "schemaVersion": "3.3",
+  "metadata": {
+    "title": "feat: DesignSpec passing",
+    "type": "feat",
+    "branchName": "feat/ds-pass",
+    "createdAt": "2026-05-11",
+    "planPath": null,
+    "maxConcurrency": 2,
+    "prototypePaths": ["proto/index.html"],
+    "designBundle": {
+      "root": "bundles/ds-pass",
+      "readme": null,
+      "chats": [],
+      "businessSpec": null,
+      "designSpec": "TASKS_DIR_PLACEHOLDER/DesignSpec-pass.md"
+    }
+  },
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Portfolio overview screen",
+      "description": "Visual story with spec citation",
+      "acceptanceCriteria": [
+        "\"Benchmark do portfolio\" (DesignSpec § 3.1 L6) MUST appear as the page H1."
+      ],
+      "priority": 1,
+      "status": "pending",
+      "dependsOn": [],
+      "notes": "",
+      "wave": 1,
+      "verification": {
+        "strategy": "visual",
+        "status": "pending"
+      }
+    }
+  ]
+}
+TASKEOF
+
+  # Patch the placeholder with the actual tasks_dir path
+  sed -i "s|TASKS_DIR_PLACEHOLDER|${TASKS_DIR}|g" "$tasks_fixture"
+
+  "$CLI" clear-state > /dev/null 2>&1 || true
+  echo "$tasks_fixture" > "$AIMI_DIR/current-tasks"
+  "$CLI" init-session > /dev/null 2>&1 || true
+  echo "$tasks_fixture" > "$AIMI_DIR/current-tasks"
+
+  local output exit_code
+  output=$("$CLI" validate-tasks) && exit_code=0 || exit_code=$?
+
+  assert_contains '"valid": true' "$output" "validate-tasks designspec passing: returns valid=true"
+  assert_contains '"errors": []' "$output" "validate-tasks designspec passing: returns empty errors"
+  assert_exit_code "0" "$exit_code" "validate-tasks designspec passing: exits 0"
+
+  rm -f "$tasks_fixture" "$spec_file"
+  echo "$TASKS_FILE" > "$AIMI_DIR/current-tasks"
+}
+
+test_validate_tasks_designspec_paraphrase_fails() {
+  echo ""
+  echo "=== Testing validate-tasks: DesignSpec paraphrase fails (literal not in subsection) ==="
+
+  local tasks_fixture="$TASKS_DIR/9999-99-92-validate-tasks-ds-fail.json"
+  local spec_file="$TASKS_DIR/DesignSpec-fail.md"
+
+  # Write a minimal DesignSpec with section 3.1 that does NOT contain the paraphrased text
+  cat > "$spec_file" << 'SPECEOF'
+# DesignSpec
+
+## 3.1 Portfolio Overview
+
+The page title is Benchmark do portfolio and shows KPI cards.
+SPECEOF
+
+  cat > "$tasks_fixture" << 'TASKEOF'
+{
+  "schemaVersion": "3.3",
+  "metadata": {
+    "title": "feat: DesignSpec paraphrase fails",
+    "type": "feat",
+    "branchName": "feat/ds-fail",
+    "createdAt": "2026-05-11",
+    "planPath": null,
+    "maxConcurrency": 2,
+    "prototypePaths": ["proto/index.html"],
+    "designBundle": {
+      "root": "bundles/ds-fail",
+      "readme": null,
+      "chats": [],
+      "businessSpec": null,
+      "designSpec": "TASKS_DIR_PLACEHOLDER/DesignSpec-fail.md"
+    }
+  },
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Portfolio overview screen",
+      "description": "Visual story with paraphrase (wrong)",
+      "acceptanceCriteria": [
+        "\"Portfolio benchmark overview\" (DesignSpec § 3.1 L5) MUST appear as the page H1."
+      ],
+      "priority": 1,
+      "status": "pending",
+      "dependsOn": [],
+      "notes": "",
+      "wave": 1,
+      "verification": {
+        "strategy": "visual",
+        "status": "pending"
+      }
+    }
+  ]
+}
+TASKEOF
+
+  sed -i "s|TASKS_DIR_PLACEHOLDER|${TASKS_DIR}|g" "$tasks_fixture"
+
+  "$CLI" clear-state > /dev/null 2>&1 || true
+  echo "$tasks_fixture" > "$AIMI_DIR/current-tasks"
+  "$CLI" init-session > /dev/null 2>&1 || true
+  echo "$tasks_fixture" > "$AIMI_DIR/current-tasks"
+
+  local output exit_code
+  output=$("$CLI" validate-tasks) && exit_code=0 || exit_code=$?
+
+  assert_contains '"valid": false' "$output" "validate-tasks designspec paraphrase: returns valid=false"
+  assert_contains 'missing DesignSpec citation' "$output" "validate-tasks designspec paraphrase: emits diagnostic"
+  assert_contains 'Portfolio benchmark overview' "$output" "validate-tasks designspec paraphrase: names the missing literal"
+  assert_exit_code "1" "$exit_code" "validate-tasks designspec paraphrase: exits 1"
+
+  rm -f "$tasks_fixture" "$spec_file"
+  echo "$TASKS_FILE" > "$AIMI_DIR/current-tasks"
+}
+
+test_validate_tasks_designspec_unicode_normalize() {
+  echo ""
+  echo "=== Testing validate-tasks: DesignSpec unicode normalization (curly quotes and em-dash) ==="
+
+  local tasks_fixture="$TASKS_DIR/9999-99-91-validate-tasks-ds-unicode.json"
+  local spec_file="$TASKS_DIR/DesignSpec-unicode.md"
+
+  # Spec uses curly quotes and em-dash; AC uses straight quotes and hyphen
+  # After normalization both sides should match
+  printf '# DesignSpec\n\n## 2.1 Metrics\n\n' > "$spec_file"
+  # Write a line with curly double quotes and an em-dash using printf with octal/hex escapes
+  # UTF-8: left double quotation mark = E2 80 9C, right = E2 80 9D, em-dash = E2 80 94
+  printf 'The label \xe2\x80\x9cNet Return\xe2\x80\x9d shows portfolio\xe2\x80\x94performance metrics.\n' >> "$spec_file"
+
+  cat > "$tasks_fixture" << 'TASKEOF'
+{
+  "schemaVersion": "3.3",
+  "metadata": {
+    "title": "feat: DesignSpec unicode normalize",
+    "type": "feat",
+    "branchName": "feat/ds-unicode",
+    "createdAt": "2026-05-11",
+    "planPath": null,
+    "maxConcurrency": 2,
+    "prototypePaths": ["proto/index.html"],
+    "designBundle": {
+      "root": "bundles/ds-unicode",
+      "readme": null,
+      "chats": [],
+      "businessSpec": null,
+      "designSpec": "TASKS_DIR_PLACEHOLDER/DesignSpec-unicode.md"
+    }
+  },
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Metrics card",
+      "description": "Visual story with unicode-normalized citation",
+      "acceptanceCriteria": [
+        "\"Net Return\" (DesignSpec § 2.1 L5) label MUST be visible."
+      ],
+      "priority": 1,
+      "status": "pending",
+      "dependsOn": [],
+      "notes": "",
+      "wave": 1,
+      "verification": {
+        "strategy": "visual",
+        "status": "pending"
+      }
+    }
+  ]
+}
+TASKEOF
+
+  sed -i "s|TASKS_DIR_PLACEHOLDER|${TASKS_DIR}|g" "$tasks_fixture"
+
+  "$CLI" clear-state > /dev/null 2>&1 || true
+  echo "$tasks_fixture" > "$AIMI_DIR/current-tasks"
+  "$CLI" init-session > /dev/null 2>&1 || true
+  echo "$tasks_fixture" > "$AIMI_DIR/current-tasks"
+
+  local output exit_code
+  output=$("$CLI" validate-tasks) && exit_code=0 || exit_code=$?
+
+  assert_contains '"valid": true' "$output" "validate-tasks unicode normalize: curly-quote spec matches straight-quote AC"
+  assert_exit_code "0" "$exit_code" "validate-tasks unicode normalize: exits 0"
+
+  rm -f "$tasks_fixture" "$spec_file"
+  echo "$TASKS_FILE" > "$AIMI_DIR/current-tasks"
+}
+
+test_validate_tasks_designspec_subsection_boundary() {
+  echo ""
+  echo "=== Testing validate-tasks: DesignSpec subsection boundary (literal in wrong subsection fails) ==="
+
+  local tasks_fixture="$TASKS_DIR/9999-99-90-validate-tasks-ds-boundary.json"
+  local spec_file="$TASKS_DIR/DesignSpec-boundary.md"
+
+  # Spec has sections 3.1 and 3.2; the literal is ONLY in 3.2, AC cites 3.1
+  cat > "$spec_file" << 'SPECEOF'
+# DesignSpec
+
+## 3.1 Overview
+
+This section contains general overview content only.
+
+## 3.2 Metrics
+
+The KPI label is Total AUM shown on the dashboard.
+SPECEOF
+
+  cat > "$tasks_fixture" << 'TASKEOF'
+{
+  "schemaVersion": "3.3",
+  "metadata": {
+    "title": "feat: DesignSpec subsection boundary",
+    "type": "feat",
+    "branchName": "feat/ds-boundary",
+    "createdAt": "2026-05-11",
+    "planPath": null,
+    "maxConcurrency": 2,
+    "prototypePaths": ["proto/index.html"],
+    "designBundle": {
+      "root": "bundles/ds-boundary",
+      "readme": null,
+      "chats": [],
+      "businessSpec": null,
+      "designSpec": "TASKS_DIR_PLACEHOLDER/DesignSpec-boundary.md"
+    }
+  },
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Dashboard metrics",
+      "description": "Visual story with wrong section citation",
+      "acceptanceCriteria": [
+        "\"Total AUM\" (DesignSpec § 3.1 L5) KPI label MUST be visible."
+      ],
+      "priority": 1,
+      "status": "pending",
+      "dependsOn": [],
+      "notes": "",
+      "wave": 1,
+      "verification": {
+        "strategy": "visual",
+        "status": "pending"
+      }
+    }
+  ]
+}
+TASKEOF
+
+  sed -i "s|TASKS_DIR_PLACEHOLDER|${TASKS_DIR}|g" "$tasks_fixture"
+
+  "$CLI" clear-state > /dev/null 2>&1 || true
+  echo "$tasks_fixture" > "$AIMI_DIR/current-tasks"
+  "$CLI" init-session > /dev/null 2>&1 || true
+  echo "$tasks_fixture" > "$AIMI_DIR/current-tasks"
+
+  local output exit_code
+  output=$("$CLI" validate-tasks) && exit_code=0 || exit_code=$?
+
+  assert_contains '"valid": false' "$output" "validate-tasks subsection boundary: literal in 3.2 but cited in 3.1 fails"
+  assert_contains 'missing DesignSpec citation' "$output" "validate-tasks subsection boundary: emits diagnostic"
+  assert_exit_code "1" "$exit_code" "validate-tasks subsection boundary: exits 1"
+
+  rm -f "$tasks_fixture" "$spec_file"
+  echo "$TASKS_FILE" > "$AIMI_DIR/current-tasks"
+}
+
 test_mark_complete_preserves_new_fields() {
   echo ""
   echo "=== Testing mark-complete preserves gate, verification, implementation, and wave fields ==="
@@ -5054,6 +5362,10 @@ main() {
   test_validate_waves_mismatch
   test_validate_tasks_skeleton_exits_zero
   test_validate_tasks_skips_pre_v33
+  test_validate_tasks_designspec_passing_case
+  test_validate_tasks_designspec_paraphrase_fails
+  test_validate_tasks_designspec_unicode_normalize
+  test_validate_tasks_designspec_subsection_boundary
   test_mark_complete_preserves_new_fields
 
   # CLI output optimization tests — run with fresh fixture each time

--- a/plugins/aimi-engineering/scripts/test-aimi-cli.sh
+++ b/plugins/aimi-engineering/scripts/test-aimi-cli.sh
@@ -1630,6 +1630,7 @@ source_cache_functions() {
   eval "$(sed -n '/^cmd_prime_cache()/,/^}/p' "$CLI")"
   eval "$(sed -n '/^cmd_validate_tasks()/,/^}/p' "$CLI")"
   eval "$(sed -n '/^_validate_designspec_citation()/,/^}/p' "$CLI")"
+  eval "$(sed -n '/^_validate_businessspec_field()/,/^}/p' "$CLI")"
 }
 
 test_write_global_cli_cache() {
@@ -3690,6 +3691,331 @@ TASKEOF
   echo "$TASKS_FILE" > "$AIMI_DIR/current-tasks"
 }
 
+test_validate_tasks_backendspec_passing_case() {
+  echo ""
+  echo "=== Testing validate-tasks: backendSpec passing case (sources valid, fields present in BusinessSpec) ==="
+
+  local tasks_fixture="$TASKS_DIR/9999-99-89-validate-tasks-bs-pass.json"
+  local spec_file="$TASKS_DIR/BusinessSpec-pass.md"
+
+  cat > "$spec_file" << 'SPECEOF'
+# BusinessSpec
+
+## 5 API Endpoints
+
+### 5.1 Benchmark Summary
+
+GET /benchmark-summary returns benchmark data.
+
+Fields: totalUsinas, receitaMediaPortfolio, benchmarkDate
+SPECEOF
+
+  cat > "$tasks_fixture" << 'TASKEOF'
+{
+  "schemaVersion": "3.3",
+  "metadata": {
+    "title": "feat: backendSpec passing",
+    "type": "feat",
+    "branchName": "feat/bs-pass",
+    "createdAt": "2026-05-11",
+    "planPath": null,
+    "maxConcurrency": 2,
+    "frontendOnly": true,
+    "designBundle": {
+      "root": "bundles/bs-pass",
+      "readme": null,
+      "chats": [],
+      "businessSpec": "TASKS_DIR_PLACEHOLDER/BusinessSpec-pass.md",
+      "designSpec": null
+    },
+    "backendSpec": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/benchmark-summary",
+          "description": "Returns benchmark summary data",
+          "source": "BusinessSpec § 5.1 L8",
+          "responseShape": {
+            "totalUsinas": { "type": "number", "source": "BusinessSpec § 5.1 L10" },
+            "receitaMediaPortfolio": { "type": "number", "source": "BusinessSpec § 5.1 L10" }
+          }
+        }
+      ],
+      "dataModels": [],
+      "businessRules": [],
+      "businessContext": {
+        "summary": "Benchmark dashboard",
+        "userRoles": [],
+        "constraints": [],
+        "assumptions": [],
+        "successCriteria": []
+      }
+    }
+  },
+  "userStories": []
+}
+TASKEOF
+
+  sed -i "s|TASKS_DIR_PLACEHOLDER|${TASKS_DIR}|g" "$tasks_fixture"
+
+  "$CLI" clear-state > /dev/null 2>&1 || true
+  echo "$tasks_fixture" > "$AIMI_DIR/current-tasks"
+  "$CLI" init-session > /dev/null 2>&1 || true
+  echo "$tasks_fixture" > "$AIMI_DIR/current-tasks"
+
+  local output exit_code
+  output=$("$CLI" validate-tasks) && exit_code=0 || exit_code=$?
+
+  assert_contains '"valid": true' "$output" "validate-tasks backendspec passing: returns valid=true"
+  assert_contains '"errors": []' "$output" "validate-tasks backendspec passing: returns empty errors"
+  assert_exit_code "0" "$exit_code" "validate-tasks backendspec passing: exits 0"
+
+  rm -f "$tasks_fixture" "$spec_file"
+  echo "$TASKS_FILE" > "$AIMI_DIR/current-tasks"
+}
+
+test_validate_tasks_backendspec_missing_source() {
+  echo ""
+  echo "=== Testing validate-tasks: backendSpec missing source field → valid:false ==="
+
+  local tasks_fixture="$TASKS_DIR/9999-99-88-validate-tasks-bs-missing-src.json"
+  local spec_file="$TASKS_DIR/BusinessSpec-missing-src.md"
+
+  cat > "$spec_file" << 'SPECEOF'
+# BusinessSpec
+
+## 5 API Endpoints
+
+GET /benchmark-summary returns totalUsinas and receitaMediaPortfolio.
+SPECEOF
+
+  cat > "$tasks_fixture" << 'TASKEOF'
+{
+  "schemaVersion": "3.3",
+  "metadata": {
+    "title": "feat: backendSpec missing source",
+    "type": "feat",
+    "branchName": "feat/bs-missing-src",
+    "createdAt": "2026-05-11",
+    "planPath": null,
+    "maxConcurrency": 2,
+    "frontendOnly": true,
+    "designBundle": {
+      "root": "bundles/bs-missing-src",
+      "readme": null,
+      "chats": [],
+      "businessSpec": "TASKS_DIR_PLACEHOLDER/BusinessSpec-missing-src.md",
+      "designSpec": null
+    },
+    "backendSpec": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/benchmark-summary",
+          "description": "Returns benchmark summary data",
+          "responseShape": {
+            "totalUsinas": { "type": "number" }
+          }
+        }
+      ],
+      "dataModels": [],
+      "businessRules": [],
+      "businessContext": {
+        "summary": "Benchmark dashboard",
+        "userRoles": [],
+        "constraints": [],
+        "assumptions": [],
+        "successCriteria": []
+      }
+    }
+  },
+  "userStories": []
+}
+TASKEOF
+
+  sed -i "s|TASKS_DIR_PLACEHOLDER|${TASKS_DIR}|g" "$tasks_fixture"
+
+  "$CLI" clear-state > /dev/null 2>&1 || true
+  echo "$tasks_fixture" > "$AIMI_DIR/current-tasks"
+  "$CLI" init-session > /dev/null 2>&1 || true
+  echo "$tasks_fixture" > "$AIMI_DIR/current-tasks"
+
+  local output exit_code
+  output=$("$CLI" validate-tasks) && exit_code=0 || exit_code=$?
+
+  assert_contains '"valid": false' "$output" "validate-tasks backendspec missing source: returns valid=false"
+  assert_contains 'missing source field' "$output" "validate-tasks backendspec missing source: emits diagnostic"
+  assert_exit_code "1" "$exit_code" "validate-tasks backendspec missing source: exits 1"
+
+  rm -f "$tasks_fixture" "$spec_file"
+  echo "$TASKS_FILE" > "$AIMI_DIR/current-tasks"
+}
+
+test_validate_tasks_backendspec_invented_field() {
+  echo ""
+  echo "=== Testing validate-tasks: backendSpec invented field (not in cited subsection) → valid:false ==="
+
+  local tasks_fixture="$TASKS_DIR/9999-99-87-validate-tasks-bs-invented.json"
+  local spec_file="$TASKS_DIR/BusinessSpec-invented.md"
+
+  cat > "$spec_file" << 'SPECEOF'
+# BusinessSpec
+
+## 5 API Endpoints
+
+### 5.1 Benchmark Summary
+
+GET /benchmark-summary returns benchmark data.
+
+Fields: totalUsinas, receitaMediaPortfolio
+SPECEOF
+
+  cat > "$tasks_fixture" << 'TASKEOF'
+{
+  "schemaVersion": "3.3",
+  "metadata": {
+    "title": "feat: backendSpec invented field",
+    "type": "feat",
+    "branchName": "feat/bs-invented",
+    "createdAt": "2026-05-11",
+    "planPath": null,
+    "maxConcurrency": 2,
+    "frontendOnly": true,
+    "designBundle": {
+      "root": "bundles/bs-invented",
+      "readme": null,
+      "chats": [],
+      "businessSpec": "TASKS_DIR_PLACEHOLDER/BusinessSpec-invented.md",
+      "designSpec": null
+    },
+    "backendSpec": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/benchmark-summary",
+          "description": "Returns benchmark summary data",
+          "source": "BusinessSpec § 5.1 L8",
+          "responseShape": {
+            "totalUsinas": { "type": "number", "source": "BusinessSpec § 5.1 L10" },
+            "inventedField": { "type": "string", "source": "BusinessSpec § 5.1 L10" }
+          }
+        }
+      ],
+      "dataModels": [],
+      "businessRules": [],
+      "businessContext": {
+        "summary": "Benchmark dashboard",
+        "userRoles": [],
+        "constraints": [],
+        "assumptions": [],
+        "successCriteria": []
+      }
+    }
+  },
+  "userStories": []
+}
+TASKEOF
+
+  sed -i "s|TASKS_DIR_PLACEHOLDER|${TASKS_DIR}|g" "$tasks_fixture"
+
+  "$CLI" clear-state > /dev/null 2>&1 || true
+  echo "$tasks_fixture" > "$AIMI_DIR/current-tasks"
+  "$CLI" init-session > /dev/null 2>&1 || true
+  echo "$tasks_fixture" > "$AIMI_DIR/current-tasks"
+
+  local output exit_code
+  output=$("$CLI" validate-tasks) && exit_code=0 || exit_code=$?
+
+  assert_contains '"valid": false' "$output" "validate-tasks backendspec invented field: returns valid=false"
+  assert_contains 'inventedField' "$output" "validate-tasks backendspec invented field: names the missing field"
+  assert_exit_code "1" "$exit_code" "validate-tasks backendspec invented field: exits 1"
+
+  rm -f "$tasks_fixture" "$spec_file"
+  echo "$TASKS_FILE" > "$AIMI_DIR/current-tasks"
+}
+
+test_validate_tasks_backendspec_derived_escape_hatch() {
+  echo ""
+  echo "=== Testing validate-tasks: backendSpec derived: source → WARN on stderr, valid:true, exit 0 ==="
+
+  local tasks_fixture="$TASKS_DIR/9999-99-86-validate-tasks-bs-derived.json"
+  local spec_file="$TASKS_DIR/BusinessSpec-derived.md"
+
+  cat > "$spec_file" << 'SPECEOF'
+# BusinessSpec
+
+## 5 API Endpoints
+
+GET /benchmark-summary returns totalUsinas and portfolioCount.
+SPECEOF
+
+  cat > "$tasks_fixture" << 'TASKEOF'
+{
+  "schemaVersion": "3.3",
+  "metadata": {
+    "title": "feat: backendSpec derived escape hatch",
+    "type": "feat",
+    "branchName": "feat/bs-derived",
+    "createdAt": "2026-05-11",
+    "planPath": null,
+    "maxConcurrency": 2,
+    "frontendOnly": true,
+    "designBundle": {
+      "root": "bundles/bs-derived",
+      "readme": null,
+      "chats": [],
+      "businessSpec": "TASKS_DIR_PLACEHOLDER/BusinessSpec-derived.md",
+      "designSpec": null
+    },
+    "backendSpec": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/benchmark-summary",
+          "description": "Returns computed benchmark summary",
+          "source": "derived: aggregated from § 5 totalUsinas + § 5 portfolioCount",
+          "responseShape": {
+            "totalUsinas": { "type": "number" }
+          }
+        }
+      ],
+      "dataModels": [],
+      "businessRules": [],
+      "businessContext": {
+        "summary": "Benchmark dashboard",
+        "userRoles": [],
+        "constraints": [],
+        "assumptions": [],
+        "successCriteria": []
+      }
+    }
+  },
+  "userStories": []
+}
+TASKEOF
+
+  sed -i "s|TASKS_DIR_PLACEHOLDER|${TASKS_DIR}|g" "$tasks_fixture"
+
+  "$CLI" clear-state > /dev/null 2>&1 || true
+  echo "$tasks_fixture" > "$AIMI_DIR/current-tasks"
+  "$CLI" init-session > /dev/null 2>&1 || true
+  echo "$tasks_fixture" > "$AIMI_DIR/current-tasks"
+
+  local stdout_output stderr_output exit_code
+  stdout_output=$("$CLI" validate-tasks 2>/tmp/bs-derived-stderr-$$.txt) && exit_code=0 || exit_code=$?
+  stderr_output=$(cat /tmp/bs-derived-stderr-$$.txt 2>/dev/null || true)
+  rm -f /tmp/bs-derived-stderr-$$.txt
+
+  assert_contains '"valid": true' "$stdout_output" "validate-tasks backendspec derived: stdout returns valid=true"
+  assert_contains '"errors": []' "$stdout_output" "validate-tasks backendspec derived: stdout returns empty errors"
+  assert_contains 'derived source' "$stderr_output" "validate-tasks backendspec derived: stderr emits WARN"
+  assert_contains 'manual review required' "$stderr_output" "validate-tasks backendspec derived: stderr WARN mentions manual review"
+  assert_exit_code "0" "$exit_code" "validate-tasks backendspec derived: exits 0"
+
+  rm -f "$tasks_fixture" "$spec_file"
+  echo "$TASKS_FILE" > "$AIMI_DIR/current-tasks"
+}
+
 test_mark_complete_preserves_new_fields() {
   echo ""
   echo "=== Testing mark-complete preserves gate, verification, implementation, and wave fields ==="
@@ -5366,6 +5692,10 @@ main() {
   test_validate_tasks_designspec_paraphrase_fails
   test_validate_tasks_designspec_unicode_normalize
   test_validate_tasks_designspec_subsection_boundary
+  test_validate_tasks_backendspec_passing_case
+  test_validate_tasks_backendspec_missing_source
+  test_validate_tasks_backendspec_invented_field
+  test_validate_tasks_backendspec_derived_escape_hatch
   test_mark_complete_preserves_new_fields
 
   # CLI output optimization tests — run with fresh fixture each time

--- a/plugins/aimi-engineering/scripts/test-aimi-cli.sh
+++ b/plugins/aimi-engineering/scripts/test-aimi-cli.sh
@@ -2561,6 +2561,110 @@ test_validate_stories_tasks_field() {
   _teardown_project_fixture
 }
 
+test_validate_stories_gate_field() {
+  echo ""
+  echo "=== Testing validate-stories gate field validation ==="
+
+  # (a) plural 'gates' key is rejected
+  "$CLI" clear-state > /dev/null
+  "$CLI" init-session > /dev/null
+  _setup_project_fixture '{
+  "schemaVersion": "3.3",
+  "metadata": {
+    "title": "feat: Gate test",
+    "type": "feat",
+    "branchName": "feat/gate-test",
+    "createdAt": "2026-05-11",
+    "planPath": null,
+    "maxConcurrency": 2
+  },
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Story with plural gates",
+      "description": "Uses wrong plural gates field",
+      "acceptanceCriteria": ["Rejects plural gates"],
+      "priority": 1,
+      "status": "pending",
+      "dependsOn": [],
+      "notes": "",
+      "gates": [{"type": "decision", "status": "pending", "prompt": "Approve?"}]
+    }
+  ]
+}'
+  local output exit_code
+  output=$("$CLI" validate-stories) && exit_code=0 || exit_code=$?
+  assert_contains '"valid": false' "$output" "validate-stories gate: plural 'gates' field fails validation"
+  assert_contains "gates field is invalid" "$output" "validate-stories gate: error mentions invalid gates field"
+  assert_exit_code "1" "$exit_code" "validate-stories gate: exits 1 for plural gates"
+  _teardown_project_fixture
+
+  # (b) singular gate missing required field 'type'
+  "$CLI" clear-state > /dev/null
+  "$CLI" init-session > /dev/null
+  _setup_project_fixture '{
+  "schemaVersion": "3.3",
+  "metadata": {
+    "title": "feat: Gate test",
+    "type": "feat",
+    "branchName": "feat/gate-test",
+    "createdAt": "2026-05-11",
+    "planPath": null,
+    "maxConcurrency": 2
+  },
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Story with gate missing type",
+      "description": "Gate object is missing the type field",
+      "acceptanceCriteria": ["Rejects missing type"],
+      "priority": 1,
+      "status": "pending",
+      "dependsOn": [],
+      "notes": "",
+      "gate": {"status": "pending", "prompt": "Approve?"}
+    }
+  ]
+}'
+  output=$("$CLI" validate-stories) && exit_code=0 || exit_code=$?
+  assert_contains '"valid": false' "$output" "validate-stories gate: gate missing type fails validation"
+  assert_contains "missing required field type" "$output" "validate-stories gate: error mentions missing type field"
+  assert_exit_code "1" "$exit_code" "validate-stories gate: exits 1 for gate missing type"
+  _teardown_project_fixture
+
+  # (c) well-formed gate passes validation
+  "$CLI" clear-state > /dev/null
+  "$CLI" init-session > /dev/null
+  _setup_project_fixture '{
+  "schemaVersion": "3.3",
+  "metadata": {
+    "title": "feat: Gate test",
+    "type": "feat",
+    "branchName": "feat/gate-test",
+    "createdAt": "2026-05-11",
+    "planPath": null,
+    "maxConcurrency": 2
+  },
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Story with valid gate",
+      "description": "Gate object has all required fields",
+      "acceptanceCriteria": ["Passes with valid gate"],
+      "priority": 1,
+      "status": "pending",
+      "dependsOn": [],
+      "notes": "",
+      "gate": {"type": "decision", "status": "pending", "prompt": "Approve release?"}
+    }
+  ]
+}'
+  output=$("$CLI" validate-stories) && exit_code=0 || exit_code=$?
+  assert_contains '"valid": true' "$output" "validate-stories gate: well-formed gate passes validation"
+  assert_exit_code "0" "$exit_code" "validate-stories gate: exits 0 for well-formed gate"
+  _teardown_project_fixture
+}
+
 test_list_ready_brief_includes_project() {
   echo ""
   echo "=== Testing list-ready --brief includes project in output ==="
@@ -5673,6 +5777,7 @@ main() {
   test_validate_stories_with_absolute_project
   test_validate_stories_skills_field
   test_validate_stories_tasks_field
+  test_validate_stories_gate_field
   test_list_ready_brief_includes_project
 
   # V3.2 schema tests — gates, waves & field preservation


### PR DESCRIPTION
## Summary

Adds `cmd_validate_tasks` that mirrors `cmd_validate_stories`' jq-accumulator shape. Skeleton stage emits `{valid:true, errors:[]}` for v3.3 `tasks.json` and skips silently (with stderr info) for older schemas. Wired into `plan.md` Phase 4.5 alongside `validate-stories`.

Adds Rule 19a to `/aimi:plan` Phase 3 requiring literal spec strings (H1, subtitle, KPI labels, column headers, button labels, footer, badges) to appear verbatim in visual ACs, anchored as `"<literal>" (DesignSpec § N.N L<line>)`. Extends `cmd_validate_tasks` with a DesignSpec scan that locates the cited subsection by heading boundary, normalizes Unicode and HTML entities on both sides, and emits per-AC diagnostics when a literal is missing from its cited section. Tightens Rule 19's no-double-deriving clause to scope to spatial layout; literal string content is always governed by Rule 19a.

Adds source-field requirement to `/aimi:plan` Phase 4 frontend-only `backendSpec` generation. Every `endpoints[]` entry and `responseShape` field must cite `"BusinessSpec § N.N L<line>"` or use the explicit `"derived:"` prefix for legitimately computed shapes. Extends `cmd_validate_tasks` with a BusinessSpec scan that regex-checks source format, accepts `derived:` as a stderr WARN, and verifies each `responseShape` field name appears in the cited subsection. Adds gate-on-missing-field instruction to the planner: when an AC needs a field absent from BusinessSpec, emit a decision gate rather than inventing the field.

Bumps `plugin.json` and `marketplace.json` to 1.79.0 and adds CHANGELOG entry describing `validate-tasks` subcommand, Rule 19a (verbatim DesignSpec citations), and `backendSpec` source-field requirement. Addresses gap-analysis cases 1, 2, 3, 6, 7. Cases 4, 5, 8 deferred to v1.80.

Bumps `plugin.json` and `marketplace.json` to 1.80.0; prepends `CHANGELOG.md` `[1.80.0]` entry summarising US-001 (brainstorm Pre-Save Blocking Gate), US-002 (plan Phase 0.5 Open Questions Resolution Gate), and US-003 (`validate-stories` rejects plural gates, validates singular gate shape). Extends the `plan.md` Phase 4.5 validator note to document the new gate-schema enforcement alongside the existing `skills[]` enforcement.

## Changes

- US-001: add validate-tasks subcommand skeleton with schemaVersion guard
- US-002: enforce verbatim DesignSpec citations in visual ACs
- US-003: require backendSpec source-field traceability to BusinessSpec
- US-004: release v1.79.0 with verbatim citation enforcement
- US-001: add Pre-Save Blocking Gate for Open Questions in brainstorm.md
- US-002: insert Phase 0.5 Open Questions Resolution Gate before Phase 1
- US-003: validate-stories rejects plural gates and validates gate object shape
- US-004: release v1.80.0 with OQ gate (brainstorm + plan) and gate-schema validator

## Files Changed

```
 .claude-plugin/marketplace.json                    |   2 +-
 CHANGELOG.md                                       |  21 +
 .../aimi-engineering/.claude-plugin/plugin.json    |   2 +-
 plugins/aimi-engineering/commands/brainstorm.md    |  16 +-
 plugins/aimi-engineering/commands/plan.md          |  58 +-
 plugins/aimi-engineering/scripts/aimi-cli.sh       | 343 +++++++++
 plugins/aimi-engineering/scripts/test-aimi-cli.sh  | 846 +++++++++++++++++++++
 7 files changed, 1279 insertions(+), 9 deletions(-)
```