### PR TITLE
fix(cli): patch nested dotted paths in update-field without clobbering parent (1.87.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and worktree+team orchestration.",
-      "version": "1.87.0",
+      "version": "1.87.1",
       "author": {
         "name": "Aimi — Autonomous Code Companion",
         "url": "https://github.com/aimi-so"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.87.1] - 2026-05-20
+
+### Fixed
+- `cmd_update_field` was dropping the final segment of a dotted path (e.g., `verification.status` built `.verification` instead of `.verification.status`) because `printf '%s' | sed | while read -r` skips the loop body for the last unterminated segment. Replaced the pipe chain with an `IFS=. read -ra` herestring split that is trailing-newline-safe, so `update-field US-NNN verification.status passed` now patches only the leaf field and preserves all sibling fields on the parent object.
+
 ## [1.87.0] - 2026-05-15
 
 ### Added

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.87.0",
+  "version": "1.87.1",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi — Autonomous Code Companion"

--- a/plugins/aimi-engineering/scripts/aimi-cli.sh
+++ b/plugins/aimi-engineering/scripts/aimi-cli.sh
@@ -2392,8 +2392,14 @@ cmd_update_field() {
   validate_story_exists "$story_id" "$tasks_file"
 
   # Build jq path from dotted notation (e.g., "verification.status" -> .verification.status)
-  local jq_path
-  jq_path=$(printf '%s' "$field_path" | sed 's/\./\n/g' | while read -r part; do printf '.%s' "$part"; done)
+  # IFS-split on a herestring is trailing-newline-safe; avoids read returning non-zero
+  # on the final unterminated segment when piping through sed, which dropped the leaf.
+  local jq_path _parts _p
+  IFS=. read -ra _parts <<< "$field_path"
+  jq_path=''
+  for _p in "${_parts[@]}"; do
+    jq_path+=".$_p"
+  done
 
   local tmp_file
   tmp_file=$(mktemp "${tasks_file}.XXXXXX")

--- a/plugins/aimi-engineering/scripts/test-aimi-cli.sh
+++ b/plugins/aimi-engineering/scripts/test-aimi-cli.sh
@@ -6230,6 +6230,42 @@ test_bundle_prototype_status_view_list_item_shape() {
   rm -rf "$tmp"
 }
 
+test_update_field_nested_path() {
+  echo ""
+  echo "=== Testing update-field: dotted path patches only the leaf field ==="
+
+  reset_fixture
+
+  # Inject a populated verification object onto US-001
+  local veri_fixture
+  veri_fixture=$(jq '.userStories |= map(if .id == "US-001" then . + {"verification": {"strategy": "test", "status": "pending", "url": "http://example.com", "expect": "all green"}} else . end)' "$TASKS_FILE")
+  printf '%s\n' "$veri_fixture" > "$TASKS_FILE"
+
+  # Snapshot sibling fields before the call
+  local pre_strategy pre_url pre_expect
+  pre_strategy=$(jq -r '.userStories[] | select(.id == "US-001") | .verification.strategy' "$TASKS_FILE")
+  pre_url=$(jq -r '.userStories[] | select(.id == "US-001") | .verification.url' "$TASKS_FILE")
+  pre_expect=$(jq -r '.userStories[] | select(.id == "US-001") | .verification.expect' "$TASKS_FILE")
+
+  # Run the update against the dotted path
+  "$CLI" update-field US-001 verification.status passed > /dev/null
+
+  # Assert the leaf changed
+  local post_status
+  post_status=$(jq -r '.userStories[] | select(.id == "US-001") | .verification.status' "$TASKS_FILE")
+  assert_eq "passed" "$post_status" "update-field nested: verification.status updated to passed"
+
+  # Assert siblings were preserved (not clobbered)
+  local post_strategy post_url post_expect
+  post_strategy=$(jq -r '.userStories[] | select(.id == "US-001") | .verification.strategy' "$TASKS_FILE")
+  post_url=$(jq -r '.userStories[] | select(.id == "US-001") | .verification.url' "$TASKS_FILE")
+  post_expect=$(jq -r '.userStories[] | select(.id == "US-001") | .verification.expect' "$TASKS_FILE")
+
+  assert_eq "$pre_strategy" "$post_strategy" "update-field nested: verification.strategy sibling preserved"
+  assert_eq "$pre_url" "$post_url" "update-field nested: verification.url sibling preserved"
+  assert_eq "$pre_expect" "$post_expect" "update-field nested: verification.expect sibling preserved"
+}
+
 # ============================================================================
 # Main
 # ============================================================================
@@ -6431,6 +6467,7 @@ main() {
   test_validate_tasks_backendspec_invented_field
   test_validate_tasks_backendspec_derived_escape_hatch
   test_mark_complete_preserves_new_fields
+  test_update_field_nested_path
 
   # CLI output optimization tests — run with fresh fixture each time
   echo ""


### PR DESCRIPTION
## Summary

`$AIMI_CLI update-field US-NNN verification.status passed` was clobbering the entire `verification` object with the scalar string `"passed"` instead of patching only `verification.status`.

Root cause in `cmd_update_field` (aimi-cli.sh:2394-2396): the path builder piped `printf '%s' "$field_path" | sed 's/\./\n/g'` into `while read -r part`. Because `printf '%s'` emits no trailing newline, the sed output ends without one, and bash's `read` returns non-zero on the final unterminated segment — silently skipping the loop body for it. The leaf segment was dropped, leaving `jq_path=".verification"`, and the subsequent jq assignment overwrote the whole object.

Fixed by replacing the `printf | sed | while read` chain with an `IFS=. read -ra` herestring split, which delivers the full value without depending on `read`'s behavior on unterminated input.

## Changes

- fix(cli): patch nested dotted paths in update-field without clobbering parent (1.87.1)

## Files Changed

```
 .claude-plugin/marketplace.json                    |  2 +-
 CHANGELOG.md                                       |  5 +++
 .../aimi-engineering/.claude-plugin/plugin.json    |  2 +-
 plugins/aimi-engineering/scripts/aimi-cli.sh       | 10 ++++--
 plugins/aimi-engineering/scripts/test-aimi-cli.sh  | 37 ++++++++++++++++++++++
 5 files changed, 52 insertions(+), 4 deletions(-)
```

## Test Plan

- [x] `bash plugins/aimi-engineering/scripts/test-aimi-cli.sh` — 494/494 pass (including new `test_update_field_nested_path`)
- [x] `bash -n plugins/aimi-engineering/scripts/aimi-cli.sh` — clean
- [x] `bash -n plugins/aimi-engineering/scripts/test-aimi-cli.sh` — clean
- [x] Dogfood check: ran `$AIMI_CLI update-field US-001 verification.status passed` against the live tasks file after the fix landed — only `.verification.status` mutated; `strategy` and `expect` retained their pre-call values.

Version bumped to 1.87.1 (PATCH) across `plugin.json`, `marketplace.json`, and `CHANGELOG.md`.