### PR TITLE
fix(cli): detect-interactivity defaults to picker; add --non-interactive flag

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and worktree+team orchestration.",
-      "version": "1.88.0",
+      "version": "1.89.0",
       "author": {
         "name": "Aimi — Autonomous Code Companion",
         "url": "https://github.com/aimi-so"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.89.0] - 2026-05-21
+
+### Added
+
+- `--non-interactive` flag for `/aimi:plan`, `/aimi:brainstorm`, and `/aimi:design:polish`. Pass `--non-interactive` to skip all interactive prompts and auto-defer every Open Question (agent/CI mode). Interactive (`picker`) mode is now the default for all three commands.
+
+### Changed
+
+- `/aimi:plan`, `/aimi:brainstorm`, and `/aimi:design:polish` default to **interactive mode** (`INTERACTIVE_MODE=picker`). Previously these commands could silently fall through to `agent` mode when running in a non-TTY shell (e.g. inside OpenCode's bash tool calls), suppressing all user-facing questions. The bare-TTY fallback in `detect-interactivity` has been removed so a hostless non-TTY shell no longer triggers agent mode.
+- `cmd_detect_interactivity` in `aimi-cli.sh` now returns `picker` as the default. Agent mode is reached only through explicit opt-out: `--non-interactive` flag, `AIMI_AGENT_MODE=true`, or `CI=true`.
+
+### Fixed
+
+- OpenCode agent-mode misclassification: `detect-interactivity` previously returned `agent` for OpenCode sessions because OpenCode runs bash tool calls in a non-TTY shell and does not export `OPENCODE_CONFIG_DIR` in that context, causing the TTY fallback (step 6) to fire. Removing the bare-TTY fallback ensures the command correctly defaults to `picker` on OpenCode.
+
 ## [1.88.0] - 2026-05-21
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ The `AIMI_PLUGIN_DIR` environment variable points to the installed plugin direct
 
 | Command | Description | Usage |
 |---------|-------------|-------|
-| `/aimi:brainstorm` | Explore ideas through guided brainstorming | `/aimi:brainstorm [feature]` |
-| `/aimi:plan` | Generate tasks.json directly from feature description | `/aimi:plan [feature]` |
+| `/aimi:brainstorm` | Explore ideas through guided brainstorming | `/aimi:brainstorm [feature] [--non-interactive]` |
+| `/aimi:plan` | Generate tasks.json directly from feature description | `/aimi:plan [feature] [--non-interactive]` |
 | `/aimi:deepen` | Enrich tasks.json stories with research insights | `/aimi:deepen [tasks-path]` |
 | `/aimi:status` | Show current task execution progress | `/aimi:status` |
 | `/aimi:next` | Execute the next pending story | `/aimi:next` |
@@ -127,18 +127,20 @@ The `AIMI_PLUGIN_DIR` environment variable points to the installed plugin direct
 
 #### `/aimi:brainstorm`
 
-Standalone brainstorm workflow with codebase research and Ralph-style batched multiple-choice questions. Explores requirements and approaches interactively before committing to implementation.
+Standalone brainstorm workflow with codebase research and Ralph-style batched multiple-choice questions. Explores requirements and approaches interactively before committing to implementation. Pass `--non-interactive` to skip all prompts and auto-defer open questions (agent/CI mode).
 
 ```bash
 /aimi:brainstorm Add social login with Google and GitHub
+/aimi:brainstorm Add social login --non-interactive
 ```
 
 #### `/aimi:plan`
 
-Generates `.aimi/tasks/YYYY-MM-DD-[feature]-tasks.json` directly from a feature description. Runs a full pipeline: brainstorm detection, parallel research (codebase + learnings), optional external research, spec-flow analysis, and story decomposition. Stories are decomposed as vertical slices — each delivers user-visible value end-to-end across all layers rather than being split by horizontal layer boundaries.
+Generates `.aimi/tasks/YYYY-MM-DD-[feature]-tasks.json` directly from a feature description. Runs a full pipeline: brainstorm detection, parallel research (codebase + learnings), optional external research, spec-flow analysis, and story decomposition. Stories are decomposed as vertical slices — each delivers user-visible value end-to-end across all layers rather than being split by horizontal layer boundaries. Interactive by default — pass `--non-interactive` to skip all Open Question prompts and auto-defer them (agent/CI mode).
 
 ```bash
 /aimi:plan Add user registration flow
+/aimi:plan Add user registration flow --non-interactive
 ```
 
 Output:
@@ -213,7 +215,7 @@ Multi-agent code review using aimi-native review agents. Runs parallel agents (a
 
 ## Skills
 
-15 skills providing domain expertise and reusable workflows.
+17 skills providing domain expertise and reusable workflows.
 
 ### Core (Internal)
 
@@ -235,6 +237,8 @@ Used internally by commands — not user-invocable.
 | `frontend-design` | Create distinctive, production-grade frontend interfaces |
 | `every-style-editor` | Review and edit copy for Every's editorial style compliance |
 | `agent-native-architecture` | Build apps where agents are first-class citizens |
+| `react-best-practices` | React and Next.js performance optimization guidelines from Vercel Engineering |
+| `react-native-skills` | React Native and Expo best practices for performant mobile apps |
 
 ### Tooling & Automation
 
@@ -586,7 +590,7 @@ For the full version history, see [CHANGELOG.md](CHANGELOG.md).
 | Type | Count | Description |
 |------|-------|-------------|
 | Commands | 15 | Slash commands for workflow stages |
-| Skills | 16 | 3 core, 6 development/style, 4 tooling/automation, 3 disabled/reference |
+| Skills | 17 | 3 core, 8 development/style, 4 tooling/automation, 2 disabled/reference |
 | Agents | 25 | 6 research, 15 review, 2 design, 2 workflow |
 
 ## License

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.88.0",
+  "version": "1.89.0",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi — Autonomous Code Companion"

--- a/plugins/aimi-engineering/commands/brainstorm.md
+++ b/plugins/aimi-engineering/commands/brainstorm.md
@@ -1,7 +1,7 @@
 ---
 name: aimi:brainstorm
 description: Explore ideas through guided brainstorming with batched questions and codebase research
-argument-hint: "[feature description]"
+argument-hint: "[feature description] [--non-interactive]"
 allowed-tools: Read, Glob, Grep, AskUserQuestion, Task, Write, Bash($AIMI_CLI:*)
 ---
 
@@ -13,7 +13,9 @@ Clarify **WHAT** to build through collaborative dialogue before planning **HOW**
 
 <feature_description> $ARGUMENTS </feature_description>
 
-**If the feature description above is empty, ask the user:** "What would you like to explore? Describe the feature, problem, or improvement you're thinking about."
+> Note: the `--non-interactive` token (if present in `$ARGUMENTS`) is stripped from the feature description in Step 0.5 before any prompt or research uses it.
+
+**If the feature description above is empty (after stripping `--non-interactive`), ask the user:** "What would you like to explore? Describe the feature, problem, or improvement you're thinking about."
 
 Do not proceed until you have a feature description from the user.
 
@@ -30,22 +32,43 @@ INTERACTIVE_MODE=picker`.
 
 ## Step 0.5: Resolve Interactivity Mode
 
-Before any question is presented, resolve which mode applies:
+Before any question is presented, resolve which mode applies.
+
+**Scan `$ARGUMENTS` for the `--non-interactive` token** (whitespace-delimited,
+case-sensitive). When present:
+
+1. Strip it from the working copy of the feature description so it is not
+   treated as part of the feature being brainstormed.
+2. Forward it to the `detect-interactivity` call so agent mode is explicitly
+   engaged.
 
 ```bash
 AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
 : "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
-INTERACTIVE_MODE=$($AIMI_CLI detect-interactivity)
+# Detect --non-interactive token (whitespace-delimited, case-sensitive)
+case " $ARGUMENTS " in
+  *" --non-interactive "*) NON_INTERACTIVE_FLAG="--non-interactive" ;;
+  *)                        NON_INTERACTIVE_FLAG="" ;;
+esac
+# Strip the token from the feature description before any downstream use
+FEATURE_DESCRIPTION=$(echo "$ARGUMENTS" | sed 's/\(^\| \)--non-interactive\( \|$\)/ /g' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+# Resolve mode; picker is the default
+INTERACTIVE_MODE=$($AIMI_CLI detect-interactivity $NON_INTERACTIVE_FLAG)
 ```
+
+Use `$FEATURE_DESCRIPTION` (not `$ARGUMENTS`) in all subsequent phases where
+the feature description is consumed (research prompts, topic-slug derivation,
+path-hint extraction, etc.).
 
 The result is one of:
 
-- `picker` — interactive user. All question sites below use **AskUserQuestion**
+- `picker` — **default**. All question sites below use **AskUserQuestion**
   (Claude Code) or the native `question` tool (OpenCode, wired by the
   translator). One question per tool call, lettered options.
-- `agent` — `AIMI_AGENT_MODE=true`, `CI=true`, or non-TTY. At every question
-  site, auto-pick the first non-escape option and log one line into the
-  brainstorm document's working memory. Never block, never prompt.
+- `agent` — reached only via **explicit opt-out**: `--non-interactive` flag,
+  `AIMI_AGENT_MODE=true`, or `CI=true`. At every question site, auto-pick the
+  first non-escape option and log one line into the brainstorm document's
+  working memory. Never block, never prompt.
 
 See `references/interactivity.md` for the full contract. Every question site
 below includes an agent-mode fallback note describing its specific auto-pick
@@ -179,7 +202,7 @@ error, no warning, no change to existing behavior.
 
 | Variable | Value | Effect |
 |----------|-------|--------|
-| `AIMI_AGENT_MODE` | `true` | Non-interactive fallback — auto-selects Variant A at every picker site, never blocks. Detected by `aimi-cli detect-interactivity` and reflected in `INTERACTIVE_MODE=agent`. |
+| `AIMI_AGENT_MODE` | `true` | Non-interactive fallback — auto-selects Variant A at every picker site, never blocks. Detected by `aimi-cli detect-interactivity` and reflected in `INTERACTIVE_MODE=agent`. Prefer passing `--non-interactive` to the command directly; this env var is a secondary escape hatch for automation where flag injection is not possible. |
 | `AIMI_BRAINSTORM_DEBUG` | `1` | Opt-in diagnostic output. When set, the agent emits a `[brainstorm-debug] <context>: <value>` line to chat at each decision point: topic-slug derivation, per-question category classification, browser-attempt result, and variant-selection picker result. Unset (or any value other than `1`) produces no diagnostic output. |
 
 Diagnostic lines are prefixed with `[brainstorm-debug]` so they are trivially greppable and visually distinct from normal output. They are emitted **to chat only** — never written to the brainstorm document or research files.

--- a/plugins/aimi-engineering/commands/design/polish.md
+++ b/plugins/aimi-engineering/commands/design/polish.md
@@ -1,22 +1,70 @@
 ---
 name: aimi:design:polish
 description: Final-pass polish for frontend interfaces — catches the small details that separate good work from great work. Use after a feature is functionally complete and you want to align it to the design system, fix visual inconsistencies, and bring everything to a consistent quality level.
-argument-hint: "[target: file, component path, or feature area]"
-allowed-tools: Read, Write, Edit, Bash(find:*), Bash(ls:*), Task
+argument-hint: "[target: file, component path, or feature area] [--non-interactive]"
+allowed-tools: Read, Write, Edit, Bash(find:*), Bash(ls:*), Bash(AIMI_CLI=*), Bash($AIMI_CLI:*), Task
 disable-model-invocation: false
 ---
-
-> **Soft context**: Ask the user for the quality bar (MVP vs flagship) if not clear from context.
 
 # Aimi Design Polish
 
 Perform a meticulous final pass to catch all the small details that separate good work from great work. The difference between shipped and polished.
 
+## Step 0: Environment Setup
+
+### Resolve CLI Path
+
+Read `${CLAUDE_PLUGIN_ROOT}/commands/references/cli-path-resolution.md` and follow the **Resolve CLI Path** and **Version Check** sections to set `$AIMI_CLI`. Each layer is a separate Bash call.
+
+If resolution fails, fall back to a default of `INTERACTIVE_MODE=picker` and log: `warning: aimi-cli.sh unresolved — forcing INTERACTIVE_MODE=picker`.
+
+**Each Bash tool call is an isolated shell — `$AIMI_CLI` does not persist.** Re-read the cache at the top of every subsequent Bash call that needs `$AIMI_CLI`. See the **Per-Call Resolution** section of `commands/references/cli-path-resolution.md` for the one-liner and shell guard to prepend.
+
+### Extract --non-interactive Flag
+
+Before using `$ARGUMENTS` as a polish target, check whether the user passed `--non-interactive`:
+
+```bash
+NON_INTERACTIVE_FLAG=""
+case "$ARGUMENTS" in
+  *--non-interactive*)
+    NON_INTERACTIVE_FLAG="--non-interactive"
+    ;;
+esac
+```
+
+Strip the token from `$ARGUMENTS` so it is not treated as a target path:
+
+```bash
+POLISH_TARGET=$(echo "$ARGUMENTS" | sed 's/--non-interactive//g' | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//')
+```
+
+Use `$POLISH_TARGET` wherever `$ARGUMENTS` would have been used as the polish target for the rest of this command.
+
+### Detect Interactivity
+
+```bash
+AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+: "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
+INTERACTIVE_MODE=$($AIMI_CLI detect-interactivity $NON_INTERACTIVE_FLAG)
+```
+
+- `picker` — interactive user. Present questions using **AskUserQuestion** (one per tool call).
+- `agent` — `--non-interactive`, `AIMI_AGENT_MODE=true`, or `CI=true`. At every question site, auto-pick the documented default and log one line. Never block, never prompt.
+
+See `references/interactivity.md` for the full contract.
+
+> **Soft context**: Ask the user for the quality bar (MVP vs flagship) if not clear from context.
+>
+> *Agent-mode fallback: if `INTERACTIVE_MODE=agent`, infer the quality bar from surrounding code context (commit messages, design-system tier, existing component polish level) and proceed without asking. Log: `agent-mode: quality-bar auto-inferred from codebase context`.*
+
 ## Target
 
-$ARGUMENTS
+$POLISH_TARGET
 
 If no target is specified, ask the user what to polish before proceeding.
+
+*Agent-mode fallback: if `INTERACTIVE_MODE=agent` and `$POLISH_TARGET` is empty, abort with: `agent-mode: no polish target specified and --non-interactive set — provide a target path or feature area`. If `$POLISH_TARGET` is non-empty, proceed with it as-is without asking for confirmation. Log: `agent-mode: target auto-accepted: $POLISH_TARGET`.*
 
 **CRITICAL**: Polish is the last step, not the first. Don't polish work that's not functionally complete.
 

--- a/plugins/aimi-engineering/commands/plan.md
+++ b/plugins/aimi-engineering/commands/plan.md
@@ -1,7 +1,7 @@
 ---
 name: aimi:plan
 description: Generate tasks.json directly from a feature description
-argument-hint: "[feature description]"
+argument-hint: "[feature description] [--non-interactive]"
 allowed-tools: Read, Write, Edit, Bash(git:*), Bash(mkdir:*), Bash(AIMI_CLI=*), Bash($AIMI_CLI:*), Task
 ---
 
@@ -9,9 +9,11 @@ allowed-tools: Read, Write, Edit, Bash(git:*), Bash(mkdir:*), Bash(AIMI_CLI=*), 
 
 Generate `.aimi/tasks/YYYY-MM-DD-[feature]-tasks.json` directly from a feature description. Full pipeline: research, spec analysis, story decomposition, JSON output. No intermediate markdown plan.
 
+By default, `/aimi:plan` runs in interactive mode — Open Question gates (Phase 0.5, Phase 1.8, Phase 2.5) present `AskUserQuestion` prompts. Pass `--non-interactive` to skip all prompts and auto-defer every Open Question (agent/CI mode).
+
 ## Feature Description
 
-$ARGUMENTS
+The planning input is `$ARGUMENTS` with the `--non-interactive` token removed (see Step 0 below).
 
 ## Step 0: Environment Setup
 
@@ -50,13 +52,32 @@ Use the output as the default branch for `branchName` derivation in Phase 4.
 
 ### Detect Interactivity
 
+Interactive (picker) mode is the default. Pass `--non-interactive` to `/aimi:plan` to explicitly opt out of all Open Question prompts and auto-defer them instead (agent/CI mode).
+
+Before calling the CLI, scan `$ARGUMENTS` for the whitespace-delimited token `--non-interactive` (case-sensitive, exact match). When present:
+- Strip it from the feature description text — store the cleaned version as `FEATURE_DESCRIPTION` for use in all downstream steps (topic slug derivation, research agent prompts, `metadata.title`). The raw `$ARGUMENTS` string is NOT used after this point.
+- Forward the flag to the CLI call.
+
+When absent, `FEATURE_DESCRIPTION` equals `$ARGUMENTS` unchanged.
+
 ```bash
 AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
 : "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
-INTERACTIVE_MODE=$($AIMI_CLI detect-interactivity)
+# Extract --non-interactive flag and strip it from the feature description
+case " $ARGUMENTS " in
+  *" --non-interactive "*)
+    NON_INTERACTIVE_FLAG="--non-interactive"
+    FEATURE_DESCRIPTION=$(echo "$ARGUMENTS" | sed 's/[[:space:]]*--non-interactive[[:space:]]*/  /g' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+    ;;
+  *)
+    NON_INTERACTIVE_FLAG=""
+    FEATURE_DESCRIPTION="$ARGUMENTS"
+    ;;
+esac
+INTERACTIVE_MODE=$($AIMI_CLI detect-interactivity $NON_INTERACTIVE_FLAG)
 ```
 
-Store `INTERACTIVE_MODE` for use by Phase 0.5, Phase 1.8, and Phase 2.5 to decide whether to present AskUserQuestion prompts or auto-defer open questions.
+Store `INTERACTIVE_MODE` for use by Phase 0.5, Phase 1.8, and Phase 2.5 to decide whether to present AskUserQuestion prompts or auto-defer open questions. Use `FEATURE_DESCRIPTION` (not `$ARGUMENTS`) everywhere a feature description string is needed from this point forward.
 
 ## Phase 0: Idea Refinement
 

--- a/plugins/aimi-engineering/commands/references/interactivity.md
+++ b/plugins/aimi-engineering/commands/references/interactivity.md
@@ -9,22 +9,36 @@ in one of two modes, resolved once per invocation and stored as
 Call `$AIMI_CLI detect-interactivity` once at the top of the command. It prints
 exactly one of: `picker`, `agent`.
 
-Precedence (first match wins):
+**Picker is the default.** The function returns `agent` only when explicitly told
+to via one of the three agent-mode signals below (explicit opt-out only):
 
-1. `AIMI_AGENT_MODE=true` → `agent` (explicit opt-out always wins)
-2. `CI=true` → `agent`
-3. `CLAUDECODE=1` → `picker` (Claude Code provides `AskUserQuestion`)
-4. `OPENCODE_CONFIG_DIR` is set → `picker` (OpenCode provides the `question` tool)
-5. stdin is a TTY → `picker`
-6. Otherwise → `agent`
+| Signal | Result |
+|---|---|
+| `--non-interactive` flag passed to the CLI | `agent` |
+| `AIMI_AGENT_MODE=true` | `agent` |
+| `CI=true` | `agent` |
+| _(everything else)_ | `picker` |
 
-Steps 3 and 4 deliberately ignore TTY state. Both hosts run command bash bodies
-in a subshell without a controlling terminal, but a host-level picker is fully
-available — relying on `[ -t 0 ]` alone would misclassify every Claude Code and
-OpenCode invocation as non-interactive.
+The old `[ -t 0 ]` TTY-test branch is removed. A non-TTY shell (e.g. an OpenCode
+bash-tool invocation without `CLAUDECODE` or `OPENCODE_CONFIG_DIR` exported)
+is **not** a signal for agent mode — it correctly resolves to `picker` so Open
+Questions are presented rather than silently auto-deferred.
 
 Do not re-implement this logic inline. Use the CLI so the rule stays in one
 place and is covered by `test-aimi-cli.sh`.
+
+### `--non-interactive` flag
+
+Pass `--non-interactive` to `detect-interactivity` when a command explicitly
+opts out of interactive prompts (e.g. when the user passes `--non-interactive`
+to the command itself, or when the command is driven from automation):
+
+```bash
+INTERACTIVE_MODE=$($AIMI_CLI detect-interactivity --non-interactive)
+```
+
+This is the preferred way to force agent mode from a command; it does not
+require callers to export environment variables.
 
 ## Picker Mode
 
@@ -56,8 +70,8 @@ either host. If a question needs multiple answers, emit multiple picker calls.
 
 ## Agent Mode
 
-Non-interactive context (`AIMI_AGENT_MODE=true`, `CI=true`, or no TTY). Never
-block, never prompt. At every question site:
+Explicit opt-out: `--non-interactive` flag, `AIMI_AGENT_MODE=true`, or `CI=true`.
+Never block, never prompt. At every question site:
 
 1. Auto-select the first non-escape option (option A).
 2. Log exactly one line into the command's output artifact (brainstorm

--- a/plugins/aimi-engineering/scripts/aimi-cli.sh
+++ b/plugins/aimi-engineering/scripts/aimi-cli.sh
@@ -1844,30 +1844,29 @@ cmd_bundle_prototype_finalize() {
 #   picker - explicit host picker is available (Claude Code or OpenCode), OR
 #            stdin is a TTY in a plain terminal
 #
-# Precedence (first match wins):
-#   1. AIMI_AGENT_MODE=true → agent  (explicit opt-out always wins)
-#   2. CI=true              → agent
-#   3. CLAUDECODE=1         → picker (AskUserQuestion is available)
-#   4. OPENCODE_CONFIG_DIR  → picker (OpenCode `question` tool is available)
-#   5. stdin is a TTY       → picker
-#   6. otherwise            → agent
+# Precedence (first match wins — explicit opt-out only):
+#   1. --non-interactive flag → agent
+#   2. AIMI_AGENT_MODE=true  → agent
+#   3. CI=true               → agent
+#   4. otherwise             → picker
 #
-# Hosts 3 and 4 deliberately ignore TTY state: their Bash tools run without a
-# controlling terminal, but a host-level picker is fully available.
+# The old TTY-test branch ([ -t 0 ]) and the CLAUDECODE/OPENCODE_CONFIG_DIR
+# host-check block are removed. A non-TTY shell is NOT a signal for agent mode;
+# picker is the safe default so commands always surface Open Questions unless
+# explicitly told not to.
 cmd_detect_interactivity() {
-  if [ "${AIMI_AGENT_MODE:-}" = "true" ] || [ "${CI:-}" = "true" ]; then
+  local non_interactive=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --non-interactive) non_interactive=1 ;;
+    esac
+    shift
+  done
+  if [ "$non_interactive" = "1" ] || [ "${AIMI_AGENT_MODE:-}" = "true" ] || [ "${CI:-}" = "true" ]; then
     echo "agent"
     return
   fi
-  if [ "${CLAUDECODE:-}" = "1" ] || [ -n "${OPENCODE_CONFIG_DIR:-}" ]; then
-    echo "picker"
-    return
-  fi
-  if [ -t 0 ]; then
-    echo "picker"
-  else
-    echo "agent"
-  fi
+  echo "picker"
 }
 
 # Setup branch: deterministic branch creation/checkout logic
@@ -3032,9 +3031,10 @@ COMMANDS:
     get-state                 Get all state files as JSON
     detect-default-branch [--project <path>]
                               Detect and cache the repository's default branch
-    detect-interactivity      Print resolved interactivity mode (picker|agent)
-                              Reads AIMI_AGENT_MODE, CI, and TTY status; used by
-                              commands to branch picker vs. auto-pick-first behavior
+    detect-interactivity [--non-interactive]
+                              Print resolved interactivity mode (picker|agent)
+                              Returns picker by default; returns agent only when
+                              --non-interactive is passed, AIMI_AGENT_MODE=true, or CI=true
     setup-branch <name> --default-branch <branch> [--project <path>]
                               Create or checkout branch with deterministic logic
     clear-state               Clear all state files
@@ -3142,7 +3142,7 @@ main() {
   case "${1:-help}" in
     help|--help|-h) cmd_help; return ;;
     version) cmd_version; return ;;
-    detect-interactivity) cmd_detect_interactivity; return ;;
+    detect-interactivity) shift; cmd_detect_interactivity "$@"; return ;;
     prime-cache) cmd_prime_cache; return ;;
   esac
 

--- a/plugins/aimi-engineering/scripts/test-aimi-cli.sh
+++ b/plugins/aimi-engineering/scripts/test-aimi-cli.sh
@@ -5558,12 +5558,35 @@ test_detect_interactivity_non_tty() {
   echo ""
   echo "=== Testing detect-interactivity with non-TTY stdin and no host indicators ==="
 
-  # Clear all host indicators to test the bare-shell fallback. Redirecting stdin
-  # from /dev/null makes it not a TTY.
+  # No host indicators, non-TTY stdin. With the TTY fallback removed, the
+  # function should now return picker (safe default).
   local output
   output=$(AIMI_AGENT_MODE= CI= CLAUDECODE= OPENCODE_CONFIG_DIR= "$CLI" detect-interactivity </dev/null)
 
-  assert_eq "agent" "$output" "detect-interactivity returns 'agent' when stdin is not a TTY and no host picker is available"
+  assert_eq "picker" "$output" "detect-interactivity returns 'picker' when stdin is not a TTY and no host indicators are set (picker-by-default)"
+}
+
+test_detect_interactivity_non_interactive_flag() {
+  echo ""
+  echo "=== Testing detect-interactivity --non-interactive flag ==="
+
+  local output
+  output=$(AIMI_AGENT_MODE= CI= CLAUDECODE= OPENCODE_CONFIG_DIR= "$CLI" detect-interactivity --non-interactive </dev/null)
+
+  assert_eq "agent" "$output" "detect-interactivity returns 'agent' when --non-interactive flag is passed"
+}
+
+test_detect_interactivity_opencode_shell_sim() {
+  echo ""
+  echo "=== Testing detect-interactivity: OpenCode shell simulation (no host env vars, non-TTY) ==="
+
+  # Reproduces the exact OpenCode bash-tool condition: no CLAUDECODE, no
+  # OPENCODE_CONFIG_DIR, no CI, no AIMI_AGENT_MODE, stdin is not a TTY.
+  # Previously the bare-TTY fallback returned agent here; now it must return picker.
+  local output
+  output=$(AIMI_AGENT_MODE= CI= CLAUDECODE= OPENCODE_CONFIG_DIR= "$CLI" detect-interactivity </dev/null)
+
+  assert_eq "picker" "$output" "detect-interactivity returns 'picker' in OpenCode shell simulation (no host env vars, non-TTY stdin)"
 }
 
 test_detect_interactivity_claudecode_host() {
@@ -6515,6 +6538,8 @@ main() {
   test_detect_interactivity_non_tty
   test_detect_interactivity_claudecode_host
   test_detect_interactivity_opencode_host
+  test_detect_interactivity_non_interactive_flag
+  test_detect_interactivity_opencode_shell_sim
 
   # Design bundle detection tests
   echo ""

--- a/plugins/aimi-engineering/skills/task-planner/references/pipeline-phases.md
+++ b/plugins/aimi-engineering/skills/task-planner/references/pipeline-phases.md
@@ -47,7 +47,7 @@ After the brainstorm check, determine the implementation scope:
 
 ### Pipeline Mode (Non-Interactive)
 
-If running in a `disable-model-invocation` context or automated pipeline:
+When `INTERACTIVE_MODE=agent` (set by `/aimi:plan --non-interactive`, `AIMI_AGENT_MODE=true`, or `CI=true`):
 - Skip all AskUserQuestion calls
 - Use the feature description as-is
 - Auto-select the most recent matching brainstorm if available


### PR DESCRIPTION
## Summary

Fixes a bug where planning and brainstorming silently auto-deferred every human decision when run inside OpenCode. The CLI's `detect-interactivity` resolved to `agent` whenever stdin was not a TTY — and OpenCode runs command bash bodies in a non-TTY shell without exporting `OPENCODE_CONFIG_DIR`, so the host check could not fire and the bare-TTY fallback misclassified a present, available human as "no human".

The fix flips the default. `detect-interactivity` now returns `picker` unless a caller explicitly opts out — `agent` is reached only via the new `--non-interactive` flag, `CI=true`, or `AIMI_AGENT_MODE=true`. The bare-TTY fallback is removed entirely. The `--non-interactive` flag is wired into `/aimi:plan`, `/aimi:brainstorm`, and `/aimi:design:polish` as the explicit, human-controlled way to run autonomously. Brainstorm and plan are inherently collaborative phases — interactive is now the correct default, and suppressing decisions is something you opt into, never the fallback.

Verified on the integrated branch: the exact OpenCode failure condition (no host env vars, non-TTY stdin) now returns `picker`; `--non-interactive` returns `agent`. Full CLI test suite: 496 passed, 0 failed.

## Changes

- fix(cli): detect-interactivity defaults to picker; add --non-interactive flag
- feat(commands): add --non-interactive flag to /aimi:plan
- feat(commands): add --non-interactive flag to /aimi:brainstorm
- feat(commands): add --non-interactive flag to /aimi:design:polish
- chore(release): 1.89.0 — default-interactive planning + --non-interactive flag

## Files Changed

```
 .claude-plugin/marketplace.json                    |  2 +-
 CHANGELOG.md                                       | 15 ++++++
 README.md                                          | 16 +++---
 .../aimi-engineering/.claude-plugin/plugin.json    |  2 +-
 plugins/aimi-engineering/commands/brainstorm.md    | 41 +++++++++++----
 plugins/aimi-engineering/commands/design/polish.md | 58 ++++++++++++++++++++--
 plugins/aimi-engineering/commands/plan.md          | 29 +++++++++--
 .../commands/references/interactivity.md           | 40 ++++++++++-----
 plugins/aimi-engineering/scripts/aimi-cli.sh       | 46 ++++++++---------
 plugins/aimi-engineering/scripts/test-aimi-cli.sh  | 31 ++++++++++--
 .../task-planner/references/pipeline-phases.md     |  2 +-
 11 files changed, 216 insertions(+), 66 deletions(-)
```

## Test Plan

- `bash plugins/aimi-engineering/scripts/test-aimi-cli.sh` — 496 passed, 0 failed
- `./install.sh --to opencode --dry-run` — clean, plan/brainstorm/polish translate with the flag logic intact
- `detect-interactivity` manual checks: hostless non-TTY shell → `picker`; `--non-interactive` → `agent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)