### PR TITLE
refactor(cli): relocate global cache to ~/.config/aimi/ with read-both fallback

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and worktree+team orchestration.",
-      "version": "1.86.7",
+      "version": "1.87.0",
       "author": {
         "name": "Aimi — Autonomous Code Companion",
         "url": "https://github.com/aimi-so"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.87.0] - 2026-05-15
+
+### Added
+- XDG-compliant cache location at `~/.config/aimi/cli-path` and `~/.config/aimi/worktree-path` for storing the resolved CLI and worktree paths. The location can be overridden via the new `AIMI_CONFIG_DIR` environment variable (e.g., `AIMI_CONFIG_DIR=/custom/path`), which governs cache file placement only — Layer 2 plugin discovery continues to use `CLAUDE_CONFIG_DIR`.
+- New `_aimi_config_dir()` helper in `aimi-cli.sh` encapsulates the `AIMI_CONFIG_DIR`-or-XDG-default resolution, making all cache read/write call sites consistent.
+- "Per-Call Resolution" section in `commands/references/cli-path-resolution.md` documenting the shell-isolation hazard and the required per-call `cat` re-read pattern with explicit precondition (Step 0 full resolution must have run first to prime the new path).
+
+### Changed
+- `plan.md`, `execute.md`, `brainstorm.md`, `skills/story-executor/SKILL.md`, and `skills/task-planner/SKILL.md` migrated to per-call CLI re-read: each Bash call that needs `$AIMI_CLI` now resolves it inline via `cat ~/.config/aimi/cli-path` rather than relying on a shell variable from a prior call.
+- `auto-approve-cli.sh` hook updated to recognize the new XDG paths (`~/.config/aimi/cli-path`, `~/.config/aimi/worktree-path`) alongside the legacy `~/.claude/aimi-engineering-{cli,worktree}-path` paths, so CLI cache reads and writes do not trigger unexpected permission prompts during the migration window.
+- Hard-coded legacy `~/.claude/aimi-engineering-cli-path` references in `commands/init.md`, `CLAUDE.md`, `install.sh`, and `settings.local.json` updated to reflect the new XDG location.
+
+### Fixed
+- Shell-isolation hazard where `$AIMI_CLI` resolved correctly in one Bash call but expanded to empty in every subsequent call (each Claude Code Bash invocation runs in an isolated subshell), causing silent "command not found: `<subcommand>`" failures throughout plan, execute, and brainstorm workflows.
+
+### Compatibility
+- Legacy `~/.claude/aimi-engineering-cli-path` and `~/.claude/aimi-engineering-worktree-path` files remain supported via a read-both fallback: `aimi-cli.sh` tries the new XDG location first and falls back to the legacy path if the new file is absent. **No user action is required.** The legacy read-both fallback is planned for removal in the next MAJOR version bump.
+
 ## [1.86.7] - 2026-05-13
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ Every plugin change requires synchronized bumps in three files (per `plugins/aim
 `aimi-cli.sh` is the only executable consumed by commands. All commands resolve it through a four-layer strategy documented in `plugins/aimi-engineering/commands/references/cli-path-resolution.md`:
 
 - Layer 0: `$AIMI_PLUGIN_DIR` (skipped inside Claude Code)
-- Layer 1: `~/.claude/aimi-engineering-cli-path` global cache
+- Layer 1: `~/.config/aimi/cli-path` global cache (new XDG path; `$AIMI_CONFIG_DIR/cli-path` when that var is set; legacy `~/.claude/aimi-engineering-cli-path` read as fallback)
 - Layer 2: glob under `~/.claude/plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh`
 - Layer 3: per-project `.aimi/cli-path`
 

--- a/install.sh
+++ b/install.sh
@@ -824,8 +824,10 @@ uninstall_opencode() {
     log "[dry-run] Would remove context7 from $target_dir/opencode.json"
     log "[dry-run] Would remove permissions from $target_dir/opencode.json"
     log "[dry-run] Would remove AIMI_PLUGIN_DIR from shell profiles"
-    local cache_file="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path"
-    [ -f "$cache_file" ] && log "[dry-run] Would remove $cache_file"
+    local new_cache_file="${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path"
+    local legacy_cache_file="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path"
+    [ -f "$new_cache_file" ]    && log "[dry-run] Would remove $new_cache_file"
+    [ -f "$legacy_cache_file" ] && log "[dry-run] Would remove $legacy_cache_file"
     return 0
   fi
 
@@ -935,11 +937,16 @@ with open('$config_file', 'w') as f:
   done
   ok "Removed AIMI_PLUGIN_DIR from shell profiles"
 
-  # Remove global CLI path cache (best-effort)
-  local cache_file="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path"
-  if [ -f "$cache_file" ]; then
-    rm -f "$cache_file"
-    log "Removed CLI path cache $cache_file"
+  # Remove global CLI path cache (best-effort; remove both new XDG and legacy paths)
+  local new_cache_file="${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path"
+  local legacy_cache_file="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path"
+  if [ -f "$new_cache_file" ]; then
+    rm -f "$new_cache_file"
+    log "Removed CLI path cache $new_cache_file"
+  fi
+  if [ -f "$legacy_cache_file" ]; then
+    rm -f "$legacy_cache_file"
+    log "Removed legacy CLI path cache $legacy_cache_file"
   fi
 
   echo

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.86.7",
+  "version": "1.87.0",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi — Autonomous Code Companion"

--- a/plugins/aimi-engineering/commands/brainstorm.md
+++ b/plugins/aimi-engineering/commands/brainstorm.md
@@ -26,11 +26,15 @@ If resolution fails, fall back to the legacy prose-only path for questions —
 do not abort the brainstorm. Log: `warning: aimi-cli.sh unresolved — forcing
 INTERACTIVE_MODE=picker`.
 
+**Each Bash tool call is an isolated shell — `$AIMI_CLI` does not persist.** Re-read the cache at the top of every subsequent Bash call that needs `$AIMI_CLI`. See the **Per-Call Resolution** section of `commands/references/cli-path-resolution.md` for the one-liner and shell guard to prepend.
+
 ## Step 0.5: Resolve Interactivity Mode
 
 Before any question is presented, resolve which mode applies:
 
 ```bash
+AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+: "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
 INTERACTIVE_MODE=$($AIMI_CLI detect-interactivity)
 ```
 
@@ -66,6 +70,8 @@ esac
 Run detection (failure is silent and non-blocking):
 
 ```bash
+AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+: "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
 if [ -n "$BUNDLE_ARG" ]; then
   BUNDLE_RESULT=$($AIMI_CLI detect-design-bundle --root "$BUNDLE_ARG" 2>/dev/null) || BUNDLE_RESULT=""
 else
@@ -90,6 +96,8 @@ error, no warning, no change to existing behavior.
 
 1. **Check status:**
    ```bash
+   AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+   : "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
    STATUS_JSON=$($AIMI_CLI bundle-prototype-status \
      --bundle "<bundlePath>" \
      --topic "<topic-slug>" \
@@ -141,6 +149,8 @@ error, no warning, no change to existing behavior.
 
    a. **Finalize the sidecar:** Compute hashes and call:
       ```bash
+      AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+      : "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
       BUNDLE_HASH=$(sha256sum "<bundlePath>/README.md" 2>/dev/null | awk '{print $1}' || echo "")
       DESIGN_HASH=$([ -n "<designSpecPath>" ] && sha256sum "<designSpecPath>" 2>/dev/null | awk '{print $1}' || echo "")
       BUSINESS_HASH=$([ -n "<businessSpecPath>" ] && sha256sum "<businessSpecPath>" 2>/dev/null | awk '{print $1}' || echo "")

--- a/plugins/aimi-engineering/commands/execute.md
+++ b/plugins/aimi-engineering/commands/execute.md
@@ -21,7 +21,7 @@ Read `${CLAUDE_PLUGIN_ROOT}/commands/references/cli-path-resolution.md` and foll
 
 If resolution fails, report error and STOP.
 
-Use `$AIMI_CLI` for all subsequent script calls.
+**Each Bash tool call is an isolated shell — `$AIMI_CLI` does not persist.** Re-read the cache at the top of every subsequent Bash call that needs `$AIMI_CLI` or `$WORKTREE_MGR`. See the **Per-Call Resolution** section of `commands/references/cli-path-resolution.md` for the one-liner and shell guard to prepend.
 
 ## Multi-Repo Handling
 
@@ -52,6 +52,8 @@ Each project group operates independently: its own default-branch detection, `gi
 After each wave (and in Post-Loop safety cleanup), for each unique `project_root` (including CWD for the DEFAULT group):
 
 ```bash
+WORKTREE_MGR=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/worktree-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-worktree-path" 2>/dev/null)
+: "${WORKTREE_MGR:?WORKTREE_MGR is empty — re-resolve via cat ~/.config/aimi/worktree-path in this Bash call}"
 cd [project_root]
 $WORKTREE_MGR list
 # For each worktree matching "[branchName]-US-*":
@@ -65,6 +67,8 @@ $WORKTREE_MGR remove [worktree_name]
 Before starting a new session, check whether any completed task files should be archived to prevent accidental re-execution of finished work.
 
 ```bash
+AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+: "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
 $AIMI_CLI list-archivable
 ```
 
@@ -88,10 +92,14 @@ Archive these completed tasks before starting? (yes/no)
 
 - **If user confirms (yes):** For each archivable file path, run:
   ```bash
+  AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+  : "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
   $AIMI_CLI archive-task [file_path]
   ```
   After all files are archived, reset state files:
   ```bash
+  AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+  : "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
   $AIMI_CLI clear-state
   ```
   Report:
@@ -141,6 +149,8 @@ When `VISUAL_FOLLOW=true`, the `visual-follow` session is intentionally left ope
 Check the tasks file directly for any stories with a visual verification strategy. Since `$AIMI_CLI status` omits the `verification` field, read the file with jq:
 
 ```bash
+AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+: "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
 TASKS_PATH="$($AIMI_CLI init-session 2>/dev/null | jq -r '.tasks // empty')"
 VISUAL_STORIES=$(jq '[.userStories[] | select(.verification | type == "object" and .strategy == "visual")] | length' "$AIMI_ROOT/$TASKS_PATH" 2>/dev/null)
 MALFORMED_VERIF=$(jq '[.userStories[] | select(.verification != null and (.verification | type != "object"))] | length' "$AIMI_ROOT/$TASKS_PATH" 2>/dev/null)
@@ -184,6 +194,8 @@ Proceed to Step 1.
 Discover all task files and check for paired frontend/backend splits:
 
 ```bash
+AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+: "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
 ALL_TASKS=$($AIMI_CLI find-tasks-all)
 ```
 
@@ -234,6 +246,8 @@ Report:
 
 Create worktrees for isolation:
 ```bash
+WORKTREE_MGR=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/worktree-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-worktree-path" 2>/dev/null)
+: "${WORKTREE_MGR:?WORKTREE_MGR is empty — re-resolve via cat ~/.config/aimi/worktree-path in this Bash call}"
 $WORKTREE_MGR create [FRONTEND_BRANCH] --from $DEFAULT_BRANCH
 $WORKTREE_MGR create [BACKEND_BRANCH] --from $DEFAULT_BRANCH
 ```
@@ -310,6 +324,8 @@ Total commits: [frontend_commits + backend_commits]
 
 Clean up worktrees after reporting:
 ```bash
+WORKTREE_MGR=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/worktree-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-worktree-path" 2>/dev/null)
+: "${WORKTREE_MGR:?WORKTREE_MGR is empty — re-resolve via cat ~/.config/aimi/worktree-path in this Bash call}"
 $WORKTREE_MGR remove [FRONTEND_BRANCH]
 $WORKTREE_MGR remove [BACKEND_BRANCH]
 ```
@@ -321,6 +337,8 @@ STOP execution (aggregated report replaces normal Step 5).
 **CRITICAL:** Use the CLI script to initialize session and get metadata. Do NOT interpret jq queries directly.
 
 ```bash
+AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+: "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
 $AIMI_CLI init-session
 ```
 
@@ -344,6 +362,8 @@ STOP execution.
 Check for and reset stories stuck in `in_progress` status (from interrupted previous runs):
 
 ```bash
+AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+: "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
 $AIMI_CLI reset-orphaned
 ```
 
@@ -359,6 +379,8 @@ Note: These stories will appear as "failed" in status. The user can review and r
 ### Content Validation
 
 ```bash
+AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+: "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
 $AIMI_CLI validate-stories
 ```
 
@@ -390,6 +412,8 @@ When the flag is true, run both of the following. When false, skip both — per-
 
 Detect the default branch:
 ```bash
+AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+: "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
 DEFAULT_BRANCH=$($AIMI_CLI detect-default-branch)
 ```
 Store `DEFAULT_BRANCH` for use in branch creation and commit counting.
@@ -416,6 +440,8 @@ If `AIMI_ROOT_IS_GIT_REPO` is false, skip this step entirely and leave `BASE_BRA
 ### Resolve Interactivity Mode
 
 ```bash
+AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+: "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
 INTERACTIVE_MODE=$($AIMI_CLI detect-interactivity)
 ```
 
@@ -484,6 +510,8 @@ Get the branch name from the init-session output (already validated by CLI).
 **Skip this step if `AIMI_ROOT_IS_GIT_REPO` is false** — see Multi-Repo Handling above.
 
 ```bash
+AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+: "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
 if [ -n "$BASE_BRANCH" ]; then
   BRANCH_JSON=$($AIMI_CLI setup-branch [branchName] --default-branch $DEFAULT_BRANCH --base $BASE_BRANCH)
 else
@@ -510,6 +538,8 @@ Run the following sub-steps when any story has a non-null `project` field, or wh
 2. Resolve each project path to an absolute path: `AIMI_ROOT / story.project` where AIMI_ROOT is the directory containing `.aimi/`.
 3. For each unique project path, detect its default branch and set up the branch:
    ```bash
+   AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+   : "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
    PROJECT_DEFAULT=$($AIMI_CLI detect-default-branch --project [resolved_project_path])
    git -C [resolved_project_path] fetch origin 2>/dev/null || true
    if [ -n "$BASE_BRANCH" ]; then
@@ -526,6 +556,8 @@ Run the following sub-steps when any story has a non-null `project` field, or wh
 ## Step 3: Check for Pending Stories
 
 ```bash
+AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+: "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
 $AIMI_CLI count-pending
 ```
 
@@ -540,6 +572,8 @@ STOP execution.
 ### Validate Dependencies
 
 ```bash
+AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+: "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
 $AIMI_CLI validate-deps
 ```
 
@@ -568,11 +602,15 @@ Read `${CLAUDE_PLUGIN_ROOT}/commands/references/cli-path-resolution.md` and foll
 
 If resolution fails, report error and STOP.
 
+**`$WORKTREE_MGR` does not persist across Bash calls.** Re-read the cache at the top of every Bash call that uses it — see the **Per-Call Resolution** section of `commands/references/cli-path-resolution.md` for the one-liner and shell guard.
+
 ## Step 3.2: Read Concurrency Setting
 
 Read the tasks file metadata to get maxConcurrency:
 
 ```bash
+AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+: "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
 $AIMI_CLI init-session
 ```
 
@@ -1091,6 +1129,8 @@ git log --oneline $DEFAULT_BRANCH..HEAD | wc -l
 
 Check for any remaining pending gates across all stories:
 ```bash
+AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+: "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
 $AIMI_CLI status
 ```
 
@@ -1190,6 +1230,8 @@ The tasks file preserves all state. Re-running `/aimi:execute` will:
 If context was cleared (via `/clear`), the CLI maintains state:
 
 ```bash
+AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+: "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
 $AIMI_CLI get-state
 ```
 

--- a/plugins/aimi-engineering/commands/init.md
+++ b/plugins/aimi-engineering/commands/init.md
@@ -30,7 +30,7 @@ STATUS=$(printf '%s' "$PRIME_JSON" | jq -r '.status')
 PATH_VAL=$(printf '%s' "$PRIME_JSON" | jq -r '.path // "null"')
 VERSION=$(printf '%s' "$PRIME_JSON" | jq -r '.version // "null"')
 MESSAGE=$(printf '%s' "$PRIME_JSON" | jq -r '.message // ""')
-CACHE_FILE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path"
+CACHE_FILE="${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path"
 ```
 
 Display the result based on `$STATUS`:

--- a/plugins/aimi-engineering/commands/plan.md
+++ b/plugins/aimi-engineering/commands/plan.md
@@ -21,6 +21,8 @@ Read `${CLAUDE_PLUGIN_ROOT}/commands/references/cli-path-resolution.md` and foll
 
 If resolution fails, report error and STOP.
 
+**Each Bash tool call is an isolated shell — `$AIMI_CLI` does not persist.** Re-read the cache at the top of every subsequent Bash call that needs `$AIMI_CLI`. See the **Per-Call Resolution** section of `commands/references/cli-path-resolution.md` for the one-liner and shell guard to prepend.
+
 ### Detect Git Repo Layout
 
 Check if the current directory (AIMI root) is itself a git repository:
@@ -36,6 +38,8 @@ Store the result as `AIMI_ROOT_IS_GIT_REPO` (true/false). When false, this is a 
 **If `AIMI_ROOT_IS_GIT_REPO` is true:**
 
 ```bash
+AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+: "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
 git fetch origin 2>&1 || echo "WARNING: git fetch failed (offline?). Continuing with local refs."
 $AIMI_CLI detect-default-branch
 ```
@@ -47,6 +51,8 @@ Use the output as the default branch for `branchName` derivation in Phase 4.
 ### Detect Interactivity
 
 ```bash
+AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+: "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
 INTERACTIVE_MODE=$($AIMI_CLI detect-interactivity)
 ```
 
@@ -91,12 +97,16 @@ Extract an optional `--root <path>` flag from `$ARGUMENTS` (e.g. `--root .aimi/b
 Run bundle detection unconditionally:
 
 ```bash
+AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+: "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
 BUNDLE_META=$($AIMI_CLI detect-design-bundle 2>/dev/null) || BUNDLE_META=""
 ```
 
 If `BUNDLE_OVERRIDE` is non-empty, pass it as the override flag:
 
 ```bash
+AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+: "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
 BUNDLE_META=$($AIMI_CLI detect-design-bundle --root "$BUNDLE_OVERRIDE" 2>/dev/null) || BUNDLE_META=""
 ```
 
@@ -113,6 +123,8 @@ When `designBundleMeta` is non-null AND (`bundlePayload.prototypes[]` is empty O
 1. **Check generation status:**
 
 ```bash
+AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+: "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
 STATUS_JSON=$($AIMI_CLI bundle-prototype-status \
   --bundle "<bundlePath>" \
   --topic "<topicSlug>" \
@@ -157,6 +169,8 @@ Task subagent_type="aimi-engineering:research:aimi-bundle-prototype-author"
    After the agent writes `outputPath`, write the sidecar atomically:
 
 ```bash
+AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+: "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
 $AIMI_CLI bundle-prototype-finalize \
   --topic "<topicSlug>" \
   --bundle-hash "<bundleHash>" \
@@ -1020,6 +1034,8 @@ After writing the tasks.json file(s), validate each generated output independent
 For each generated tasks file, run `normalize-verification` first. This auto-migrates any string-typed `verification` values emitted by the planner into the required object shape, preventing `validate-stories` from rejecting them.
 
 ```bash
+AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+: "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
 TASKS_PATH=".aimi/tasks/YYYY-MM-DD-[feature-name]-tasks.json"
 $AIMI_CLI normalize-verification "$TASKS_PATH"
 NORMALIZE_EXIT=$?
@@ -1037,6 +1053,8 @@ If `normalize-verification` exits non-zero, **stop here** — do not run any fur
 **For split files (full-stack):** run validation on each file separately using `init-session --file`:
 
 ```bash
+AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+: "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
 $AIMI_CLI init-session --file .aimi/tasks/YYYY-MM-DD-[feature-name]-frontend-tasks.json
 $AIMI_CLI validate-ids
 $AIMI_CLI validate-deps
@@ -1053,6 +1071,8 @@ $AIMI_CLI validate-tasks
 **For single file (frontend-only or legacy):**
 
 ```bash
+AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+: "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
 $AIMI_CLI init-session --file .aimi/tasks/YYYY-MM-DD-[feature-name]-frontend-tasks.json
 $AIMI_CLI validate-ids
 $AIMI_CLI validate-deps

--- a/plugins/aimi-engineering/commands/references/cli-path-resolution.md
+++ b/plugins/aimi-engineering/commands/references/cli-path-resolution.md
@@ -16,8 +16,10 @@ Layer 0 first checks that `CLAUDECODE` is unset — when running inside Claude C
 
 ### Layer 1: Global cache (fast path)
 
+Try the new XDG path first; fall back to the legacy path during the migration window.
+
 ```bash
-if [ -z "$AIMI_CLI" ]; then AIMI_CLI=$(cat ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path 2>/dev/null); fi
+if [ -z "$AIMI_CLI" ]; then AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null); fi
 ```
 
 ### Layer 1 validation: verify cached path exists and is executable
@@ -36,8 +38,10 @@ if [ -z "$AIMI_CLI" ]; then AIMI_CLI=$(bash -c 'ls ${CLAUDE_CONFIG_DIR:-$HOME/.c
 
 ### Layer 2 cache update: save for next time
 
+Writes to the new XDG path. `mkdir -p` ensures the directory exists before the atomic write.
+
 ```bash
-if [ -n "$AIMI_CLI" ]; then printf '%s\n' "$AIMI_CLI" > "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path.tmp" && mv "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path.tmp" "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" && chmod 600 "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path"; fi
+if [ -n "$AIMI_CLI" ]; then _aimi_cfg="${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}"; mkdir -p "$_aimi_cfg" && printf '%s\n' "$AIMI_CLI" > "$_aimi_cfg/cli-path.tmp" && mv "$_aimi_cfg/cli-path.tmp" "$_aimi_cfg/cli-path" && chmod 600 "$_aimi_cfg/cli-path"; fi
 ```
 
 ### Layer 3: Per-project fallback (last resort)
@@ -64,8 +68,10 @@ Layer 0 first checks that `CLAUDECODE` is unset — when running inside Claude C
 
 ### Layer 1: Global cache (fast path)
 
+Try the new XDG path first; fall back to the legacy path during the migration window.
+
 ```bash
-if [ -z "$WORKTREE_MGR" ]; then WORKTREE_MGR=$(cat ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-worktree-path 2>/dev/null); fi
+if [ -z "$WORKTREE_MGR" ]; then WORKTREE_MGR=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/worktree-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-worktree-path" 2>/dev/null); fi
 ```
 
 ### Layer 1 validation: verify cached path exists and is executable
@@ -84,8 +90,10 @@ if [ -z "$WORKTREE_MGR" ]; then WORKTREE_MGR=$(bash -c 'ls ${CLAUDE_CONFIG_DIR:-
 
 ### Layer 2 cache update: save for next time
 
+Writes to the new XDG path. `mkdir -p` ensures the directory exists before the atomic write.
+
 ```bash
-if [ -n "$WORKTREE_MGR" ]; then printf '%s\n' "$WORKTREE_MGR" > "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-worktree-path.tmp" && mv "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-worktree-path.tmp" "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-worktree-path" && chmod 600 "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-worktree-path"; fi
+if [ -n "$WORKTREE_MGR" ]; then _aimi_cfg="${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}"; mkdir -p "$_aimi_cfg" && printf '%s\n' "$WORKTREE_MGR" > "$_aimi_cfg/worktree-path.tmp" && mv "$_aimi_cfg/worktree-path.tmp" "$_aimi_cfg/worktree-path" && chmod 600 "$_aimi_cfg/worktree-path"; fi
 ```
 
 ### Layer 3: Per-project fallback (last resort)
@@ -108,7 +116,37 @@ $AIMI_CLI check-version --quiet --fix
 
 If `check-version` exits 0, no action is needed — proceed normally. The `--quiet` flag suppresses informational output and `--fix` auto-updates a stale cli-path. This does NOT call `cleanup-versions` (cleanup is manual-only).
 
-**Use `$AIMI_CLI` for ALL subsequent script calls in this command.**
+**`$AIMI_CLI` does not persist across Bash tool calls.** Re-read the cache at the top of every subsequent call — see [Per-Call Resolution](#per-call-resolution) below.
+
+## Per-Call Resolution
+
+**Precondition:** this pattern assumes Step 0 (the full Layer 0–3 resolution above) has already run in a prior Bash call and written the cache to the new XDG path. Without that primer, the one-liner below returns empty.
+
+Each Bash tool call is an **isolated shell** — variables set in one call do not exist in the next. Re-read both `$AIMI_CLI` and `$WORKTREE_MGR` from the cache file at the top of every Bash call that needs them.
+
+### $AIMI_CLI one-liner
+
+```bash
+AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+: "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
+```
+
+The `||` fallback covers the migration window: if only the legacy file exists, it is used. The `: "${VAR:?…}"` guard turns a silent empty into a loud failure that exits the Bash call immediately with a clear message.
+
+### $WORKTREE_MGR one-liner
+
+```bash
+WORKTREE_MGR=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/worktree-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-worktree-path" 2>/dev/null)
+: "${WORKTREE_MGR:?WORKTREE_MGR is empty — re-resolve via cat ~/.config/aimi/worktree-path in this Bash call}"
+```
+
+### Failure Signature
+
+Symptom: the Bash call prints `command not found: <subcommand>` with no path prefix before the subcommand name.
+
+Cause: `$AIMI_CLI` (or `$WORKTREE_MGR`) expanded to empty in this Bash call. The shell tried to run the subcommand name as a standalone binary and failed.
+
+Fix: add the per-call re-read one-liner at the top of the failing Bash call. If the re-read itself returns empty, Step 0 has not yet run in this session — run the full Layer 0–3 resolution first.
 
 ## CWD Auto-Discovery
 

--- a/plugins/aimi-engineering/hooks/auto-approve-cli.sh
+++ b/plugins/aimi-engineering/hooks/auto-approve-cli.sh
@@ -28,6 +28,19 @@ ESCAPED_CONFIG_DIR=$(printf '%s' "$RESOLVED_CONFIG_DIR" | sed 's/[.[\*^$()+?{|\\
 #   ~\/.claude  |  \$\{CLAUDE_CONFIG_DIR:-\$HOME\/\.claude\}  |  /resolved/path
 CONFIG_DIR_RE="(~/\\.claude|\\\$\\{CLAUDE_CONFIG_DIR:-\\\$HOME/\\.claude\\}|${ESCAPED_CONFIG_DIR})"
 
+# --- Resolve XDG aimi config directory for new cache path matching ---
+# Commands may reference the aimi config dir as:
+#   1. ~/.config/aimi                                        (tilde shorthand)
+#   2. ${XDG_CONFIG_HOME:-$HOME/.config}/aimi                (parameterized XDG form)
+#   3. ${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}  (AIMI_CONFIG_DIR form)
+#   4. /resolved/absolute/path/aimi                          (resolved absolute path)
+RESOLVED_AIMI_DIR="${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}"
+RESOLVED_AIMI_DIR="${RESOLVED_AIMI_DIR%/}"
+ESCAPED_AIMI_DIR=$(printf '%s' "$RESOLVED_AIMI_DIR" | sed 's/[.[\*^$()+?{|\\]/\\&/g; s/\//\\\//g')
+# Build the aimi dir regex alternation:
+#   ~/\.config\/aimi  |  \$\{XDG_CONFIG_HOME:-\$HOME\/\.config\}\/aimi  |  \$\{AIMI_CONFIG_DIR:-...\}  |  /resolved/path
+AIMI_DIR_RE="(~/\\.config/aimi|\\\$\\{XDG_CONFIG_HOME:-\\\$HOME/\\.config\\}/aimi|\\\$\\{AIMI_CONFIG_DIR:-\\\$\\{XDG_CONFIG_HOME:-\\\$HOME/\\.config\\}/aimi\\}|${ESCAPED_AIMI_DIR})"
+
 # --- Helper: Reject shell metacharacters ---
 # Returns 0 (true) if dangerous metacharacters are found after the variable reference.
 has_metacharacters() {
@@ -69,8 +82,13 @@ if echo "$COMMAND" | grep -qE '^AIMI_CLI='; then
     echo "$ALLOW"
     exit 0
   fi
-  # Cache read: AIMI_CLI=$(cat <config>/aimi-engineering-cli-path 2>/dev/null)
+  # Cache read: AIMI_CLI=$(cat <config>/aimi-engineering-cli-path 2>/dev/null)  [legacy]
   if echo "$COMMAND" | grep -qE "^AIMI_CLI=\\$\\(cat ${CONFIG_DIR_RE}/aimi-engineering-cli-path 2>/dev/null\\)\$"; then
+    echo "$ALLOW"
+    exit 0
+  fi
+  # Cache read: AIMI_CLI=$(cat <aimi-dir>/cli-path 2>/dev/null)  [new XDG]
+  if echo "$COMMAND" | grep -qE "^AIMI_CLI=\\$\\(cat ${AIMI_DIR_RE}/cli-path 2>/dev/null\\)\$"; then
     echo "$ALLOW"
     exit 0
   fi
@@ -116,8 +134,13 @@ if echo "$COMMAND" | grep -qE '^WORKTREE_MGR='; then
     echo "$ALLOW"
     exit 0
   fi
-  # Cache read: WORKTREE_MGR=$(cat <config>/aimi-engineering-worktree-path 2>/dev/null)
+  # Cache read: WORKTREE_MGR=$(cat <config>/aimi-engineering-worktree-path 2>/dev/null)  [legacy]
   if echo "$COMMAND" | grep -qE "^WORKTREE_MGR=\\$\\(cat ${CONFIG_DIR_RE}/aimi-engineering-worktree-path 2>/dev/null\\)\$"; then
+    echo "$ALLOW"
+    exit 0
+  fi
+  # Cache read: WORKTREE_MGR=$(cat <aimi-dir>/worktree-path 2>/dev/null)  [new XDG]
+  if echo "$COMMAND" | grep -qE "^WORKTREE_MGR=\\$\\(cat ${AIMI_DIR_RE}/worktree-path 2>/dev/null\\)\$"; then
     echo "$ALLOW"
     exit 0
   fi
@@ -176,16 +199,37 @@ if echo "$COMMAND" | grep -qE "^if \\[ -z \"\\\$WORKTREE_MGR\" \\]; then WORKTRE
   exit 0
 fi
 
-# --- Pattern 9: AIMI_CLI Layer 2 cache write ---
+# --- Pattern 9: AIMI_CLI Layer 2 cache write [legacy] ---
 # Approves: if [ -n "$AIMI_CLI" ]; then printf '%s\n' "$AIMI_CLI" > "<config>/aimi-engineering-cli-path.tmp" && mv "<config>/aimi-engineering-cli-path.tmp" "<config>/aimi-engineering-cli-path" && chmod 600 "<config>/aimi-engineering-cli-path"; fi
 if echo "$COMMAND" | grep -qE "^if \\[ -n \"\\\$AIMI_CLI\" \\]; then printf '%s\\\\n' \"\\\$AIMI_CLI\" > \"${CONFIG_DIR_RE}/aimi-engineering-cli-path\\.tmp\" && mv \"${CONFIG_DIR_RE}/aimi-engineering-cli-path\\.tmp\" \"${CONFIG_DIR_RE}/aimi-engineering-cli-path\" && chmod 600 \"${CONFIG_DIR_RE}/aimi-engineering-cli-path\"; fi\$"; then
   echo "$ALLOW"
   exit 0
 fi
 
-# --- Pattern 10: WORKTREE_MGR Layer 2 cache write ---
+# --- Pattern 10: WORKTREE_MGR Layer 2 cache write [legacy] ---
 # Approves: if [ -n "$WORKTREE_MGR" ]; then printf '%s\n' "$WORKTREE_MGR" > "<config>/aimi-engineering-worktree-path.tmp" && mv "<config>/aimi-engineering-worktree-path.tmp" "<config>/aimi-engineering-worktree-path" && chmod 600 "<config>/aimi-engineering-worktree-path"; fi
 if echo "$COMMAND" | grep -qE "^if \\[ -n \"\\\$WORKTREE_MGR\" \\]; then printf '%s\\\\n' \"\\\$WORKTREE_MGR\" > \"${CONFIG_DIR_RE}/aimi-engineering-worktree-path\\.tmp\" && mv \"${CONFIG_DIR_RE}/aimi-engineering-worktree-path\\.tmp\" \"${CONFIG_DIR_RE}/aimi-engineering-worktree-path\" && chmod 600 \"${CONFIG_DIR_RE}/aimi-engineering-worktree-path\"; fi\$"; then
+  echo "$ALLOW"
+  exit 0
+fi
+
+# --- Pattern 9x: AIMI_CLI Layer 2 cache write [new XDG] ---
+# Approves: if [ -n "$AIMI_CLI" ]; then printf '%s\n' "$AIMI_CLI" > "<aimi-dir>/cli-path.tmp" && mv "<aimi-dir>/cli-path.tmp" "<aimi-dir>/cli-path" && chmod 600 "<aimi-dir>/cli-path"; fi
+if echo "$COMMAND" | grep -qE "^if \\[ -n \"\\\$AIMI_CLI\" \\]; then printf '%s\\\\n' \"\\\$AIMI_CLI\" > \"${AIMI_DIR_RE}/cli-path\\.tmp\" && mv \"${AIMI_DIR_RE}/cli-path\\.tmp\" \"${AIMI_DIR_RE}/cli-path\" && chmod 600 \"${AIMI_DIR_RE}/cli-path\"; fi\$"; then
+  echo "$ALLOW"
+  exit 0
+fi
+
+# --- Pattern 10x: WORKTREE_MGR Layer 2 cache write [new XDG] ---
+# Approves: if [ -n "$WORKTREE_MGR" ]; then printf '%s\n' "$WORKTREE_MGR" > "<aimi-dir>/worktree-path.tmp" && mv "<aimi-dir>/worktree-path.tmp" "<aimi-dir>/worktree-path" && chmod 600 "<aimi-dir>/worktree-path"; fi
+if echo "$COMMAND" | grep -qE "^if \\[ -n \"\\\$WORKTREE_MGR\" \\]; then printf '%s\\\\n' \"\\\$WORKTREE_MGR\" > \"${AIMI_DIR_RE}/worktree-path\\.tmp\" && mv \"${AIMI_DIR_RE}/worktree-path\\.tmp\" \"${AIMI_DIR_RE}/worktree-path\" && chmod 600 \"${AIMI_DIR_RE}/worktree-path\"; fi\$"; then
+  echo "$ALLOW"
+  exit 0
+fi
+
+# --- Pattern 10y: mkdir -p for new XDG aimi config dir ---
+# Approves: mkdir -p <aimi-dir>
+if echo "$COMMAND" | grep -qE "^mkdir -p \"?${AIMI_DIR_RE}\"?\$"; then
   echo "$ALLOW"
   exit 0
 fi

--- a/plugins/aimi-engineering/scripts/aimi-cli.sh
+++ b/plugins/aimi-engineering/scripts/aimi-cli.sh
@@ -231,18 +231,47 @@ _is_claude_code_host() {
   [ "${CLAUDECODE:-}" = "1" ]
 }
 
-# Return the global cache file path for aimi-cli.sh
-_global_cache_path() {
+# Resolve the Aimi config directory (XDG-compliant, host-agnostic).
+# Honors AIMI_CONFIG_DIR env var; falls back to ${XDG_CONFIG_HOME:-$HOME/.config}/aimi.
+# When AIMI_CONFIG_DIR is set, validates it is an absolute path.
+# Always returns the path with any trailing slash stripped.
+_aimi_config_dir() {
+  local dir="${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}"
+  # Validate absolute path when explicitly set
+  if [ -n "${AIMI_CONFIG_DIR:-}" ] && [ "${dir#/}" = "$dir" ]; then
+    echo "Error: AIMI_CONFIG_DIR must be an absolute path, got: $dir" >&2
+    exit 1
+  fi
+  # Strip trailing slash
+  printf '%s\n' "${dir%/}"
+}
+
+# Return the legacy global cache file path for aimi-cli.sh (read-fallback only)
+_global_cache_path_legacy() {
   local config_dir
   config_dir=$(_claude_config_dir)
   printf '%s\n' "$config_dir/aimi-engineering-cli-path"
 }
 
-# Return the global cache file path for worktree-manager.sh
-_global_worktree_cache_path() {
+# Return the legacy global cache file path for worktree-manager.sh (read-fallback only)
+_global_worktree_cache_path_legacy() {
   local config_dir
   config_dir=$(_claude_config_dir)
   printf '%s\n' "$config_dir/aimi-engineering-worktree-path"
+}
+
+# Return the global cache file path for aimi-cli.sh (new XDG location)
+_global_cache_path() {
+  local aimi_dir
+  aimi_dir=$(_aimi_config_dir)
+  printf '%s\n' "$aimi_dir/cli-path"
+}
+
+# Return the global cache file path for worktree-manager.sh (new XDG location)
+_global_worktree_cache_path() {
+  local aimi_dir
+  aimi_dir=$(_aimi_config_dir)
+  printf '%s\n' "$aimi_dir/worktree-path"
 }
 
 # Atomically write the CLI path to the global cache file
@@ -251,6 +280,12 @@ write_global_cli_cache() {
   local path="$1"
   local cache_file
   cache_file=$(_global_cache_path)
+  local cache_dir
+  cache_dir=$(dirname "$cache_file")
+  if ! mkdir -p "$cache_dir" 2>/dev/null; then
+    echo "Error: write_global_cli_cache: cannot create directory: $cache_dir" >&2
+    return 1
+  fi
   local tmp_file
   tmp_file=$(mktemp "${cache_file}.XXXXXX")
   printf '%s\n' "$path" > "$tmp_file"
@@ -258,19 +293,10 @@ write_global_cli_cache() {
   mv "$tmp_file" "$cache_file"
 }
 
-# Read and validate the cached CLI path from the global cache file
-# Returns the cached path if valid, empty string otherwise
-read_global_cli_cache() {
-  local cache_file
-  cache_file=$(_global_cache_path)
-  if [ ! -f "$cache_file" ] || [ ! -r "$cache_file" ]; then
-    return 0
-  fi
-  local cached_path
-  cached_path=$(cat "$cache_file" 2>/dev/null) || return 0
-  # Validate path matches expected pattern
-  # Expected: */plugins/cache/*/aimi-engineering/*/scripts/aimi-cli.sh
-  # Or: $AIMI_PLUGIN_DIR/scripts/aimi-cli.sh (compound-plugin converter)
+# _validate_cached_cli_path: run a path through the whitelist case statement
+# Returns the path unchanged if valid, empty string if rejected
+_validate_cached_cli_path() {
+  local cached_path="$1"
   local plugin_dir
   plugin_dir=$(_validate_plugin_dir)
   case "$cached_path" in
@@ -285,12 +311,41 @@ read_global_cli_cache() {
   esac
 }
 
+# Read and validate the cached CLI path from the global cache file
+# Tries new XDG path first, falls back to legacy path if new is absent.
+# Returns the cached path if valid, empty string otherwise.
+read_global_cli_cache() {
+  local cache_file
+  cache_file=$(_global_cache_path)
+  if [ -f "$cache_file" ] && [ -r "$cache_file" ]; then
+    local cached_path
+    cached_path=$(cat "$cache_file" 2>/dev/null) || return 0
+    _validate_cached_cli_path "$cached_path"
+    return 0
+  fi
+  # Fall back to legacy path
+  local legacy_file
+  legacy_file=$(_global_cache_path_legacy)
+  if [ ! -f "$legacy_file" ] || [ ! -r "$legacy_file" ]; then
+    return 0
+  fi
+  local cached_path
+  cached_path=$(cat "$legacy_file" 2>/dev/null) || return 0
+  _validate_cached_cli_path "$cached_path"
+}
+
 # Atomically write the worktree manager path to the global cache file
 # Usage: write_global_worktree_cache "/path/to/worktree-manager.sh"
 write_global_worktree_cache() {
   local path="$1"
   local cache_file
   cache_file=$(_global_worktree_cache_path)
+  local cache_dir
+  cache_dir=$(dirname "$cache_file")
+  if ! mkdir -p "$cache_dir" 2>/dev/null; then
+    echo "Error: write_global_worktree_cache: cannot create directory: $cache_dir" >&2
+    return 1
+  fi
   local tmp_file
   tmp_file=$(mktemp "${cache_file}.XXXXXX")
   printf '%s\n' "$path" > "$tmp_file"
@@ -298,19 +353,10 @@ write_global_worktree_cache() {
   mv "$tmp_file" "$cache_file"
 }
 
-# Read and validate the cached worktree manager path from the global cache file
-# Returns the cached path if valid, empty string otherwise
-read_global_worktree_cache() {
-  local cache_file
-  cache_file=$(_global_worktree_cache_path)
-  if [ ! -f "$cache_file" ] || [ ! -r "$cache_file" ]; then
-    return 0
-  fi
-  local cached_path
-  cached_path=$(cat "$cache_file" 2>/dev/null) || return 0
-  # Validate path matches expected pattern
-  # Expected: */plugins/cache/*/aimi-engineering/*/skills/git-worktree/scripts/worktree-manager.sh
-  # Or: $AIMI_PLUGIN_DIR/skills/git-worktree/scripts/worktree-manager.sh (compound-plugin converter)
+# _validate_cached_worktree_path: run a worktree path through the whitelist case statement
+# Returns the path unchanged if valid, empty string if rejected
+_validate_cached_worktree_path() {
+  local cached_path="$1"
   local plugin_dir
   plugin_dir=$(_validate_plugin_dir)
   case "$cached_path" in
@@ -323,6 +369,29 @@ read_global_worktree_cache() {
       printf '%s\n' "$cached_path"
       ;;
   esac
+}
+
+# Read and validate the cached worktree manager path from the global cache file
+# Tries new XDG path first, falls back to legacy path if new is absent.
+# Returns the cached path if valid, empty string otherwise.
+read_global_worktree_cache() {
+  local cache_file
+  cache_file=$(_global_worktree_cache_path)
+  if [ -f "$cache_file" ] && [ -r "$cache_file" ]; then
+    local cached_path
+    cached_path=$(cat "$cache_file" 2>/dev/null) || return 0
+    _validate_cached_worktree_path "$cached_path"
+    return 0
+  fi
+  # Fall back to legacy path
+  local legacy_file
+  legacy_file=$(_global_worktree_cache_path_legacy)
+  if [ ! -f "$legacy_file" ] || [ ! -r "$legacy_file" ]; then
+    return 0
+  fi
+  local cached_path
+  cached_path=$(cat "$legacy_file" 2>/dev/null) || return 0
+  _validate_cached_worktree_path "$cached_path"
 }
 
 # Validate story ID format (US-NNN or US-NNNa)

--- a/plugins/aimi-engineering/scripts/test-aimi-cli.sh
+++ b/plugins/aimi-engineering/scripts/test-aimi-cli.sh
@@ -1588,13 +1588,15 @@ test_next_story_returns_full_object() {
 # behavior, manually source aimi-cli.sh in a zsh shell and verify
 # _global_cache_path and read_global_cli_cache return correct results.
 
-# Helper: set up an isolated CLAUDE_CONFIG_DIR with a mock plugin cache
+# Helper: set up an isolated CLAUDE_CONFIG_DIR and AIMI_CONFIG_DIR with a mock plugin cache
 # structure so the CLI's glob-based resolution finds a fake aimi-cli.sh.
-# Sets CLAUDE_CONFIG_DIR, MOCK_CLI_PATH, and MOCK_WORKTREE_PATH globals.
+# Sets CLAUDE_CONFIG_DIR, AIMI_CONFIG_DIR, MOCK_CLI_PATH, and MOCK_WORKTREE_PATH globals.
 setup_global_cache_env() {
   GLOBAL_CACHE_TMPDIR=$(mktemp -d)
   export CLAUDE_CONFIG_DIR="$GLOBAL_CACHE_TMPDIR/claude-config"
+  export AIMI_CONFIG_DIR="$GLOBAL_CACHE_TMPDIR/aimi-config"
   mkdir -p "$CLAUDE_CONFIG_DIR"
+  mkdir -p "$AIMI_CONFIG_DIR"
 
   # Build a mock plugin cache directory structure:
   #   <config>/plugins/cache/marketplace-hash/aimi-engineering/1.99.0/scripts/aimi-cli.sh
@@ -1618,6 +1620,7 @@ setup_global_cache_env() {
 teardown_global_cache_env() {
   rm -rf "$GLOBAL_CACHE_TMPDIR"
   unset CLAUDE_CONFIG_DIR
+  unset AIMI_CONFIG_DIR
   unset GLOBAL_CACHE_TMPDIR
   unset MOCK_CLI_PATH
   unset MOCK_WORKTREE_PATH
@@ -1659,11 +1662,16 @@ teardown_aimi_plugin_dir_env() {
 # We extract the needed functions using sed so we can call them directly.
 source_cache_functions() {
   eval "$(sed -n '/^_claude_config_dir()/,/^}/p' "$CLI")"
+  eval "$(sed -n '/^_aimi_config_dir()/,/^}/p' "$CLI")"
   eval "$(sed -n '/^_validate_plugin_dir()/,/^}/p' "$CLI")"
   eval "$(sed -n '/^_is_claude_code_host()/,/^}/p' "$CLI")"
+  eval "$(sed -n '/^_global_cache_path_legacy()/,/^}/p' "$CLI")"
+  eval "$(sed -n '/^_global_worktree_cache_path_legacy()/,/^}/p' "$CLI")"
   eval "$(sed -n '/^_global_cache_path()/,/^}/p' "$CLI")"
   eval "$(sed -n '/^_global_worktree_cache_path()/,/^}/p' "$CLI")"
   eval "$(sed -n '/^_extract_version_from_path()/,/^}/p' "$CLI")"
+  eval "$(sed -n '/^_validate_cached_cli_path()/,/^}/p' "$CLI")"
+  eval "$(sed -n '/^_validate_cached_worktree_path()/,/^}/p' "$CLI")"
   eval "$(sed -n '/^write_global_cli_cache()/,/^}/p' "$CLI")"
   eval "$(sed -n '/^read_global_cli_cache()/,/^}/p' "$CLI")"
   eval "$(sed -n '/^write_global_worktree_cache()/,/^}/p' "$CLI")"
@@ -1942,6 +1950,279 @@ test_check_version_fix_updates_global_cache() {
   assert_eq "$latest_glob_path" "$cached_content" "check-version --fix: global cache updated to latest path"
 
   teardown_global_cache_env
+}
+
+# ============================================================================
+# _aimi_config_dir Tests
+# ============================================================================
+
+test_aimi_config_dir_default() {
+  echo ""
+  echo "=== Testing _aimi_config_dir: unset falls back to XDG default ==="
+
+  source_cache_functions
+
+  local result
+  result=$(unset AIMI_CONFIG_DIR; unset XDG_CONFIG_HOME; _aimi_config_dir)
+
+  assert_eq "$HOME/.config/aimi" "$result" "_aimi_config_dir: unset AIMI_CONFIG_DIR falls back to \$HOME/.config/aimi"
+}
+
+test_aimi_config_dir_xdg_override() {
+  echo ""
+  echo "=== Testing _aimi_config_dir: XDG_CONFIG_HOME override ==="
+
+  source_cache_functions
+
+  local result
+  result=$(unset AIMI_CONFIG_DIR; XDG_CONFIG_HOME="/tmp/custom-xdg" _aimi_config_dir)
+
+  assert_eq "/tmp/custom-xdg/aimi" "$result" "_aimi_config_dir: XDG_CONFIG_HOME override used"
+}
+
+test_aimi_config_dir_custom_absolute() {
+  echo ""
+  echo "=== Testing _aimi_config_dir: AIMI_CONFIG_DIR custom absolute path ==="
+
+  source_cache_functions
+
+  local result
+  result=$(AIMI_CONFIG_DIR="/tmp/custom-aimi" _aimi_config_dir)
+  assert_eq "/tmp/custom-aimi" "$result" "_aimi_config_dir: custom absolute path resolves correctly"
+
+  result=$(AIMI_CONFIG_DIR="/tmp/custom-aimi/" _aimi_config_dir)
+  assert_eq "/tmp/custom-aimi" "$result" "_aimi_config_dir: trailing slash is stripped from custom path"
+}
+
+test_aimi_config_dir_relative_path_error() {
+  echo ""
+  echo "=== Testing _aimi_config_dir: relative path produces validation error ==="
+
+  source_cache_functions
+
+  local stderr_output exit_code
+  stderr_output=$(AIMI_CONFIG_DIR="relative/path" _aimi_config_dir 2>&1 >/dev/null) && exit_code=0 || exit_code=$?
+
+  assert_contains "must be an absolute path" "$stderr_output" "_aimi_config_dir: relative path produces error message"
+  assert_exit_code "1" "$exit_code" "_aimi_config_dir: relative path exits with code 1"
+}
+
+# ============================================================================
+# XDG Cache Location Tests (new path + read-both fallback)
+# ============================================================================
+
+# Helper: set up an isolated AIMI_CONFIG_DIR (new) alongside CLAUDE_CONFIG_DIR (legacy)
+# Sets AIMI_CONFIG_TMPDIR, LEGACY_CONFIG_TMPDIR globals.
+# Also sets MOCK_CLI_PATH and MOCK_WORKTREE_PATH to paths valid under the new structure.
+setup_xdg_cache_env() {
+  AIMI_CONFIG_TMPDIR=$(mktemp -d)
+  LEGACY_CONFIG_TMPDIR=$(mktemp -d)
+
+  export AIMI_CONFIG_DIR="$AIMI_CONFIG_TMPDIR/aimi"
+  export CLAUDE_CONFIG_DIR="$LEGACY_CONFIG_TMPDIR/claude-config"
+
+  mkdir -p "$CLAUDE_CONFIG_DIR"
+  # Do NOT pre-create AIMI_CONFIG_DIR — write_global_cli_cache must mkdir -p it
+
+  # Build a mock plugin cache so the whitelist pattern matches
+  local mock_scripts_dir="$CLAUDE_CONFIG_DIR/plugins/cache/abc123/aimi-engineering/1.99.0/scripts"
+  local mock_worktree_dir="$CLAUDE_CONFIG_DIR/plugins/cache/abc123/aimi-engineering/1.99.0/skills/git-worktree/scripts"
+  mkdir -p "$mock_scripts_dir"
+  mkdir -p "$mock_worktree_dir"
+
+  echo '#!/usr/bin/env bash' > "$mock_scripts_dir/aimi-cli.sh"
+  chmod +x "$mock_scripts_dir/aimi-cli.sh"
+  MOCK_CLI_PATH="$mock_scripts_dir/aimi-cli.sh"
+
+  echo '#!/usr/bin/env bash' > "$mock_worktree_dir/worktree-manager.sh"
+  chmod +x "$mock_worktree_dir/worktree-manager.sh"
+  MOCK_WORKTREE_PATH="$mock_worktree_dir/worktree-manager.sh"
+}
+
+teardown_xdg_cache_env() {
+  rm -rf "$AIMI_CONFIG_TMPDIR" "$LEGACY_CONFIG_TMPDIR"
+  unset AIMI_CONFIG_DIR CLAUDE_CONFIG_DIR
+  unset AIMI_CONFIG_TMPDIR LEGACY_CONFIG_TMPDIR
+  unset MOCK_CLI_PATH MOCK_WORKTREE_PATH
+}
+
+test_write_creates_xdg_dir() {
+  echo ""
+  echo "=== Testing write_global_cli_cache mkdir -p creates destination dir when missing ==="
+
+  setup_xdg_cache_env
+  source_cache_functions
+
+  # AIMI_CONFIG_DIR is set but the directory does not exist yet
+  local aimi_dir
+  aimi_dir=$(_aimi_config_dir)
+
+  if [ -d "$aimi_dir" ]; then
+    echo -e "${RED}✗${NC} write_global_cli_cache mkdir: pre-condition failed — dir already exists"
+    ((TESTS_FAILED++))
+    teardown_xdg_cache_env
+    return
+  fi
+
+  write_global_cli_cache "$MOCK_CLI_PATH"
+
+  if [ -d "$aimi_dir" ]; then
+    echo -e "${GREEN}✓${NC} write_global_cli_cache mkdir: destination dir created"
+    ((TESTS_PASSED++))
+  else
+    echo -e "${RED}✗${NC} write_global_cli_cache mkdir: destination dir NOT created"
+    ((TESTS_FAILED++))
+  fi
+
+  teardown_xdg_cache_env
+}
+
+test_write_goes_to_new_path_not_legacy() {
+  echo ""
+  echo "=== Testing write_global_cli_cache writes to new XDG path only (not legacy) ==="
+
+  setup_xdg_cache_env
+  source_cache_functions
+
+  write_global_cli_cache "$MOCK_CLI_PATH"
+
+  local new_cache
+  new_cache=$(_global_cache_path)
+  local legacy_cache
+  legacy_cache=$(_global_cache_path_legacy)
+
+  if [ -f "$new_cache" ]; then
+    echo -e "${GREEN}✓${NC} write_global_cli_cache: new XDG cache file exists"
+    ((TESTS_PASSED++))
+  else
+    echo -e "${RED}✗${NC} write_global_cli_cache: new XDG cache file missing"
+    ((TESTS_FAILED++))
+  fi
+
+  if [ ! -f "$legacy_cache" ]; then
+    echo -e "${GREEN}✓${NC} write_global_cli_cache: legacy cache file NOT written"
+    ((TESTS_PASSED++))
+  else
+    echo -e "${RED}✗${NC} write_global_cli_cache: legacy cache file was written (should not be)"
+    ((TESTS_FAILED++))
+  fi
+
+  teardown_xdg_cache_env
+}
+
+test_read_fallback_to_legacy_when_new_absent() {
+  echo ""
+  echo "=== Testing read_global_cli_cache falls back to legacy when new path is absent ==="
+
+  setup_xdg_cache_env
+  source_cache_functions
+
+  # Write a valid path directly to the legacy file (simulating pre-upgrade state)
+  local legacy_cache
+  legacy_cache=$(_global_cache_path_legacy)
+  mkdir -p "$(dirname "$legacy_cache")"
+  printf '%s\n' "$MOCK_CLI_PATH" > "$legacy_cache"
+
+  # Ensure the new XDG file does NOT exist
+  local new_cache
+  new_cache=$(_global_cache_path)
+  rm -f "$new_cache"
+
+  local result
+  result=$(read_global_cli_cache)
+
+  assert_eq "$MOCK_CLI_PATH" "$result" "read_global_cli_cache: falls back to legacy path when new is absent"
+
+  teardown_xdg_cache_env
+}
+
+test_read_prefers_new_over_legacy() {
+  echo ""
+  echo "=== Testing read_global_cli_cache prefers new XDG path over legacy ==="
+
+  setup_xdg_cache_env
+  source_cache_functions
+
+  # Write a different path to legacy
+  local legacy_cache
+  legacy_cache=$(_global_cache_path_legacy)
+  mkdir -p "$(dirname "$legacy_cache")"
+  # Use a second distinct mock path (same pattern, different version)
+  local mock_scripts2="$CLAUDE_CONFIG_DIR/plugins/cache/abc123/aimi-engineering/2.00.0/scripts"
+  mkdir -p "$mock_scripts2"
+  echo '#!/usr/bin/env bash' > "$mock_scripts2/aimi-cli.sh"
+  chmod +x "$mock_scripts2/aimi-cli.sh"
+  printf '%s\n' "$mock_scripts2/aimi-cli.sh" > "$legacy_cache"
+
+  # Write the 1.99.0 path to the new XDG cache
+  write_global_cli_cache "$MOCK_CLI_PATH"
+
+  local result
+  result=$(read_global_cli_cache)
+
+  assert_eq "$MOCK_CLI_PATH" "$result" "read_global_cli_cache: new XDG path takes precedence over legacy"
+
+  teardown_xdg_cache_env
+}
+
+test_worktree_write_creates_xdg_dir() {
+  echo ""
+  echo "=== Testing write_global_worktree_cache mkdir -p creates destination dir when missing ==="
+
+  setup_xdg_cache_env
+  source_cache_functions
+
+  local aimi_dir
+  aimi_dir=$(_aimi_config_dir)
+  rm -rf "$aimi_dir"  # ensure it doesn't exist
+
+  write_global_worktree_cache "$MOCK_WORKTREE_PATH"
+
+  if [ -d "$aimi_dir" ]; then
+    echo -e "${GREEN}✓${NC} write_global_worktree_cache mkdir: destination dir created"
+    ((TESTS_PASSED++))
+  else
+    echo -e "${RED}✗${NC} write_global_worktree_cache mkdir: destination dir NOT created"
+    ((TESTS_FAILED++))
+  fi
+
+  local new_cache
+  new_cache=$(_global_worktree_cache_path)
+  if [ -f "$new_cache" ]; then
+    echo -e "${GREEN}✓${NC} write_global_worktree_cache: new XDG cache file exists"
+    ((TESTS_PASSED++))
+  else
+    echo -e "${RED}✗${NC} write_global_worktree_cache: new XDG cache file missing"
+    ((TESTS_FAILED++))
+  fi
+
+  teardown_xdg_cache_env
+}
+
+test_worktree_read_fallback_to_legacy() {
+  echo ""
+  echo "=== Testing read_global_worktree_cache falls back to legacy when new path is absent ==="
+
+  setup_xdg_cache_env
+  source_cache_functions
+
+  # Write a valid path directly to the legacy file
+  local legacy_cache
+  legacy_cache=$(_global_worktree_cache_path_legacy)
+  mkdir -p "$(dirname "$legacy_cache")"
+  printf '%s\n' "$MOCK_WORKTREE_PATH" > "$legacy_cache"
+
+  # Ensure the new XDG file does NOT exist
+  local new_cache
+  new_cache=$(_global_worktree_cache_path)
+  rm -f "$new_cache"
+
+  local result
+  result=$(read_global_worktree_cache)
+
+  assert_eq "$MOCK_WORKTREE_PATH" "$result" "read_global_worktree_cache: falls back to legacy path when new is absent"
+
+  teardown_xdg_cache_env
 }
 
 # ============================================================================
@@ -3257,9 +3538,11 @@ test_prime_cache_not_found() {
   echo "=== Testing prime-cache: not_found when no plugin installed and AIMI_PLUGIN_DIR unset ==="
 
   # Use an empty tmp dir as CLAUDE_CONFIG_DIR (no plugin cache)
-  local empty_tmp
+  local empty_tmp aimi_tmp
   empty_tmp=$(mktemp -d)
+  aimi_tmp=$(mktemp -d)
   export CLAUDE_CONFIG_DIR="$empty_tmp"
+  export AIMI_CONFIG_DIR="$aimi_tmp"
   export CLAUDECODE=1
   unset AIMI_PLUGIN_DIR 2>/dev/null || true
   source_cache_functions
@@ -3275,7 +3558,8 @@ test_prime_cache_not_found() {
 
   unset CLAUDECODE
   unset CLAUDE_CONFIG_DIR
-  rm -rf "$empty_tmp"
+  unset AIMI_CONFIG_DIR
+  rm -rf "$empty_tmp" "$aimi_tmp"
 }
 
 # (e) Rejects a path outside the expected pattern (malicious path)
@@ -3294,9 +3578,11 @@ test_prime_cache_rejects_bad_path() {
   chmod +x "$bad_tmp/plugins/cache/abc/aimi-engineering/1.0.0/scripts/aimi-cli.sh"
 
   # Create a separate config dir where the cache file would live
-  local cfg_tmp
+  local cfg_tmp aimi_tmp
   cfg_tmp=$(mktemp -d)
+  aimi_tmp=$(mktemp -d)
   export CLAUDE_CONFIG_DIR="$cfg_tmp"
+  export AIMI_CONFIG_DIR="$aimi_tmp"
   export CLAUDECODE=1
   unset AIMI_PLUGIN_DIR 2>/dev/null || true
   source_cache_functions
@@ -3318,7 +3604,8 @@ test_prime_cache_rejects_bad_path() {
 
   unset CLAUDECODE
   unset CLAUDE_CONFIG_DIR
-  rm -rf "$bad_tmp" "$cfg_tmp"
+  unset AIMI_CONFIG_DIR
+  rm -rf "$bad_tmp" "$cfg_tmp" "$aimi_tmp"
 }
 
 # (f) Unwritable cache dir exits 1 with status=error
@@ -3331,8 +3618,9 @@ test_prime_cache_unwritable_cache_dir() {
   export CLAUDECODE=1
   unset AIMI_PLUGIN_DIR 2>/dev/null || true
 
-  # Make the config dir unwritable
-  chmod 0500 "$CLAUDE_CONFIG_DIR"
+  # Make the AIMI_CONFIG_DIR unwritable so mkdir -p fails when write_global_cli_cache
+  # tries to create the parent directory for the new XDG cache file
+  chmod 0500 "$AIMI_CONFIG_DIR"
 
   local output
   output=$(cmd_prime_cache 2>/dev/null)
@@ -3344,7 +3632,7 @@ test_prime_cache_unwritable_cache_dir() {
   assert_eq "error" "$status" "prime-cache (unwritable): status=error"
 
   # Restore so teardown can clean up
-  chmod 0700 "$CLAUDE_CONFIG_DIR"
+  chmod 0700 "$AIMI_CONFIG_DIR"
 
   unset CLAUDECODE
   teardown_global_cache_env
@@ -6032,6 +6320,14 @@ main() {
   test_claude_config_dir_custom_absolute
   test_claude_config_dir_relative_path_error
 
+  # _aimi_config_dir tests
+  echo ""
+  echo "--- AIMI_CONFIG_DIR Tests ---"
+  test_aimi_config_dir_default
+  test_aimi_config_dir_xdg_override
+  test_aimi_config_dir_custom_absolute
+  test_aimi_config_dir_relative_path_error
+
   # AIMI_PLUGIN_DIR tests
   echo ""
   echo "--- AIMI_PLUGIN_DIR Tests ---"
@@ -6069,6 +6365,16 @@ main() {
   test_read_global_worktree_cache_tampered
   test_init_session_writes_global_cache
   test_check_version_fix_updates_global_cache
+
+  # XDG cache location tests — new path + read-both fallback
+  echo ""
+  echo "--- XDG Cache Location Tests ---"
+  test_write_creates_xdg_dir
+  test_write_goes_to_new_path_not_legacy
+  test_read_fallback_to_legacy_when_new_absent
+  test_read_prefers_new_over_legacy
+  test_worktree_write_creates_xdg_dir
+  test_worktree_read_fallback_to_legacy
 
   # prime-cache tests
   echo ""

--- a/plugins/aimi-engineering/skills/story-executor/SKILL.md
+++ b/plugins/aimi-engineering/skills/story-executor/SKILL.md
@@ -236,8 +236,14 @@ If HEADED_MODE is false or absent:
 
 STORY_ID: [STORY_ID]
 
-Your first action is to fetch full story context:
+Your first action is to resolve the CLI path, then fetch full story context.
+
+**Step 0 — Resolve CLI Path** (see [cli-path-resolution.md](../commands/references/cli-path-resolution.md) for full Layer 0–3 strategy).
+Each Bash call is an isolated shell — `$AIMI_CLI` is never inherited. Re-read from cache at the top of every Bash call that needs it:
+
 ```bash
+AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+: "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
 $AIMI_CLI get-story-context [STORY_ID]
 ```
 Parse the returned JSON for two top-level fields:
@@ -359,7 +365,7 @@ All file operations MUST stay within the project boundary: PROJECT_PATH when set
 
 <execution_flow>
 
-0a. **Bootstrap (FIRST ACTION):** Run `$AIMI_CLI get-story-context $STORY_ID` and parse the returned JSON. Extract:
+0a. **Bootstrap (FIRST ACTION):** Re-read `$AIMI_CLI` from cache (per-call re-read — see `<task_pointer>` Step 0 above), then run `$AIMI_CLI get-story-context $STORY_ID` and parse the returned JSON. Extract:
     - `story` — full story object (`id`, `title`, `description`, `acceptanceCriteria`, `notes`, `tasks`, `implementation`, `verification`, `gate`)
     - `metadata` — session metadata (`prototypePaths`, `prototypeAnchor`, `branchName`, etc.)
     If this command fails, report failure immediately and stop.
@@ -475,7 +481,15 @@ If HEADED_MODE is false or absent:
 <task_pointer>
 STORY_ID: [STORY_ID]
 
-First action: run `$AIMI_CLI get-story-context [STORY_ID]` and parse `{story, metadata}` from the returned JSON. If it fails, report failure and stop.
+First action — re-read `$AIMI_CLI` from cache, then fetch story context:
+
+```bash
+AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+: "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
+$AIMI_CLI get-story-context [STORY_ID]
+```
+
+Parse `{story, metadata}` from the returned JSON. If the command fails, report failure and stop.
 </task_pointer>
 
 <prototype_context>
@@ -503,7 +517,7 @@ CRITICAL: Stay within project root. Never read/write outside project boundary. W
 </project_root_boundary>
 
 <execution_flow>
-Bootstrap: run `$AIMI_CLI get-story-context $STORY_ID`, parse `{story, metadata}`. Read prototype files from `metadata.prototypePaths[]` and `story.implementation.prototypeAnchor` via Read tool (log missing, skip). Then follow standard execution flow: read criteria → implement → test → commit. If `story.verification.strategy == "visual"` OR `metadata.prototypePaths` is non-empty or `story.implementation.prototypeAnchor` is set, run the Visual Source-of-Truth Protocol (V1/V2/V3) before writing code. Stage only story-related files (never `-A` or `.`). Commit format: `git commit -m "type(scope): Story title"`. Verify with `git log -1 --oneline`. On commit failure: report immediately, do not retry. Do NOT update tasks file — caller handles status. When a reference artifact is declared, run the Reference-Artifact Parity Pass before committing (see full named section above).
+Bootstrap: re-read `$AIMI_CLI` from cache (per-call re-read one-liner — see `<task_pointer>` above), run `$AIMI_CLI get-story-context $STORY_ID`, parse `{story, metadata}`. Read prototype files from `metadata.prototypePaths[]` and `story.implementation.prototypeAnchor` via Read tool (log missing, skip). Then follow standard execution flow: read criteria → implement → test → commit. If `story.verification.strategy == "visual"` OR `metadata.prototypePaths` is non-empty or `story.implementation.prototypeAnchor` is set, run the Visual Source-of-Truth Protocol (V1/V2/V3) before writing code. Stage only story-related files (never `-A` or `.`). Commit format: `git commit -m "type(scope): Story title"`. Verify with `git log -1 --oneline`. On commit failure: report immediately, do not retry. Do NOT update tasks file — caller handles status. When a reference artifact is declared, run the Reference-Artifact Parity Pass before committing (see full named section above).
 </execution_flow>
 
 <on_failure>

--- a/plugins/aimi-engineering/skills/task-planner/SKILL.md
+++ b/plugins/aimi-engineering/skills/task-planner/SKILL.md
@@ -242,9 +242,19 @@ Branch on `implementationScope` from Phase 0:
 
 After writing the tasks.json file(s), validate each generated output independently.
 
+**Step 0 — Resolve CLI Path** (see [cli-path-resolution.md](../../commands/references/cli-path-resolution.md) for full Layer 0–3 strategy).
+Each Bash call is an isolated shell — `$AIMI_CLI` is never inherited. Re-read from cache at the top of every Bash call that needs it:
+
+```bash
+AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+: "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
+```
+
 **For split files (full-stack):** run validation on each file separately, using `init-session --file` to target each file:
 
 ```bash
+AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+: "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
 $AIMI_CLI init-session --file .aimi/tasks/YYYY-MM-DD-[feature-name]-frontend-tasks.json
 $AIMI_CLI validate-ids
 $AIMI_CLI validate-deps
@@ -259,6 +269,8 @@ $AIMI_CLI validate-stories
 **For single file (frontend-only or legacy):**
 
 ```bash
+AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+: "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
 $AIMI_CLI init-session --file .aimi/tasks/YYYY-MM-DD-[feature-name]-frontend-tasks.json
 $AIMI_CLI validate-ids
 $AIMI_CLI validate-deps


### PR DESCRIPTION
## Summary

Relocates the global CLI cache to a host-agnostic XDG location (`~/.config/aimi/cli-path`) with a read-both fallback during the migration window, and fixes shell-isolation issues by adding a per-call CLI re-read pattern across commands and skills.

Updates `init.md` CACHE_FILE display var, root CLAUDE.md Layer 1 description, and `install.sh` uninstall logic (dry-run + live) to reference the new `~/.config/aimi/cli-path` location; uninstall now removes both the new XDG and legacy `~/.claude/aimi-engineering-cli-path` files. The legacy file is never deleted on read — migration is read-side only.

## Changes

- chore(release): 1.87.0
- refactor(commands): migrate plan/execute/brainstorm to per-call CLI re-read
- refactor(skills): add per-call CLI re-read to story-executor and task-planner
- chore(hooks): allow new XDG cache paths in auto-approve hook
- chore: align legacy CLI cache references with new XDG path
- docs(cli-path): document Per-Call Resolution pattern and failure signature
- refactor(cli): relocate global cache to ~/.config/aimi/ with read-both fallback

## Files Changed

```
 .claude-plugin/marketplace.json                    |   2 +-
 CHANGELOG.md                                       |  18 ++
 CLAUDE.md                                          |   2 +-
 install.sh                                         |  21 +-
 .../aimi-engineering/.claude-plugin/plugin.json    |   2 +-
 plugins/aimi-engineering/commands/brainstorm.md    |  10 +
 plugins/aimi-engineering/commands/execute.md       |  44 ++-
 plugins/aimi-engineering/commands/init.md          |   2 +-
 plugins/aimi-engineering/commands/plan.md          |  20 ++
 .../commands/references/cli-path-resolution.md     |  48 ++-
 plugins/aimi-engineering/hooks/auto-approve-cli.sh |  52 +++-
 plugins/aimi-engineering/scripts/aimi-cli.sh       | 129 ++++++--
 plugins/aimi-engineering/scripts/test-aimi-cli.sh  | 324 ++++++++++++++++++++-
 .../skills/story-executor/SKILL.md                 |  22 +-
 .../aimi-engineering/skills/task-planner/SKILL.md  |  12 +
 15 files changed, 644 insertions(+), 64 deletions(-)
```