### PR TITLE
bug: /aimi:open-pr resolve o branch e a base corretamente no modo container (issue #69)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and worktree+team orchestration.",
-      "version": "1.113.0",
+      "version": "1.114.0",
       "author": {
         "name": "Aimi — Autonomous Code Companion",
         "url": "https://github.com/aimi-so"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.114.0] - 2026-07-26
+
+### Added
+
+- **`detect-parent-branch` aimi-cli.sh verb.** New `aimi-cli.sh detect-parent-branch <branch>` resolves a branch's parent by walking `git log --first-parent` ref decorations as individual tokens — never as whole lines or substrings — matching candidates against the current branch by exact token equality, then verifies the surviving candidate via `git merge-base` before returning it. Falls back to the default branch (`verified:false, source:"default-branch"`) when no candidate survives verification. Output shape: `{branch, base, verified, source}`. Extracted `_resolve_default_branch` as a shared private helper reused by the new verb, and covered by 29 new `test-aimi-cli.sh` assertions spanning all six defect/design cases.
+
+### Fixed
+
+- **`/aimi:open-pr` resolved the wrong base branch, and under container mode the wrong feature branch too (resolves issue #69, `aimi-so/aimi-engineering-plugin`).** Two independent defects failed silently. First, Step 2b's parent-branch detection piped `git log --first-parent --pretty=format:'%D'` through `grep -v "HEAD"` and `grep -v "$CURRENT_BRANCH"` (`commands/open-pr.md:128`) — line and substring filters where token filters were required, since `%D` packs every ref decorating a commit onto one comma-separated line. A parent decorated `HEAD -> <parent>` — exactly what git writes when the parent branch is the one checked out — lost its entire line to the first filter, and the second filter dropped any parent branch that merely contained the current branch's name as a substring (`feat/auth-base` vanishing when the current branch was `feat/auth`). Verified live in this repo: the old pipeline returned a branch 125 commits behind the true base, and because the result was non-empty it silently suppressed the default-branch fallback that would otherwise have caught the failure. Second, Step 2a resolved the feature branch via `git rev-parse --abbrev-ref HEAD`, which is wrong under container execution mode — the Main Working Tree Untouched Invariant plus `--keep-branch` teardown leave the feature branch checked out nowhere and HEAD parked on the base branch. Since `/aimi:plan` writes `"container"` by default for fresh flat tasks files, this was the default execution path, not an edge case; verified live, the old read resolved the base branch where the new one resolves the feature branch.
+- **`/aimi:open-pr` now reuses the plugin's shared detection primitives instead of maintaining its own.** Step 2b/2c/2d call the new `detect-parent-branch` verb (reading `.base`, warning when `verified` is `false`) instead of the in-markdown grep pipeline; Step 2c uses the shared cached `$AIMI_CLI detect-default-branch` instead of a `gh repo view --json defaultBranchRef` network round-trip — `open-pr.md` was the only command in the repo still doing its own network round-trip for the default branch. Step 2a now resolves the branch from `metadata.branchName` via a guarded `$AIMI_CLI metadata` call (Case A: HEAD is already a real feature branch, reuse it; Case B: HEAD is on the default branch or detached, read the tasks file), mirroring the Case A/Case B pattern `commands/review.md` already uses for the identical problem.
+
 ## [1.113.0] - 2026-07-26
 
 ### Changed

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.113.0",
+  "version": "1.114.0",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi — Autonomous Code Companion"

--- a/plugins/aimi-engineering/commands/open-pr.md
+++ b/plugins/aimi-engineering/commands/open-pr.md
@@ -122,20 +122,38 @@ git rev-parse --abbrev-ref HEAD
 
 Store as `$CURRENT_BRANCH`.
 
-### 2b. Detect parent branch via decorated ancestor
+### 2b. Detect parent branch via `detect-parent-branch`
+
+Call the tested CLI verb instead of parsing decorations by hand — it already handles decoration parsing, `origin/` prefix normalization, and `git merge-base` verification internally, and owns the "no verified candidate" fallback (it returns the repository's default branch itself in that case).
 
 ```bash
-git log "$CURRENT_BRANCH" --pretty=format:'%D' --first-parent | grep -v '^$' | grep -v "HEAD" | grep -v "$CURRENT_BRANCH" | head -1
+AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+: "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
+PARENT_RESULT=$($AIMI_CLI detect-parent-branch "$CURRENT_BRANCH")
+BASE_BRANCH=$(printf '%s' "$PARENT_RESULT" | jq -r '.base // empty')
+PARENT_VERIFIED=$(printf '%s' "$PARENT_RESULT" | jq -r '.verified // false')
 ```
 
-Parse the output to extract a branch name. The output may contain multiple refs separated by commas (e.g., `origin/main, main`). Extract the first local branch name (without `origin/` prefix). If the output contains `origin/branch-name`, strip the `origin/` prefix.
+Store as `$BASE_BRANCH` and `$PARENT_VERIFIED`. Note `.base` is the resolved parent branch — `.branch` in the response is merely an echo of the input `$CURRENT_BRANCH` and must never be read here.
 
-### 2c. Fallback to default branch
+When `$PARENT_VERIFIED` is not `true` (the candidate could not be confirmed via `git merge-base`, or no decoration candidate existed and the verb fell back to the default branch), print an explicit warning naming the unverified candidate before continuing — do not silently proceed as if the value were trustworthy:
 
-If no parent branch was detected in 2b, use the repository's default branch:
+```
+Warning: could not verify "$BASE_BRANCH" as the true parent branch of "$CURRENT_BRANCH" (git merge-base check failed or no candidate found). Proceeding with this value as the PR base — double-check it before merging.
+```
+
+Execution continues regardless of `$PARENT_VERIFIED`; Step 2d's regex validation is the only hard STOP gate on `$BASE_BRANCH`.
+
+### 2c. Fallback when the CLI call itself failed
+
+`detect-parent-branch` already owns the "no verified candidate" case internally (see 2b) — this step is **not** a second "no parent found" handler. It exists only as defense-in-depth for the narrower case where the CLI call in 2b itself failed or produced no output (e.g., `$AIMI_CLI` resolution broke, the process exited non-zero, or the JSON could not be parsed) and `$BASE_BRANCH` is still empty here:
 
 ```bash
-gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'
+if [ -z "$BASE_BRANCH" ]; then
+  AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+  : "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
+  BASE_BRANCH=$($AIMI_CLI detect-default-branch)
+fi
 ```
 
 Store the result as `$BASE_BRANCH`.

--- a/plugins/aimi-engineering/commands/open-pr.md
+++ b/plugins/aimi-engineering/commands/open-pr.md
@@ -116,11 +116,37 @@ Build the PR from git state directly — commits and diff against the base branc
 
 **Skip this step entirely when `$CURRENT_BRANCH` is already set (from `--branch`)** — reuse that value instead of resolving HEAD.
 
+A bare HEAD read is not reliable here: after a container-mode `/aimi:execute` run, the **Main Working Tree Untouched Invariant** (`commands/references/container-execution.md:57`) means the main working tree was never checked out onto the feature branch, and Step 5's teardown (`container-execution.md:198`) removes the container with `--keep-branch`, leaving the feature branch checked out nowhere. HEAD stays parked on the base branch for the whole run — trusting it as-is would open a PR of the base branch against its own grandparent. Resolve both HEAD and the repository's default branch up front, then decide which one is actually the feature branch:
+
 ```bash
-git rev-parse --abbrev-ref HEAD
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+AIMI_CLI=$(cat "${AIMI_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/aimi}/cli-path" 2>/dev/null || cat "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/aimi-engineering-cli-path" 2>/dev/null)
+: "${AIMI_CLI:?AIMI_CLI is empty — re-resolve via cat ~/.config/aimi/cli-path in this Bash call}"
+DEFAULT_BRANCH=$($AIMI_CLI detect-default-branch 2>/dev/null)
 ```
 
-Store as `$CURRENT_BRANCH`.
+**Case A — HEAD is already on a real feature branch.** When `$CURRENT_BRANCH` is non-empty, is not the literal string `HEAD` (detached), and differs from `$DEFAULT_BRANCH`, reuse it unchanged — no behavior change from before:
+
+```bash
+: # CURRENT_BRANCH already holds the right value; nothing to do
+```
+
+**Case B — HEAD is on `$DEFAULT_BRANCH` (or detached).** This is the normal container-mode end state. Resolve the feature branch from the active tasks file's `metadata.branchName` instead of trusting HEAD:
+
+```bash
+CANDIDATE_BRANCH=$($AIMI_CLI metadata 2>/dev/null | jq -r '.branchName // empty' 2>/dev/null)
+if [ -n "$CANDIDATE_BRANCH" ] && echo "$CANDIDATE_BRANCH" | grep -qE '^[a-zA-Z0-9][a-zA-Z0-9/_-]*$'; then
+  CURRENT_BRANCH="$CANDIDATE_BRANCH"
+else
+  echo "Warning: No active tasks file found (or its branchName is missing/invalid) and HEAD is on $DEFAULT_BRANCH — proceeding with the checked-out branch, which may be the base branch itself." >&2
+fi
+```
+
+This reuses the single guarded `$AIMI_CLI metadata` call already established at Step 4a for `.title`, rather than `commands/review.md`'s two-step `find-tasks` + separate `jq -r '.metadata.branchName'`. That is safe for the same reason `find-tasks` is safe: `cmd_metadata`'s `get_tasks_file` (`aimi-cli.sh:507`) never calls `init-session`, so it satisfies `commands/review.md:63`'s concurrent-session-safety rationale — it never repoints a live `/aimi:execute` session's tracked tasks file. Its only state write is the narrow self-heal path (`aimi-cli.sh:511-521`) that fires only when the recorded state pointer already points to a deleted file, correcting a broken pointer rather than clobbering a valid one.
+
+Store the resolved value as `$CURRENT_BRANCH`.
+
+**Why Step 1c's skip condition is not widened to cover this case:** at Step 1c's point in the flow, neither `$DEFAULT_BRANCH` nor the Case A/Case B outcome exist yet — both are computed here in Step 2a, which runs after 1c. Widening 1c's skip condition would require moving branch detection earlier, out of this story's scope. The check is also advisory-only (it warns, never stops) and vacuously harmless in container mode, since the Main Working Tree Untouched Invariant keeps the CWD clean throughout the run regardless.
 
 ### 2b. Detect parent branch via `detect-parent-branch`
 

--- a/plugins/aimi-engineering/scripts/aimi-cli.sh
+++ b/plugins/aimi-engineering/scripts/aimi-cli.sh
@@ -1561,6 +1561,41 @@ cmd_get_state() {
     }'
 }
 
+# Shared default-branch resolution logic: cache read, primary git remote
+# show origin parse, offline symbolic-ref fallback, cache write. Assumes the
+# caller has already cd'd into the target repo and verified it is a git
+# repository (both cmd_detect_default_branch and cmd_detect_parent_branch
+# do this themselves before calling here). Returns the branch name on
+# stdout; exits 1 on total failure.
+_resolve_default_branch() {
+  # Return cached value if available
+  local cached
+  cached=$(read_state "default-branch")
+  if [ -n "$cached" ]; then
+    echo "$cached"
+    return 0
+  fi
+
+  local branch=""
+
+  # Primary: parse HEAD branch from remote
+  branch=$(git remote show origin 2>/dev/null | sed -n 's/.*HEAD branch: //p')
+
+  # Fallback: symbolic-ref (works offline)
+  if [ -z "$branch" ]; then
+    branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')
+  fi
+
+  if [ -z "$branch" ]; then
+    echo "Error: Could not detect default branch" >&2
+    exit 1
+  fi
+
+  # Cache for session reuse
+  write_state "default-branch" "$branch"
+  echo "$branch"
+}
+
 # Detect the repository's default branch
 # Primary: git remote show origin (requires network)
 # Fallback: git symbolic-ref refs/remotes/origin/HEAD (offline)
@@ -1594,32 +1629,198 @@ cmd_detect_default_branch() {
     exit 1
   fi
 
-  # Return cached value if available
-  local cached
-  cached=$(read_state "default-branch")
-  if [ -n "$cached" ]; then
-    echo "$cached"
+  _resolve_default_branch
+}
+
+# Normalize a single %D decoration token for parent-branch detection.
+# Pipeline: (1) strip an "X -> Y" arrow decoration, keeping the right-hand
+# side (covers "HEAD -> <branch>" and, defensively, "origin/HEAD ->
+# origin/<branch>"); (2) drop a bare HEAD token; (3) drop a tag: -prefixed
+# token; (4) strip a leading origin/ remote-tracking prefix; (5) re-check
+# for a bare HEAD token now that origin/ has been stripped (catches
+# "origin/HEAD" -> "HEAD"); (6) drop the token if it is now empty or equals
+# the branch being examined exactly -- exact match only, never a substring
+# match (this is the DEFECT 3 fix for the old grep -v "$CURRENT_BRANCH").
+# Prints the surviving token, or nothing when the token was dropped.
+_normalize_decoration_token() {
+  local token="$1" branch="$2"
+
+  # (1) Arrow decoration: keep the right-hand side.
+  if [[ "$token" == *" -> "* ]]; then
+    token="${token#*" -> "}"
+  fi
+
+  # (2) Bare HEAD (detached-HEAD marker, or the left side of an
+  #     already-stripped arrow that somehow left just HEAD).
+  if [ "$token" = "HEAD" ]; then
     return 0
   fi
 
-  local branch=""
-
-  # Primary: parse HEAD branch from remote
-  branch=$(git remote show origin 2>/dev/null | sed -n 's/.*HEAD branch: //p')
-
-  # Fallback: symbolic-ref (works offline)
-  if [ -z "$branch" ]; then
-    branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')
+  # (3) Tag refs are never a parent-branch candidate.
+  if [[ "$token" == "tag: "* ]]; then
+    return 0
   fi
 
+  # (4) Strip the remote-tracking prefix.
+  if [[ "$token" == "origin/"* ]]; then
+    token="${token#origin/}"
+  fi
+
+  # (5) Re-check for HEAD now that origin/ has been stripped.
+  if [ "$token" = "HEAD" ]; then
+    return 0
+  fi
+
+  # (6) Exact-match-only drop: empty token, or the token IS the branch
+  #     we're examining (its own tip decoration). Never a substring check.
+  if [ -z "$token" ] || [ "$token" = "$branch" ]; then
+    return 0
+  fi
+
+  printf '%s' "$token"
+}
+
+# Walk branch's --first-parent decoration history (git log --pretty=format:'%D')
+# token-by-token, nearest ancestor first, and return the first surviving
+# candidate parent-branch name after _normalize_decoration_token. Prints
+# nothing when no candidate survives across the whole history.
+_detect_parent_branch_candidate() {
+  local branch="$1"
+  local log_output
+  log_output=$(git log "$branch" --pretty=format:'%D' --first-parent 2>/dev/null) || true
+
+  local line raw_token normalized candidate=""
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+
+    local -a tokens
+    local old_ifs="$IFS"
+    IFS=','
+    read -ra tokens <<< "$line"
+    IFS="$old_ifs"
+
+    for raw_token in "${tokens[@]}"; do
+      # Decoration tokens are separated by ", " -- trim the leading space.
+      raw_token="${raw_token# }"
+      normalized=$(_normalize_decoration_token "$raw_token" "$branch")
+      if [ -n "$normalized" ]; then
+        candidate="$normalized"
+        break 2
+      fi
+    done
+  done <<< "$log_output"
+
+  printf '%s' "$candidate"
+}
+
+# Verify a decoration candidate is a genuine ancestor of branch via
+# git merge-base, rejecting a divergent sibling whose ref happens to share
+# the candidate's (post-normalization) name. Resolves the candidate against
+# a local branch first, falling back to an origin-prefixed remote-tracking
+# ref only when no local branch of that name exists.
+_verify_parent_candidate() {
+  local branch="$1" candidate="$2"
+  local candidate_ref candidate_commit branch_commit merge_base
+
+  if candidate_commit=$(git rev-parse --verify "${candidate}^{commit}" 2>/dev/null); then
+    candidate_ref="$candidate"
+  elif candidate_commit=$(git rev-parse --verify "origin/${candidate}^{commit}" 2>/dev/null); then
+    candidate_ref="origin/${candidate}"
+  else
+    return 1
+  fi
+
+  branch_commit=$(git rev-parse --verify "${branch}^{commit}" 2>/dev/null) || return 1
+
+  # The candidate must not be the branch's own tip commit.
+  if [ "$candidate_commit" = "$branch_commit" ]; then
+    return 1
+  fi
+
+  # The candidate must be a genuine ancestor of branch (its own commit is
+  # the merge base), not a divergent sibling.
+  merge_base=$(git merge-base "$branch" "$candidate_ref" 2>/dev/null) || return 1
+
+  [ "$merge_base" = "$candidate_commit" ]
+}
+
+# Detect a branch's parent (base) branch by parsing its --first-parent git
+# log decorations token-by-token (replacing the old grep -v line-filtering
+# pipeline in commands/open-pr.md, which mishandled "HEAD -> <parent>" and
+# substring-alike branch names) and confirming the candidate with
+# git merge-base. Falls back to the repository's default branch (unverified)
+# when no decoration candidate survives normalization or merge-base
+# verification.
+# Usage: aimi-cli.sh detect-parent-branch <branch> [--project <path>]
+# Output: {"branch":<input>,"base":<resolved>,"verified":<bool>,"source":"decoration"|"default-branch"}
+cmd_detect_parent_branch() {
+  local branch="" project_dir=""
+
+  # Parse positional branch arg + --project flag
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --project)
+        shift
+        project_dir="${1:-}"
+        ;;
+      *)
+        if [ -z "$branch" ]; then
+          branch="$1"
+        else
+          echo "Error: Unexpected argument: $1" >&2
+          echo "Usage: aimi-cli.sh detect-parent-branch <branch> [--project <path>]" >&2
+          exit 1
+        fi
+        ;;
+    esac
+    shift
+  done
+
   if [ -z "$branch" ]; then
-    echo "Error: Could not detect default branch" >&2
+    echo "Usage: aimi-cli.sh detect-parent-branch <branch> [--project <path>]" >&2
     exit 1
   fi
 
-  # Cache for session reuse
-  write_state "default-branch" "$branch"
-  echo "$branch"
+  # cd into project dir if specified (supports multi-repo layouts where AIMI root is not a git repo)
+  if [ -n "$project_dir" ]; then
+    if [ ! -d "$project_dir" ]; then
+      echo "Error: Project directory does not exist: $project_dir" >&2
+      exit 1
+    fi
+    cd "$project_dir"
+  fi
+
+  # Guard: must be inside a git repository
+  if ! git rev-parse --git-dir >/dev/null 2>&1; then
+    echo "Error: Not a git repository. Use --project <path> to specify the git repo directory." >&2
+    exit 1
+  fi
+
+  # Validate branch name (security) — before any git command uses it
+  if ! [[ "$branch" =~ ^[a-zA-Z0-9][a-zA-Z0-9/_-]*$ ]]; then
+    echo "Error: Invalid branch name: $branch" >&2
+    exit 1
+  fi
+
+  local raw_candidate
+  raw_candidate=$(_detect_parent_branch_candidate "$branch")
+
+  local base="" verified="false" source="default-branch"
+
+  if [ -n "$raw_candidate" ] && _verify_parent_candidate "$branch" "$raw_candidate"; then
+    base="$raw_candidate"
+    verified="true"
+    source="decoration"
+  else
+    base=$(_resolve_default_branch)
+  fi
+
+  jq -nc \
+    --arg branch "$branch" \
+    --arg base "$base" \
+    --argjson verified "$verified" \
+    --arg source "$source" \
+    '{branch: $branch, base: $base, verified: $verified, source: $source}'
 }
 
 # Detect a Claude Design handoff bundle under a given root (defaults to CWD).
@@ -7107,6 +7308,13 @@ COMMANDS:
     get-state                 Get all state files as JSON
     detect-default-branch [--project <path>]
                               Detect and cache the repository's default branch
+    detect-parent-branch <branch> [--project <path>]
+                              Detect branch's parent (base) branch by token-aware
+                              git log decoration parsing + git merge-base verification.
+                              Output: {branch, base, verified, source
+                              ("decoration"|"default-branch")}. Falls back to the
+                              default branch (unverified) when no decoration
+                              candidate survives normalization or merge-base check.
     detect-interactivity [--non-interactive]
                               Print resolved interactivity mode (picker|agent)
                               Returns picker by default; returns agent only when
@@ -7503,6 +7711,7 @@ main() {
     get-story-context) cmd_get_story_context "${2:-}" ;;
     get-state)         cmd_get_state ;;
     detect-default-branch) shift; cmd_detect_default_branch "$@" ;;
+    detect-parent-branch) shift; cmd_detect_parent_branch "$@" ;;
     setup-branch)      shift; cmd_setup_branch "$@" ;;
     clear-state)       cmd_clear_state ;;
     version)           cmd_version ;;

--- a/plugins/aimi-engineering/scripts/test-aimi-cli.sh
+++ b/plugins/aimi-engineering/scripts/test-aimi-cli.sh
@@ -6002,6 +6002,236 @@ test_setup_branch() {
 }
 
 # ============================================================================
+# Detect Parent Branch Fixture Helper
+# ============================================================================
+
+# Creates a minimal bare remote + local clone with a single commit on main,
+# with the bare remote's HEAD pointed at refs/heads/main so `git remote show
+# origin` can resolve a default branch (a fresh --bare init defaults to
+# master, which is never pushed here, leaving "HEAD branch: (unknown)"
+# otherwise). Reuses setup_git_fixture's globals (GIT_FIXTURE_REMOTE /
+# GIT_FIXTURE_LOCAL) so the existing teardown_git_fixture applies unchanged.
+# Kept separate from setup_git_fixture because detect-parent-branch tests
+# need precise, uncluttered control over decoration history --
+# setup_git_fixture's merged/unmerged branches would add unrelated decorated
+# commits to every ancestry chain.
+setup_parent_branch_fixture() {
+  GIT_FIXTURE_REMOTE=$(mktemp -d)
+  GIT_FIXTURE_LOCAL=$(mktemp -d)
+
+  git init --bare "$GIT_FIXTURE_REMOTE" >/dev/null 2>&1
+  git --git-dir="$GIT_FIXTURE_REMOTE" symbolic-ref HEAD refs/heads/main
+
+  git clone "$GIT_FIXTURE_REMOTE" "$GIT_FIXTURE_LOCAL" >/dev/null 2>&1
+
+  pushd "$GIT_FIXTURE_LOCAL" >/dev/null
+  git checkout -b main >/dev/null 2>&1
+  echo "init" > README.md
+  git add README.md
+  git commit -m "Initial commit" >/dev/null 2>&1
+  git push -u origin main >/dev/null 2>&1
+
+  # Create .aimi/ directory so find_aimi_root succeeds
+  mkdir -p .aimi/tasks
+
+  popd >/dev/null
+}
+
+# ============================================================================
+# Detect Parent Branch Tests
+# ============================================================================
+
+test_detect_parent_branch() {
+  echo ""
+  echo "=== Testing detect-parent-branch command ==="
+
+  local stdout stderr_file stderr_output exit_code
+  local base_out verified_out source_out branch_out
+
+  # --- Case (a): DEFECT 1 fix — parent is the currently checked-out branch,
+  #     decorated "HEAD -> <parent>, origin/<parent>" on the first ancestor
+  #     commit. Must resolve to the parent, not some further ancestor. ---
+  setup_parent_branch_fixture
+  pushd "$GIT_FIXTURE_LOCAL" >/dev/null
+
+  git checkout -b feat/parent >/dev/null 2>&1
+  echo "p" > p.txt && git add p.txt && git commit -m "parent work" >/dev/null 2>&1
+  git push origin feat/parent >/dev/null 2>&1
+  git checkout -b feat/child >/dev/null 2>&1
+  echo "c" > c.txt && git add c.txt && git commit -m "child work" >/dev/null 2>&1
+  git checkout feat/parent >/dev/null 2>&1
+
+  stdout=$("$CLI" detect-parent-branch feat/child) && exit_code=0 || exit_code=$?
+  branch_out=$(echo "$stdout" | jq -r '.branch')
+  base_out=$(echo "$stdout" | jq -r '.base')
+  verified_out=$(echo "$stdout" | jq -r '.verified')
+  source_out=$(echo "$stdout" | jq -r '.source')
+  assert_exit_code "0" "$exit_code" "detect-parent-branch (a) checked-out-parent decoration: exit code"
+  assert_eq "feat/child" "$branch_out" "detect-parent-branch (a): branch echoed"
+  assert_eq "feat/parent" "$base_out" "detect-parent-branch (a): base is the checked-out parent, not a further ancestor"
+  assert_eq "true" "$verified_out" "detect-parent-branch (a): verified true"
+  assert_eq "decoration" "$source_out" "detect-parent-branch (a): source is decoration"
+
+  popd >/dev/null
+  teardown_git_fixture
+
+  # --- Case (b): DEFECT 3 fix — parent branch name (feat/auth-base)
+  #     contains the current branch name (feat/auth) as a substring. The old
+  #     unanchored grep -v "feat/auth" would have dropped this line. ---
+  setup_parent_branch_fixture
+  pushd "$GIT_FIXTURE_LOCAL" >/dev/null
+
+  git checkout -b feat/auth-base >/dev/null 2>&1
+  echo "b" > b.txt && git add b.txt && git commit -m "auth base work" >/dev/null 2>&1
+  git checkout -b feat/auth >/dev/null 2>&1
+  echo "a" > a.txt && git add a.txt && git commit -m "auth work" >/dev/null 2>&1
+  git checkout feat/auth-base >/dev/null 2>&1
+
+  stdout=$("$CLI" detect-parent-branch feat/auth) && exit_code=0 || exit_code=$?
+  base_out=$(echo "$stdout" | jq -r '.base')
+  verified_out=$(echo "$stdout" | jq -r '.verified')
+  source_out=$(echo "$stdout" | jq -r '.source')
+  assert_exit_code "0" "$exit_code" "detect-parent-branch (b) substring-alike sibling: exit code"
+  assert_eq "feat/auth-base" "$base_out" "detect-parent-branch (b): base survives despite containing branch name as substring"
+  assert_eq "true" "$verified_out" "detect-parent-branch (b): verified true"
+  assert_eq "decoration" "$source_out" "detect-parent-branch (b): source is decoration"
+
+  popd >/dev/null
+  teardown_git_fixture
+
+  # --- Case (c): detached-HEAD decoration — token list is exactly
+  #     "HEAD, feat/foo" (bare HEAD token, no arrow). The bare HEAD token
+  #     must be skipped and the real branch token used. ---
+  setup_parent_branch_fixture
+  pushd "$GIT_FIXTURE_LOCAL" >/dev/null
+
+  git checkout -b feat/foo >/dev/null 2>&1
+  echo "f" > f.txt && git add f.txt && git commit -m "foo work" >/dev/null 2>&1
+  git checkout -b feat/target >/dev/null 2>&1
+  echo "t" > t.txt && git add t.txt && git commit -m "target work" >/dev/null 2>&1
+  git checkout "$(git rev-parse feat/foo)" >/dev/null 2>&1
+
+  stdout=$("$CLI" detect-parent-branch feat/target) && exit_code=0 || exit_code=$?
+  base_out=$(echo "$stdout" | jq -r '.base')
+  verified_out=$(echo "$stdout" | jq -r '.verified')
+  source_out=$(echo "$stdout" | jq -r '.source')
+  assert_exit_code "0" "$exit_code" "detect-parent-branch (c) detached-HEAD decoration: exit code"
+  assert_eq "feat/foo" "$base_out" "detect-parent-branch (c): bare HEAD token skipped, real branch token used"
+  assert_eq "true" "$verified_out" "detect-parent-branch (c): verified true"
+  assert_eq "decoration" "$source_out" "detect-parent-branch (c): source is decoration"
+
+  popd >/dev/null
+  teardown_git_fixture
+
+  # --- Case (d): own-tip decoration is skipped — target's own tip commit is
+  #     decorated "origin/<branch>, <branch>"; both tokens must drop (exact
+  #     match, never substring) and the walk continues to the next ancestor
+  #     rather than returning the branch as its own parent. ---
+  setup_parent_branch_fixture
+  pushd "$GIT_FIXTURE_LOCAL" >/dev/null
+
+  git checkout -b feat/lonely >/dev/null 2>&1
+  echo "l" > l.txt && git add l.txt && git commit -m "lonely work" >/dev/null 2>&1
+  git push origin feat/lonely >/dev/null 2>&1
+  git checkout main >/dev/null 2>&1
+
+  stdout=$("$CLI" detect-parent-branch feat/lonely) && exit_code=0 || exit_code=$?
+  base_out=$(echo "$stdout" | jq -r '.base')
+  verified_out=$(echo "$stdout" | jq -r '.verified')
+  source_out=$(echo "$stdout" | jq -r '.source')
+  assert_exit_code "0" "$exit_code" "detect-parent-branch (d) own-tip decoration skip: exit code"
+  assert_eq "main" "$base_out" "detect-parent-branch (d): never returns branch as its own parent -- walk continues to real ancestor"
+  assert_eq "true" "$verified_out" "detect-parent-branch (d): verified true"
+  assert_eq "decoration" "$source_out" "detect-parent-branch (d): source is decoration"
+
+  popd >/dev/null
+  teardown_git_fixture
+
+  # --- Case (e): no-decoration fallback — an orphan branch whose entire
+  #     first-parent history has zero non-empty/non-HEAD/non-tag/non-self
+  #     decoration tokens anywhere. Must fall back to the default branch,
+  #     unverified. ---
+  setup_parent_branch_fixture
+  pushd "$GIT_FIXTURE_LOCAL" >/dev/null
+
+  git checkout --orphan feat/no-decoration >/dev/null 2>&1
+  echo "o1" > o1.txt && git add o1.txt && git commit -m "orphan commit 1" >/dev/null 2>&1
+  echo "o2" > o2.txt && git add o2.txt && git commit -m "orphan commit 2" >/dev/null 2>&1
+
+  stdout=$("$CLI" detect-parent-branch feat/no-decoration) && exit_code=0 || exit_code=$?
+  base_out=$(echo "$stdout" | jq -r '.base')
+  verified_out=$(echo "$stdout" | jq -r '.verified')
+  source_out=$(echo "$stdout" | jq -r '.source')
+  assert_exit_code "0" "$exit_code" "detect-parent-branch (e) no-decoration fallback: exit code"
+  assert_eq "main" "$base_out" "detect-parent-branch (e): falls back to the shared default-branch resolution"
+  assert_eq "false" "$verified_out" "detect-parent-branch (e): verified false on fallback"
+  assert_eq "default-branch" "$source_out" "detect-parent-branch (e): source is default-branch"
+
+  popd >/dev/null
+  teardown_git_fixture
+
+  # --- Case (f): merge-base rejection — a decoration token survives
+  #     normalization (origin/feat/sibling -> feat/sibling) but a LOCAL
+  #     branch of that same normalized name points to an unrelated,
+  #     divergent commit not on the target's first-parent lineage.
+  #     merge-base must reject it and fall back to the default branch. ---
+  setup_parent_branch_fixture
+  pushd "$GIT_FIXTURE_LOCAL" >/dev/null
+
+  git checkout -b feat/sibling >/dev/null 2>&1
+  echo "s" > s.txt && git add s.txt && git commit -m "sibling original work" >/dev/null 2>&1
+  git push origin feat/sibling >/dev/null 2>&1
+  git checkout -b feat/fbranch >/dev/null 2>&1
+  echo "fb" > fb.txt && git add fb.txt && git commit -m "fbranch work" >/dev/null 2>&1
+  # Delete the local feat/sibling (origin/feat/sibling still decorates the
+  # ancestor commit) and recreate it pointing at unrelated, divergent work.
+  git branch -D feat/sibling >/dev/null 2>&1
+  git checkout main >/dev/null 2>&1
+  git checkout -b feat/sibling >/dev/null 2>&1
+  echo "unrelated" > unrelated.txt && git add unrelated.txt && git commit -m "unrelated sibling work" >/dev/null 2>&1
+  git checkout main >/dev/null 2>&1
+
+  stdout=$("$CLI" detect-parent-branch feat/fbranch) && exit_code=0 || exit_code=$?
+  base_out=$(echo "$stdout" | jq -r '.base')
+  verified_out=$(echo "$stdout" | jq -r '.verified')
+  source_out=$(echo "$stdout" | jq -r '.source')
+  assert_exit_code "0" "$exit_code" "detect-parent-branch (f) merge-base rejection: exit code"
+  assert_eq "main" "$base_out" "detect-parent-branch (f): rejected candidate falls back to default branch"
+  assert_eq "false" "$verified_out" "detect-parent-branch (f): verified false on merge-base rejection"
+  assert_eq "default-branch" "$source_out" "detect-parent-branch (f): source is default-branch"
+
+  popd >/dev/null
+  teardown_git_fixture
+
+  # --- Error path: invalid branch argument ---
+  setup_parent_branch_fixture
+  pushd "$GIT_FIXTURE_LOCAL" >/dev/null
+
+  stderr_file=$(mktemp)
+  stdout=$("$CLI" detect-parent-branch '../bad' 2>"$stderr_file") && exit_code=0 || exit_code=$?
+  stderr_output=$(cat "$stderr_file")
+  assert_exit_code "1" "$exit_code" "detect-parent-branch: invalid branch name — exit code"
+  assert_stderr_contains "Invalid branch name" "$stderr_output" "detect-parent-branch: invalid branch name — stderr message"
+  rm -f "$stderr_file"
+
+  popd >/dev/null
+  teardown_git_fixture
+
+  # --- Error path: not a git repository ---
+  local non_git_dir
+  non_git_dir=$(mktemp -d)
+  mkdir -p "$non_git_dir/.aimi"
+
+  stderr_file=$(mktemp)
+  stdout=$("$CLI" detect-parent-branch feat/test --project "$non_git_dir" 2>"$stderr_file") && exit_code=0 || exit_code=$?
+  stderr_output=$(cat "$stderr_file")
+  assert_exit_code "1" "$exit_code" "detect-parent-branch: not a git repo — exit code"
+  assert_stderr_contains "Not a git repository" "$stderr_output" "detect-parent-branch: not a git repo — stderr message"
+  rm -f "$stderr_file"
+  rm -rf "$non_git_dir"
+}
+
+# ============================================================================
 # Archive Task Tests
 # ============================================================================
 
@@ -13172,6 +13402,11 @@ main() {
   echo ""
   echo "--- Setup Branch Tests ---"
   test_setup_branch
+
+  # Detect-parent-branch tests — uses own git fixture (independent of TEST_DIR)
+  echo ""
+  echo "--- Detect Parent Branch Tests ---"
+  test_detect_parent_branch
 
   # Archive-task tests — each creates its own isolated temp dir
   echo ""


### PR DESCRIPTION
## Summary

`/aimi:open-pr` picked the wrong base branch — and, in container mode, the wrong branch entirely. Two independent defects stacked, both on what is now the default path, and both failed silently: they produced a plausible-looking PR against a real-but-wrong base rather than an error.

**Defect 1 — `open-pr.md:128` filtered decoration lines where it meant to filter tokens.**

```bash
git log "$CURRENT_BRANCH" --pretty=format:'%D' --first-parent | grep -v '^$' | grep -v "HEAD" | grep -v "$CURRENT_BRANCH" | head -1
```

`%D` packs every ref decorating a commit onto one comma-separated line. `grep -v "HEAD"` therefore discarded the **whole line** whenever the parent branch was the checked-out one — which is exactly when git writes `HEAD -> <parent>`. The detector then fell through to the next decorated ancestor, which is merely *an* ancestor, not the branch point. The same line's `grep -v "$CURRENT_BRANCH"` had the same defect by substring: a parent named `feat/auth-base` vanished when the current branch was `feat/auth`.

Reproduced live in this repo, on this very branch: the shipped pipeline returns `feat/large-scope-phase-milestone-generation` — 130 commits away — where `git merge-base` confirms the immediate parent is `feat/container-execution-mode`, 4 commits away. Because the wrong answer is non-empty, it also suppressed Step 2c's default-branch fallback entirely.

**Defect 2 — Step 2a trusted HEAD, which container mode leaves on the base branch.**

`commands/references/container-execution.md` establishes the Main Working Tree Untouched Invariant: the main working tree never checks out the feature branch, and Step 5's teardown removes the container with `--keep-branch`, leaving that branch checked out **nowhere**. A bare `/aimi:open-pr` therefore resolved `$CURRENT_BRANCH` to the base and would open a PR of the base against its own grandparent. This is the default path, not an edge case — `/aimi:plan` writes `"container"` by default for every fresh flat tasks file.

Also reproduced live while opening this PR: HEAD reads `feat/container-execution-mode` while the feature branch sits in zero worktrees.

## What changed

**A new `detect-parent-branch` verb in `aimi-cli.sh`,** rather than a patch to the markdown. This was a deliberate choice: nothing in this repo verifies bash embedded in command `.md` files — there is no `.github/workflows/` directory, no lint tooling, no `package.json`, and `test-aimi-cli.sh` has zero references to `open-pr`. Leaving the logic in markdown would have left it exactly as unverifiable as it was when the defect shipped. The verb splits each `%D` line into individual ref tokens, normalizes each (strip `HEAD -> `, drop bare `HEAD` and `tag:`, handle `origin/`), drops the current branch only on **exact** equality, and then confirms the surviving candidate with `git merge-base` before returning it — falling back to the shared default-branch resolution when nothing survives. It reports which path produced the answer (`source`) and whether merge-base confirmed it (`verified`), so a caller can surface an unconfirmed guess as a guess. Covered by 29 new assertions in `test-aimi-cli.sh`, one per defect and design guarantee, including the `HEAD -> parent` case, the substring-sibling case, detached HEAD, own-tip skip, no-decoration fallback, and merge-base rejection.

**`open-pr.md` Step 2b/2c/2d now call it.** Step 2c also drops `gh repo view --json defaultBranchRef` for the shared, cached `$AIMI_CLI detect-default-branch` — `open-pr.md` was the only command in the repo still doing its own network round-trip for that — and narrows to a defense-in-depth fallback, since the verb already owns the no-candidate case. Step 2d's name validation is unchanged.

**`open-pr.md` Step 2a resolves from `metadata.branchName`.** Case A reuses HEAD when it is genuinely a feature branch; Case B reads the active tasks file when HEAD is on the default branch or detached. This mirrors the Case A/Case B pattern `commands/review.md` already uses — `/aimi:review` hit this identical bug and fixed it in commit `3e91b57`; that precedent is reused rather than reinvented.

Worth naming explicitly: the deeper limitation behind Defect 1 is that **a decoration on an ancestor is not evidence of a branch point.** That is what made the failure credible rather than obviously broken — the fallback always returns *some* real branch. The `merge-base` check is what turns the result from inferred into verified.

## Verification

Full suites green on the merged branch: **1123 passed / 0 failed** (`test-aimi-cli.sh`, 1094 baseline + 29 new) and **27 passed / 0 failed** (`test-worktree-manager.sh`). `bash -n` clean.

Both defects were re-verified live against real repository state rather than fixtures:

| | shipped | fixed |
|---|---|---|
| base for `bug/open-pr-base-branch-detection` | `feat/large-scope-phase-milestone-generation` (130 commits away) | `feat/container-execution-mode`, `verified: true` |
| branch under container mode (HEAD on base) | `feat/container-execution-mode` — the base | `bug/open-pr-base-branch-detection` — the feature |

No regression: for `feat/container-execution-mode` itself, old and new agree — there the decorated ancestor genuinely *is* the parent, and merge-base confirms it.

`install.sh` needs no change; it never rewrites Bash logic inside `aimi-cli.sh`, and `open-pr.md`'s only translated token is an unrelated `${CLAUDE_PLUGIN_ROOT}` reference at Step 0.

## Files Changed

```
 .claude-plugin/marketplace.json                    |   2 +-
 CHANGELOG.md                                       |  11 +
 .../aimi-engineering/.claude-plugin/plugin.json    |   2 +-
 plugins/aimi-engineering/commands/open-pr.md       |  60 +++++-
 plugins/aimi-engineering/scripts/aimi-cli.sh       | 239 +++++++++++++++++++--
 plugins/aimi-engineering/scripts/test-aimi-cli.sh  | 235 ++++++++++++++++++++
 6 files changed, 524 insertions(+), 25 deletions(-)
```

Released as 1.114.0 — MINOR rather than PATCH, because this adds a new subcommand to the CLI's public verb surface.

Resolves #69.
