### PR TITLE
feat: proactive prototyping offer when a frontend is a roadmap deliverable (issue #55)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and worktree+team orchestration.",
-      "version": "1.105.0",
+      "version": "1.106.0",
       "author": {
         "name": "Aimi — Autonomous Code Companion",
         "url": "https://github.com/aimi-so"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.106.0] - 2026-07-23
+
+### Added
+
+- **Proactive Prototype Offer Gate in `/aimi:brainstorm` (Phase 3.6, issue #55).** Brainstorm now checks whether the drafted roadmap ships a frontend by inspecting **structural** roadmap deliverables — phase `creates` entries, `areas`, and the feature `goal` — rather than relying on the free-text description alone. This closes the gap where a backend-worded description ("add an endpoint for X") still ships a UI and previously skipped prototyping silently. When a frontend deliverable is detected and no prototype exists yet, brainstorm offers a three-option gate: **[Prototipar]** (launch guided prototype creation), **[Tenho uma referência]** (Reference Intake — see below), or **[Pular]** (skip, proceeding without a prototype). The gate only fires once per brainstorm session and never blocks progress.
+- **Reference Intake flow.** When the user has an existing reference instead of wanting a prototype built from scratch, brainstorm accepts a local image, HTML/CSS file, a URL, or free-text description of the look-and-feel, and feeds the extracted visual tokens (colors, spacing, component shapes, copy tone) into the design pipeline as **Probe #0** — a seed probe that subsequent design exploration builds on rather than starting from a blank slate.
+- **`plugins/aimi-engineering/commands/references/ui-signals.md`.** A new shared reference unifying the vocabulary used to detect "this feature has a UI" across commands: the keyword list (visual/UI-bearing terms) and the structural markers (roadmap `creates`/`areas`/`goal` patterns that imply a frontend). Both `/aimi:brainstorm` and `/aimi:plan` now source their frontend detection from this single file instead of maintaining separate, drifting keyword lists.
+
+### Changed
+
+- **`/aimi:brainstorm` Phase 1.7** now sources its keyword list from `ui-signals.md` instead of an inline list. The keyword scan is kept as an additive signal alongside the new structural check, and its vocabulary was extended with `frontend` and common framework names (React, Vue, Next.js, etc.) so more real-world descriptions are caught.
+- **`/aimi:plan`** now emits a non-blocking warning when a frontend-bearing feature reaches the end of planning with no prototype on record, surfacing the same structural signal used by the brainstorm gate so features planned without going through `/aimi:brainstorm` first still get a nudge — the warning never stops or fails planning.
+
 ## [1.105.0] - 2026-07-21
 
 ### Added

--- a/install.sh
+++ b/install.sh
@@ -213,6 +213,12 @@ translate_command_body() {
   # The aimi-cli story-merge invocation (Phase 3e) uses the standard per-call
   # AIMI_CLI resolution and requires no additional translation — the CLI-path
   # rewrite above handles the path, and the subcommand name is preserved verbatim.
+  #
+  # Coverage re-verified (US-006): brainstorm.md's Phase 3.6 Prototype Offer
+  # Gate picker ("Present via **AskUserQuestion** (picker mode)" / "Skip
+  # AskUserQuestion entirely") is fully covered by the existing four rules
+  # below — no new rule was needed. Any future picker phrased the same way is
+  # covered automatically by the bare-token catch-all (last rule below).
   body="${body//Use \*\*AskUserQuestion\*\*/Use the **question** tool}"
   body="${body//Use AskUserQuestion/Use the question tool}"
   body="${body//via AskUserQuestion/via the question tool}"
@@ -421,6 +427,11 @@ install_plugin_source() {
 
   mkdir -p "$plugin_dst"
   # Copy everything except .git
+  # This is a whole-tree copy, not a per-file allowlist: commands/references/*.md
+  # (cli-path-resolution.md, scope-contexts.md, ui-signals.md, visual-variants.md, ...)
+  # is carried verbatim by this cp -R with no code change needed when new reference
+  # files are added — install_commands' subdirectory loops deliberately skip
+  # "references" (see below) because this copy already delivers them (verified US-006).
   cp -R "$src/." "$plugin_dst/"
 
   # Ensure scripts are executable

--- a/install.sh
+++ b/install.sh
@@ -106,7 +106,10 @@ backup_file() {
       log "[dry-run] Would backup $path -> $bak"
     else
       cp "$path" "$bak"
-      [ "$VERBOSE" -eq 1 ] && log "Backed up $path -> $bak"
+      # Use an explicit if (not `[ ... ] && log`): as the function's last
+      # statement, a bare `&&` test returns 1 when VERBOSE=0, which aborts the
+      # caller under `set -euo pipefail`. An if returns 0 when the test is false.
+      if [ "$VERBOSE" -eq 1 ]; then log "Backed up $path -> $bak"; fi
     fi
   fi
 }

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.105.0",
+  "version": "1.106.0",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi — Autonomous Code Companion"

--- a/plugins/aimi-engineering/commands/brainstorm.md
+++ b/plugins/aimi-engineering/commands/brainstorm.md
@@ -430,9 +430,7 @@ Before generating questions, review the research output from Phase 1.
 
 ## Phase 1.7: UI Feature Detection
 
-Scan the feature description for visual/UI keywords using case-insensitive whole-word matching (regex word boundaries `\b`).
-
-**Keyword list:** page, modal, dashboard, form, component, layout, ui, design
+Scan the feature description for visual/UI keywords using the "Keyword Signals" section of `${CLAUDE_PLUGIN_ROOT}/commands/references/ui-signals.md` — read that file and apply its keyword list and case-insensitive whole-word matching rule (regex word boundaries `\b`) as written; the keyword vocabulary is defined there and should not be restated inline here.
 
 **Co-occurrence rule:** The keyword "design" alone does not trigger detection — it requires co-occurrence with at least one other keyword from the list. This prevents false positives from phrases like "system design" or "API design."
 

--- a/plugins/aimi-engineering/commands/brainstorm.md
+++ b/plugins/aimi-engineering/commands/brainstorm.md
@@ -1035,6 +1035,53 @@ Once Approve is accepted with zero orphans, check the final phase count:
 
 Pass the final approved `phases` array (2 or more entries) to Phase 4, which sanitizes and emits it as the `phases:` frontmatter key — see "phases frontmatter rules" under Phase 4 below.
 
+## Phase 3.6: Prototype Offer Gate
+
+This is a **gate**, not a roadmap phase. It produces at most one in-conversation design artifact — a prototype HTML persisted through the existing Visual Variant Rendering machinery — and it never writes to the in-memory `phases[]` array or to any file under `.aimi/tasks/`. Nothing in this section materializes a roadmap phase or a task file.
+
+### Step 1: Fire-Condition Check
+
+The gate fires only when **both** of the following hold:
+
+1. **`prototype_entries` is empty.** If an entry already exists — from a Phase 2 Aesthetic Direction/Differentiation question (Visual Variant Rendering Step 7) or from the bundle early-exit (Step 0a above) — skip this entire phase: emit no log line, present no offer, proceed straight to Phase 4.
+2. **A ui-signals.md signal is present**, checked in this order:
+   - **Primary — Structural Signal:** When Phase 3.5 ran (2 or more scope contexts, so an approved in-memory `phases[]` array exists), scan every phase's `creates`, `areas`, and `goal` fields against the Structural Signals defined in `${CLAUDE_PLUGIN_ROOT}/commands/references/ui-signals.md` (file-extension, path-segment, and lexical markers). Apply that file's rules as written — do not restate them here. The first phase that matches becomes the "matched phase" named in the offer below.
+   - **Fallback — Phase 1.7 fired without a prototype:** When Phase 3.5 was skipped entirely (0 or 1 scope contexts, Phase 3.5 Step 1 — no `phases[]` array was ever built), check instead whether Phase 1.7 (UI Feature Detection) marked the feature UI-relevant. If it did, and `prototype_entries` is still empty, this fallback signal counts as present, and the feature description itself (not a phase name) is what gets named in the offer below.
+
+If neither signal is present, skip this phase silently: emit no log line, present no offer, proceed straight to Phase 4 exactly as if this phase did not exist.
+
+*(Optional debug: if `AIMI_BRAINSTORM_DEBUG=1`, emit `[brainstorm-debug] phase-3.6: <fired|skipped> (reason: <structural-signal|phase-1.7-fallback|no-signal|prototype-entries-non-empty>)` to chat.)*
+
+### Step 2: Non-Interactive Fast Path
+
+When `INTERACTIVE_MODE=agent`:
+
+- Skip AskUserQuestion entirely — do not present the offer, do not ask anything.
+- Log exactly one line to the brainstorm document's working memory: `agent-mode: prototype-offer-gate skipped (no user to prototype with)`.
+- Proceed to Phase 4 with `prototype_entries` left unchanged (still empty).
+
+### Step 3: Interactive Offer
+
+Name the concrete UI surface the signal matched — the matched phase's `name` for the Structural Signal case, or the feature itself for the Phase 1.7 fallback case. Present via **AskUserQuestion** (picker mode) with exactly three options:
+
+```
+A fase "<name>" entrega telas que operadores usam — quer prototipar antes de seguirmos para a Fase 4?
+
+Prototipar — gerar variantes visuais agora
+Tenho uma referência — quero indicar um estilo ou exemplo antes
+Pular — seguir direto para a Fase 4
+```
+
+- **[Pular]:** Proceed to Phase 4 unchanged. `prototype_entries` remains exactly as it was (still empty, per the fire condition). No artifact is produced.
+
+- **[Prototipar]:** Set `visualOverridePending = true` and present one Aesthetic Direction question (same format as the "Design Questions" example above, e.g. "What visual tone fits this interface best?"). Because `visualOverridePending = true`, the existing **#### Visual Variant Rendering** machinery's override check (Phase 2 above, "`show variants` override check") treats this question as Aesthetic Direction and runs Steps 0a through 7 completely unchanged — authoring variants, opening the preview, and persisting the chosen variant into `prototype_entries` via Step 7. No part of that machinery is re-implemented here.
+
+- **[Tenho uma referência]:** First run the Reference Intake flow defined in `${CLAUDE_PLUGIN_ROOT}/commands/references/visual-variants.md` under `## Reference Intake` (accepts a local path, a URL, or a free-text style directive; sanitizes it; establishes it as Probe #0 ahead of every project-source probe in Token Extraction). Apply that section's rules as written — do not restate them here. Then proceed identically to the [Prototipar] branch above: set `visualOverridePending = true`, present one Aesthetic Direction question, and let Visual Variant Rendering run unchanged. A Reference Intake failure does not abort this gate — it degrades to the plain [Prototipar] flow with that section's single warning line (`⚠ Reference intake: ...`) and continues from there.
+
+### Cross-Reference: Prototype Persistence
+
+A prototype produced by this gate lands in `prototype_entries` through the exact same Visual Variant Rendering Step 7 persistence path a Phase 2 Aesthetic Direction/Differentiation question uses. Phase 4 therefore emits it into the `prototype:` frontmatter via the existing "`prototype:` frontmatter rules" below with no new Phase 4 plumbing required.
+
 ## Phase 4: Capture the Design
 
 ### Derive Filename

--- a/plugins/aimi-engineering/commands/plan.md
+++ b/plugins/aimi-engineering/commands/plan.md
@@ -596,6 +596,24 @@ After the brainstorm check, determine the implementation scope:
 
 3. **Store the result** as `implementationScope: "frontend-only" | "full-stack"` for use in Phase 4 metadata.
 
+### Frontend-Without-Prototype Warning (Advisory)
+
+Runs once, immediately after `implementationScope` is stored above. Purely advisory — it never blocks, aborts, or spawns any Task/agent; the rest of the pipeline continues unchanged regardless of outcome.
+
+**Determine `frontendBearing`:**
+
+- `true` when `implementationScope` is `"frontend-only"` or `"full-stack"`.
+- Otherwise, when `ROADMAP_MODE=true`: read `${CLAUDE_PLUGIN_ROOT}/commands/references/ui-signals.md` (the `${CLAUDE_PLUGIN_ROOT}` prefix is required — it is the only form `install.sh` rewrites to `${AIMI_PLUGIN_DIR}` for OpenCode) and apply its Structural Signals section to `SELECTED_PHASE_JSON`'s `creates`, `PHASE_AREAS_JSON` (`areas`), and `PHASE_GOAL` (`goal`) — a match against any of the three sets `frontendBearing = true`.
+- Otherwise: `false`.
+
+**Emit the warning.** When `frontendBearing` is `true` AND `resolvedPrototypePaths` is empty, emit exactly one chat line and continue:
+
+```
+warning: feature ships a frontend but no prototype exists — run /aimi:brainstorm to create one, or proceed without a visual acceptance target.
+```
+
+Otherwise, emit no line.
+
 ### Scope-Context Classification (Inline Fallback)
 
 **Trigger.** Runs when EITHER no brainstorm was loaded in Phase 0, OR a brainstorm was loaded but its YAML frontmatter has no `phases:` key (legacy brainstorm). When the loaded brainstorm's frontmatter DOES contain a `phases:` key, skip this subsection entirely, with no log line — that feature's phase cut was already produced by `/aimi:brainstorm`'s Phase 3.5 roadmap-definition gate and is materialized by Roadmap Materialization above; it is never reclassified here.

--- a/plugins/aimi-engineering/commands/references/ui-signals.md
+++ b/plugins/aimi-engineering/commands/references/ui-signals.md
@@ -1,0 +1,84 @@
+# UI Signals
+
+Shared reference for detecting UI-bearing work — a feature description, a
+brainstorm phase, or a roadmap phase whose deliverable includes a rendered
+surface (a page, screen, dashboard, form, or component a user looks at and
+interacts with). Apply the rules in this file wherever the caller says "scan
+for UI signals" or "check whether this is UI-bearing."
+
+**Consumed by:** brainstorm.md's Phase 1.7 (UI Feature Detection), brainstorm.md's Phase 3.6 (the prototype-offer gate), and plan.md.
+
+All three cite this file instead of maintaining their own keyword or
+structural detection lists, so the same feature description or roadmap phase
+is classified identically regardless of which command runs the check.
+
+## Keyword Signals
+
+Scan the feature description (or a roadmap phase's goal/creates/areas text)
+for visual/UI keywords using case-insensitive whole-word matching (regex word
+boundaries `\b`).
+
+**Keyword list:** page, modal, dashboard, form, component, layout, ui, design,
+frontend, react, next, next.js, vue, svelte, sveltekit, angular, remix, nuxt,
+solid
+
+The keyword "design" alone does not trigger detection — it requires co-occurrence with at least one other keyword from the list. This prevents false positives from phrases like "system design" or "API design."
+
+| Bucket | Signals | Action |
+|--------|---------|--------|
+| **Detect** | Text contains at least one keyword (with "design" requiring co-occurrence) | Mark the text as UI-relevant |
+| **Skip** | No keywords match, or "design" appears alone without another keyword | Treat the text as non-UI for keyword-signal purposes |
+
+## Structural Signals
+
+Keyword matching is evaded by phrasing (a feature can be UI-bearing without
+using any of the words above — e.g. "render account balances in the client").
+Structural signals close that gap by inspecting what a phase actually
+produces, not how its description is worded.
+
+**File-extension markers** — a `creates`/`areas` path ending in one of these
+extensions is a structural match:
+
+| Extension |
+|---|
+| `.tsx` |
+| `.jsx` |
+| `.vue` |
+| `.svelte` |
+
+**Path-segment markers** — a `creates`/`areas` path containing one of these
+segments is a structural match:
+
+| Segment |
+|---|
+| `components/` |
+| `pages/` |
+| `views/` |
+| `routes/` |
+| `app/` route directories (e.g. Next.js `app/<route>/page.tsx`) |
+
+**Lexical markers** — an artifact description containing one of these words
+is a structural match:
+
+| Word |
+|---|
+| screen |
+| page |
+| view |
+| route |
+| component |
+| frontend |
+
+**UI-bearing phase definition:** a phase is UI-bearing when any `creates` or
+`areas` entry, or the phase `goal`, matches a file-extension, path-segment, or
+lexical marker above (see the Roadmap File Schema note on `phases[].creates`/
+`areas`/`goal` in the top-level CLAUDE.md).
+
+## How to Combine
+
+The structural signal is authoritative and cannot be evaded by phrasing: if
+any `creates`/`areas` entry or the goal matches a structural marker, the
+phase is UI-bearing regardless of what the keyword scan finds. The keyword
+signal is additive — it can flag a plain-text feature description (which has
+no `creates`/`areas` to inspect yet) as UI-relevant before a structural
+artifact list exists. When both signals are absent, the text is non-UI.

--- a/plugins/aimi-engineering/commands/references/visual-variants.md
+++ b/plugins/aimi-engineering/commands/references/visual-variants.md
@@ -197,6 +197,42 @@ This makes tokens both visible to the user (one block to scan) and trivially tra
 
 If `references/visual-variants.md` is being read from a brainstorm that already performed a component-shell scan (see `brainstorm.md` Phase 2 "Component Shell Scan"), use the extracted structural patterns (wrapper tags, spacing idioms, primary-action class recipes) as additional structural constraints alongside the canonical shape. Component-shell findings *narrow* structural choices; they do not replace the canonical shape selection.
 
+## Reference Intake
+
+At the Phase 3.6 gate, the brainstorm agent may offer the user an optional opportunity to supply an external visual reference before Token Extraction (below) runs. Intake is entirely optional: if the user declines or offers nothing, the agent proceeds straight to Token Extraction using only the project-source probes. When a reference is supplied, it resolves as **Probe #0** — the highest-precedence token source in the whole extraction chain (see "Precedence — Probe #0" below).
+
+### Input Kinds
+
+Exactly three input kinds are accepted:
+
+1. **Local file path** — an image (`.png`, `.jpg`, `.jpeg`, `.webp`, `.gif`, `.svg`), an `.html` file, or a `.css` file, read via the Read tool. This is a **read-only reference path**, and unlike written prototype/output paths governed by "## Output Path Pattern" and "## Topic-Slug Sanitization" above, it MAY resolve **outside AIMI_ROOT** — the user is pointing at an existing design artifact anywhere on disk, not asking the agent to write one. Path traversal into system directories (e.g. `/etc`, `/proc`, `/sys`, or other absolute paths outside any reasonable project or home boundary) is still forbidden, and the file is **never executed** — it is read as plain data only (pixels, markup, or CSS text), identically to every project-source probe below.
+
+2. **URL** — opened via the existing `agent-browser` session described in "## Browser Session Lifecycle" below. The agent takes a screenshot of the rendered page and extracts palette, typography, and spacing cues from what renders. This reuses that lifecycle's open/reload/close/fallback mechanics as-is — intake does not open a second browser or invent a new fetch mechanism; if the Browser Session Lifecycle's own fallback rules are already engaged (e.g. `agent-browser` unavailable), URL intake degrades the same way (see "Sanitization and Failure Degradation" below).
+
+3. **Free-text style directive** — a short natural-language description of a desired look (e.g. "estilo Linear, dark, tipografia densa"). This kind yields no extracted token files at all; it is an **authoring directive** that biases variant generation (Structural Guidance, Step 2) and is recorded as **provenance only** in the token sidecar.
+
+### Precedence — Probe #0
+
+When a reference is supplied, it resolves as **Probe #0**, ahead of every project-source probe in "### Probe Order (fixed precedence)" below. Full precedence, highest to lowest:
+
+```
+Probe #0 (user reference) → Probes #1..#N (project code) → Tailwind CDN defaults
+```
+
+Probe #0 does not necessarily cover every token family — an image reference, for instance, yields color/font/spacing cues but rarely radii or transition timing. Any family the reference does not cover falls through to the existing project-source probes (Probe #1 onward) and, failing those, to Tailwind CDN defaults, exactly as if no reference had been supplied.
+
+### Sanitization and Failure Degradation
+
+The user-supplied path, URL, or free text is sanitized before being stored in working memory or written to the sidecar's `reference.source` field (see "### Token Sidecar JSON" below): apply the base rules in `commands/references/sanitization.md` (strip code fences, HTML/XML tags, instruction-override patterns), plus strip newlines/carriage-returns, remove `$(` sequences and backtick characters, and truncate (path/URL: 500 chars; free text: 280 chars).
+
+Intake failure never aborts the brainstorm — mirroring "### Error Handling" below. On a missing or unreadable local path, a URL that will not open, or any other intake failure, the agent emits **exactly one** warning line, formatted as:
+
+```
+⚠ Reference intake: <kind> reference unavailable (<reason>) — using project tokens.
+```
+
+and degrades to the plain [Prototipar] flow — project-source probes only (Probe #1 onward, then Tailwind CDN defaults) — as if no reference had been supplied.
+
 ## Token Extraction
 
 The brainstorm agent attempts to extract design tokens (colors, fonts, radii, spacing, shadows, transitions, screens, dark-mode) from the target project before generating variant HTML. Extraction is **best-effort**: parse errors on any source are silently swallowed and that source is skipped — extraction failures never abort the brainstorm.
@@ -204,6 +240,8 @@ The brainstorm agent attempts to extract design tokens (colors, fonts, radii, sp
 ### Probe Order (fixed precedence)
 
 For each token family, the agent probes sources in this order and stops at the **first source that yields non-empty tokens** for that family. Different families may resolve from different sources (e.g., colors from `tailwind.config`, fonts from `theme.ts`).
+
+When a user reference was supplied via "## Reference Intake" above, it resolves first as **Probe #0**; the numbered probes below run only for families Probe #0 did not already cover.
 
 1. **`tailwind.config.{js,ts,mjs,cjs}`** — Read the file and extract values under `theme.extend` (preferred) or `theme` keys: `colors`, `fontFamily`, `borderRadius`, `spacing`. Pattern: look for object literals following those key names. If the file imports or requires another module for its config, skip and continue to the next source.
 
@@ -271,14 +309,16 @@ Shape:
   "screens": { "sm": "640px", "md": "768px", "...": "..." },
   "darkMode": { "strategy": "class|media|none", "colors": { "background": "#0b0b0b", "...": "..." } },
   "sources": { "colors": "tailwind.config.ts", "fonts": "theme.ts", "...": "..." },
-  "fallbacks": ["shadows", "transitions"]
+  "fallbacks": ["shadows", "transitions"],
+  "reference": { "kind": "image|url|text", "source": "<sanitized path, URL, or truncated text>" }
 }
 ```
 
 - Include only families that were actually resolved or fell back; omit a family entirely if it was neither resolved nor required by the variant.
 - `sources[family]` names the file that won for that family (relative path from project root). Omit the key for families that fell back.
 - `fallbacks[]` lists every family that fell back to Tailwind defaults.
-- `/aimi:plan` reads this sidecar to thread token context into implementation stories. `/aimi:review` reads it to verify generated mockups match the target project's tokens.
+- `reference` is present only when a reference was supplied via "## Reference Intake" above; `kind` is `image`, `url`, or `text`; `source` is the sanitized path, URL, or truncated free text (see "Sanitization and Failure Degradation" in that section). Omit the key entirely when no reference was supplied.
+- `/aimi:plan` reads this sidecar to thread token context into implementation stories. `/aimi:review` reads it to verify generated mockups match the target project's tokens. Both can read `reference` to know the visual target had an external reference.
 
 ### Error Handling
 


### PR DESCRIPTION
## Summary

Fixes #55. The brainstorm → plan flow never conducted the user toward prototyping when a project shipped a frontend but was *described* in non-UI vocabulary (e.g. "port the backend… the frontend should use an SSR framework"). The prototyping trigger read the **words of the feature description** (a keyword scan), not the **deliverables of the roadmap** — so a frontend-bearing project described in backend terms silently produced no prototype.

This introduces a proactive prototyping offer driven by **structural roadmap deliverables**, not description keywords:

- **`commands/references/ui-signals.md` (new)** — a shared UI-signal vocabulary unifying "does this feature involve UI?" detection: a keyword list (the original 8 words extended with `frontend` and common framework names) *and* structural markers (file extensions, path segments, and lexical terms) for detecting UI-bearing surfaces in a roadmap's `creates`/`areas`/`goal` fields — a signal that cannot be evaded by prose phrasing.
- **Brainstorm Phase 3.6: Prototype Offer Gate (new)** — a gate (not a roadmap phase) inserted between the roadmap cut (Phase 3.5) and document write (Phase 4). It fires when the approved `phases[]` carry a UI signal and no prototype exists yet, offering a three-option picker: **[Prototipar] / [Tenho uma referência] / [Pular]**. Auto-skips under agent mode. Reuses the existing Visual Variant Rendering machinery — no new infrastructure.
- **Reference Intake (new, in `visual-variants.md`)** — the "[Tenho uma referência]" path: accepts a local image/HTML/CSS path, a URL (via the existing agent-browser session), or a free-text style description, feeding token extraction as **Probe #0** (highest precedence: user reference → project code → Tailwind defaults). Records provenance in the token sidecar and degrades safely (never aborts).
- **Brainstorm Phase 1.7** now sources its keyword list from `ui-signals.md` (keyword scan kept as an additive signal).
- **`/aimi:plan`** now emits a non-blocking warning when a frontend-bearing feature has no prototype — closing the "silent failure" on the plan side.

Also bundled: a small unrelated **`install.sh` bugfix** — `backup_file` ended with `[ "$VERBOSE" -eq 1 ] && log …`, which returned 1 when `VERBOSE=0` (default) and, as the function's last statement under `set -euo pipefail`, aborted a real `--to opencode` install once a config file already existed. Converted to an explicit `if` so it returns 0.

Version bumped **1.105.0 → 1.106.0** (MINOR). Backward-compatible: existing behavior is unchanged unless a roadmap ships a UI surface.

> **Note on base branch:** this PR targets `feat/container-execution-mode` (not `main`) because the work is stacked on it — this keeps the diff scoped to just the issue-#55 feature.

## Changes

- fix(install): backup_file returns 0 when VERBOSE=0 to avoid set -e abort
- chore(release): bump to 1.106.0 — proactive prototyping offer (issue #55)
- chore(install): confirm ui-signals reference + Phase 3.6 picker carried to OpenCode
- feat(brainstorm): add Phase 3.6 prototype offer gate
- feat(plan): warn when frontend-bearing feature has no prototype
- refactor(brainstorm): source Phase 1.7 keywords from ui-signals reference
- docs(brainstorm): add reference intake to visual-variants
- docs(references): add shared ui-signals vocabulary reference

## Files Changed

```
 .claude-plugin/marketplace.json                    |  2 +-
 CHANGELOG.md                                       | 13 ++++
 install.sh                                         | 16 ++++-
 plugins/aimi-engineering/.claude-plugin/plugin.json |  2 +-
 plugins/aimi-engineering/commands/brainstorm.md    | 51 ++++++++++++-
 plugins/aimi-engineering/commands/plan.md          | 18 +++++
 plugins/aimi-engineering/commands/references/ui-signals.md      | 84 ++++++++++++++++++++++
 plugins/aimi-engineering/commands/references/visual-variants.md | 44 +++++++++++-
 8 files changed, 222 insertions(+), 8 deletions(-)
```

## Test Plan

- `bash plugins/aimi-engineering/scripts/test-worktree-manager.sh` → 27/0
- `bash plugins/aimi-engineering/scripts/test-aimi-cli.sh` → 967/1 (the single failure `init-session: global CLI cache file created` is pre-existing and unrelated — no `aimi-cli.sh` change in this PR)
- `bash -n install.sh` clean; `backup_file` no longer aborts under `set -euo pipefail` with `VERBOSE=0` (verified by reproducing the exact crash scenario)
- Behavioral OpenCode-install check: `ui-signals.md` and `visual-variants.md` land in the installed tree; the Phase 3.6 `AskUserQuestion` picker is rewritten to "the question tool" by the existing bulk rule; `${CLAUDE_PLUGIN_ROOT}` citations rewritten to `${AIMI_PLUGIN_DIR}`
