### PR TITLE
fix(hooks): detect invocations behind an env, wrapper or keyword prefix (1.119.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and worktree+team orchestration.",
-      "version": "1.119.1",
+      "version": "1.119.2",
       "author": {
         "name": "Aimi — Autonomous Code Companion",
         "url": "https://github.com/aimi-so"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.119.2] - 2026-07-30
+
+### Fixed
+
+- **1.119.1's command-position anchoring regressed real detections: a `git commit` or `git worktree add` preceded on the same statement by an environment assignment, a wrapper command, or a body-opening keyword stopped being guarded at all.** `[^\S\n]*` after the anchor consumes whitespace only, so any token between the separator and `git` broke the match — and the failure was silent, in the fail-open direction: the commit on the protected branch simply happened, with no message. Verified missed by 1.119.1 and detected again now: `GIT_AUTHOR_DATE=2020-01-01 git commit` (the canonical way to backdate a commit, and an everyday git idiom), `sudo git commit`, `env FOO=1 git commit`, `time`/`nohup`, `for f in a b; do git commit; done`, `if ok; then git commit; fi`, `else` bodies, `{ git commit; }` brace groups, and `! git commit`. `_CMD_START` is now `_CMD_ANCHOR` (unchanged) plus `_CMD_PREFIX`, a bounded run of those tokens; the four guard regexes concatenate `_CMD_START`, so none of their own definitions changed. Issue #82 stays closed — no prefix token can match `grep`, `echo`, `cat`, `find`, `jq` or `awk`, and every token requires trailing whitespace, which is what keeps `find … {} \;`, `jq '{a: 1}'`, `awk '{print $1}'`, brace expansion `{src,test}`, `${VAR}` and `!=` out of the guard. Confirmed a strict superset over all 802 string literals in the hook test suite: 28 detections gained, zero lost.
+- **This entry supersedes the environment-assignment and wrapper clause of 1.119.1's "Known limitation" bullet below** — that class is now detected, and the sentence claiming `\s*` consumes whitespace only is no longer the shipped behavior. The rest of that bullet (`bash -c`, subshell, command substitution, single `&`, non-`-C` option forms) still stands.
+- **Known limitation, accepted as residual risk:** a wrapper outside the four covered (`timeout`, `xargs`, `command`, `exec`, `nice`, `stdbuf`) or one carrying its own option token (`sudo -u alice git commit`, `env -i git commit`, `time -p git commit`) is not detected — covering those needs another nested quantifier, and the backtracking surface is not worth it. Also undetected: an assignment whose value holds a `$(...)` substitution containing whitespace, `VAR="a"b`, prefix runs deeper than six tokens, and `case` arms or bodies opened by `(`. Note that `FOO=a&b git commit` not matching is correct rather than a gap — bash parses it as `FOO=a &` followed by `b git commit`, so no commit runs.
+
+### Changed
+
+- `_GIT_WORKTREE_ADD_RE` gained the leading `\b` its three sibling regexes already carried. Provably a no-op — the anchor already guarantees the word boundary — but the asymmetry had been flagged by four separate reviewers as an inconsistency inviting a reader to hunt for a reason that does not exist.
+
 ## [1.119.1] - 2026-07-30
 
 ### Fixed

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.119.1",
+  "version": "1.119.2",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi — Autonomous Code Companion"

--- a/plugins/aimi-engineering/hooks/pre-bash-dispatcher.py
+++ b/plugins/aimi-engineering/hooks/pre-bash-dispatcher.py
@@ -25,36 +25,83 @@ from hook_utils import safe_hook, effective_cwd, load_aimi_config, deny  # noqa:
 # re module. No re.MULTILINE flag: the newline case is handled as a literal
 # lookbehind alternative, not via `^`/`$` line semantics.
 #
+# `_CMD_START` is the anchor followed by `_CMD_PREFIX`, the bounded run of
+# tokens a real invocation may legitimately carry between the separator and
+# `git`: environment assignments, the four wrapper commands, and the keywords
+# that open a body. Anchoring alone (1.119.1) rejected all of those, which
+# silently stopped guarding `GIT_AUTHOR_DATE=... git commit` and `sudo git
+# commit` — shapes the pre-anchoring regexes did detect.
+#
 # Residual risk (accepted, documented here rather than fixed). This list is
 # meant to be exhaustive — a reader should be able to trust that a shape not
 # named here is detected. Undetected:
 #   * nested inside `bash -c '...'`, a subshell `(git commit)`, or command
 #     substitution `$(git commit)`;
 #   * chained with a single `&` (background) rather than `&&`;
-#   * inside an `if`/`then`, `else`, `case`, loop (`do ... done`) or brace-
-#     group body;
-#   * preceded on the same statement by an environment assignment or wrapper
-#     prefix — `GIT_AUTHOR_DATE=... git commit`, `env`, `sudo`, `time`,
-#     `nohup`. `\s*` after the anchor consumes whitespace only, so anything
-#     between the separator and `git` breaks the match;
+#   * inside a `case` arm, or any body opened by `(` — `(` is deliberately
+#     not an anchor, since a paren as an anchor reopens the mention-matching
+#     false positives of issue #82;
+#   * a wrapper outside the four below (`timeout`, `xargs`, `command`,
+#     `exec`, `nice`, `stdbuf`), or one carrying its own option token
+#     (`sudo -u alice git commit`, `env -i git commit`, `time -p git
+#     commit`) — covering those needs another nested quantifier, which is
+#     not worth the backtracking surface;
+#   * an assignment whose value holds a `$(...)` substitution containing
+#     whitespace, or whose unquoted form starts with a quote (`VAR="a"b`);
+#   * a prefix run deeper than the {0,6} ceiling below;
 #   * option forms other than `-C`: `git -c key=value commit`,
 #     `git --git-dir=... commit`.
-# The old unanchored regexes caught these shapes only "by accident" — while
-# also false-positiving on mere mentions of the phrase. Closing the quote-
-# wrapped cases would require quote/paren-aware shell parsing, which is out of
-# scope here.
-# The trailing run must exclude `\n` specifically. A newline is both an anchor
-# (its own lookbehind branch) and a `\s` character, so `\s*` would let every
-# position inside a whitespace run start a match and then backtrack across the
-# rest of it — quadratic on a long run of blank lines (seconds of CPU on a few
-# thousand, enough to exhaust the hook timeout and stop denying anything).
-# `[^\S\n]*` is "whitespace except newline", which keeps `\r`, `\v` and `\f`
-# matching exactly as `\s*` did; `[ \t]*` would silently stop detecting a
-# command prefixed by a carriage return.
-_CMD_START = r"(?:(?<=^)|(?<=;)|(?<=&&)|(?<=\|\|)|(?<=\|)|(?<=\n))[^\S\n]*"
+# Note `FOO=a&b git commit` is NOT in this list: it does not match, and that
+# is correct rather than a gap — bash parses it as `FOO=a &` followed by
+# `b git commit`, so no commit runs. Excluding `&` from the value class is
+# faithful shell semantics.
+# Also: `effective_cwd` (hook_utils) resolves a `cd <path> &&` prefix only at
+# string start, so a `cd` inside a `do`/`then` body — newly detected here —
+# falls back to the session cwd and may check the wrong repository's branch.
+# Closing the quote-wrapped cases above would require quote/paren-aware shell
+# parsing, which is out of scope here.
+#
+# The anchor's trailing run must exclude `\n` specifically. A newline is both
+# an anchor (its own lookbehind branch) and a `\s` character, so `\s*` would
+# let every position inside a whitespace run start a match and then backtrack
+# across the rest of it — quadratic on a long run of blank lines (seconds of
+# CPU on a few thousand, enough to exhaust the hook timeout and stop denying
+# anything). `[^\S\n]*` is "whitespace except newline", which keeps `\r`, `\v`
+# and `\f` matching exactly as `\s*` did; `[ \t]*` would silently stop
+# detecting a command prefixed by a carriage return.
+_CMD_ANCHOR = r"(?:(?<=^)|(?<=;)|(?<=&&)|(?<=\|\|)|(?<=\|)|(?<=\n))[^\S\n]*"
+
+# The prefix run is bounded ({0,6}) and its assignment-value branches are
+# disjoint by first character — the bare branch may not begin with a quote,
+# and empty is its own branch. Both matter, and for different reasons. A bare
+# branch that may start with a quote makes `A="xy" ` parse two ways over the
+# identical span, doubling live paths per token: 0.0004s at 10 tokens,
+# 0.023s at 16, 0.38s at 20, over 3s at 24. The disjoint branches remove that
+# outright; the {0,6} ceiling on its own does NOT — measured, a bounded run
+# over an ambiguous value still scales ~5-7x per doubling, because the blowup
+# lives inside one iteration rather than in the iteration count. Keep both:
+# the ceiling is what makes a future added alternative safe by construction.
+# The {0,63} bound on the variable name likewise stops a long identifier with
+# no `=` from backtracking one character at a time. Each token's mandatory
+# trailing `[^\S\n]+` supplies the word boundary (`sudoedit`, `done`,
+# `timeout` cannot match) and guarantees no iteration matches empty — it is
+# also what keeps `find ... {} \;` and `jq '{a: 1}'` out of the guard, since
+# `{` and `!` then only match their real shell-operator forms.
+_ENV_ASSIGN = (
+    r"[A-Za-z_][A-Za-z0-9_]{0,63}="
+    r"(?:\"[^\"\n]*\"|'[^'\n]*'|[^\s;&|\"'][^\s;&|]*|)"
+)
+_WRAPPER_CMD = r"(?:sudo|env|time|nohup)"
+_BODY_KEYWORD = r"(?:do|then|else|\{|!)"
+_CMD_PREFIX = (
+    r"(?:(?:" + _ENV_ASSIGN + r"|" + _WRAPPER_CMD + r"|" + _BODY_KEYWORD
+    + r")[^\S\n]+){0,6}"
+)
+
+_CMD_START = _CMD_ANCHOR + _CMD_PREFIX
 
 _GIT_COMMIT_RE = re.compile(_CMD_START + r"\bgit\s+commit\b")
-_GIT_WORKTREE_ADD_RE = re.compile(_CMD_START + r"git\s+worktree\s+add\b")
+_GIT_WORKTREE_ADD_RE = re.compile(_CMD_START + r"\bgit\s+worktree\s+add\b")
 
 # Used by handle_default_branch for git -C variant. Path token accepts a
 # double-quoted path, a single-quoted path, or a bare non-whitespace token so

--- a/plugins/aimi-engineering/hooks/tests/test_guard_default_branch.py
+++ b/plugins/aimi-engineering/hooks/tests/test_guard_default_branch.py
@@ -265,3 +265,38 @@ def test_custom_protected_branches_via_config(tmp_path):
     data = json.loads(captured[0])
     assert data["hookSpecificOutput"]["permissionDecision"] == "deny"
     assert "release" in data["hookSpecificOutput"]["userMessage"]
+
+
+# ---------------------------------------------------------------------------
+# Statement-prefix detection reaches the deny path (issue #82 follow-up)
+# ---------------------------------------------------------------------------
+
+def test_denies_env_prefixed_commit_on_protected_branch():
+    """`GIT_AUTHOR_DATE=... git commit` is a real invocation, not a mention.
+
+    1.119.1's anchoring rejected any token between the separator and `git`,
+    so this shape -- the canonical way to backdate a commit -- stopped being
+    guarded entirely, silently.
+    """
+    captured = _run_handler("GIT_AUTHOR_DATE=2020-01-01 git commit -m x", "main")
+    assert captured, "Expected deny for an env-prefixed commit on a protected branch"
+    data = json.loads(captured[0])
+    assert data["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_denies_sudo_prefixed_commit_on_protected_branch():
+    captured = _run_handler("sudo git commit -m x", "main")
+    assert captured, "Expected deny for a sudo-prefixed commit on a protected branch"
+    assert json.loads(captured[0])["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_denies_loop_body_commit_on_protected_branch():
+    captured = _run_handler("for f in a b; do git commit -m $f; done", "main")
+    assert captured, "Expected deny for a commit inside a loop body"
+    assert json.loads(captured[0])["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_env_prefixed_mention_still_allows_on_protected_branch():
+    """The prefix must not drag mentions back in -- issue #82 stays closed."""
+    captured = _run_handler('echo "FOO=1 git commit"', "main")
+    assert captured == [], f"Expected silent allow for a mention, got {captured}"

--- a/plugins/aimi-engineering/hooks/tests/test_guard_worktree_budget.py
+++ b/plugins/aimi-engineering/hooks/tests/test_guard_worktree_budget.py
@@ -685,3 +685,45 @@ def test_denies_git_C_quoted_path_worktree_add_when_budget_exhausted(tmp_path, m
     assert captured, "Expected deny message -- quoted git -C path worktree add must reach budget-counting logic"
     deny_data = json.loads(captured[0])
     assert "2/2" in deny_data["hookSpecificOutput"]["userMessage"]
+
+
+def test_denies_loop_body_worktree_add_when_budget_exhausted(tmp_path, monkeypatch):
+    """A worktree add inside a `do ... done` body must still be gated.
+
+    Creating several worktrees in a loop is the natural way to blow the
+    budget, and it is exactly the shape 1.119.1's anchoring stopped seeing.
+    """
+    _make_tasks_json(tmp_path, max_concurrency=2)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(subprocess, "run", _fake_run_factory(2, str(tmp_path)))
+    monkeypatch.delenv("AIMI_WORKTREE_BUDGET_GUARD", raising=False)
+
+    captured = []
+    monkeypatch.setattr("builtins.print", lambda msg: captured.append(msg))
+
+    cmd = "for f in a b; do git worktree add ../wt-$f feat/$f; done"
+    with pytest.raises(SystemExit) as exc_info:
+        dispatcher.handle_worktree_budget(cmd, _tool_input_for(cmd))
+
+    assert exc_info.value.code == 0
+    assert captured, "Expected deny message -- loop-body invocation must be gated"
+    deny_data = json.loads(captured[0])
+    assert "2/2" in deny_data["hookSpecificOutput"]["userMessage"]
+
+
+def test_denies_sudo_prefixed_worktree_add_when_budget_exhausted(tmp_path, monkeypatch):
+    _make_tasks_json(tmp_path, max_concurrency=2)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(subprocess, "run", _fake_run_factory(2, str(tmp_path)))
+    monkeypatch.delenv("AIMI_WORKTREE_BUDGET_GUARD", raising=False)
+
+    captured = []
+    monkeypatch.setattr("builtins.print", lambda msg: captured.append(msg))
+
+    cmd = "sudo git worktree add ../wt-new feat/x"
+    with pytest.raises(SystemExit) as exc_info:
+        dispatcher.handle_worktree_budget(cmd, _tool_input_for(cmd))
+
+    assert exc_info.value.code == 0
+    assert captured, "Expected deny message -- sudo-prefixed invocation must be gated"
+    assert "2/2" in json.loads(captured[0])["hookSpecificOutput"]["userMessage"]

--- a/plugins/aimi-engineering/hooks/tests/test_pre_bash_dispatcher.py
+++ b/plugins/aimi-engineering/hooks/tests/test_pre_bash_dispatcher.py
@@ -459,3 +459,163 @@ def test_main_prefilter_does_not_swallow_a_real_commit():
     out = _run_dispatcher("git commit -m x", branch="main")
     assert out, "Expected deny -- prefilter wrongly skipped a real invocation"
     assert json.loads(out[0])["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+# ---------------------------------------------------------------------------
+# Statement-prefix detection: env assignments, wrappers, body keywords
+#
+# 1.119.1's anchoring rejected every token between the separator and `git`,
+# which silently stopped guarding shapes the pre-anchoring regexes caught.
+# ---------------------------------------------------------------------------
+
+def _detects(command):
+    """True when any of the four guard regexes matches the detection copy."""
+    detect = dispatcher._strip_heredocs(command)
+    return any(
+        pattern.search(detect)
+        for pattern in (
+            dispatcher._GIT_COMMIT_RE,
+            dispatcher._GIT_C_COMMIT_RE,
+            dispatcher._GIT_WORKTREE_ADD_RE,
+            dispatcher._GIT_C_WORKTREE_ADD_RE,
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "GIT_AUTHOR_DATE=2020-01-01 git commit -m x",
+        'GIT_AUTHOR_DATE="2020-01-01 12:00:00" git commit -m x',
+        "GIT_AUTHOR_DATE='2020-01-01 12:00:00' git commit -m x",
+        "GIT_AUTHOR_DATE=2020-01-01 GIT_COMMITTER_DATE=2020-01-01 git commit -m x",
+        "EMPTY= git commit -m x",
+        'FOO=a"b" git commit -m x',
+        'PATH="$HOME/bin:$PATH" git commit',
+        "sudo git commit -m x",
+        "env FOO=1 git commit",
+        "time git commit",
+        "nohup git commit",
+        "for f in a b; do git commit -m $f; done",
+        "if ok; then git commit; fi",
+        "if x; then y; else git commit; fi",
+        "{ git commit -m x; }",
+        "! git commit",
+        "while read l; do sudo GIT_AUTHOR_DATE=1 git commit; done",
+        "cd /r && sudo git commit -m x",
+        "x\n  GIT_AUTHOR_DATE=1 git commit",
+        "sudo git -C /repo commit -m x",
+        'FOO=1 git -C "/path with spaces" commit -m x',
+        "sudo git worktree add /tmp/w",
+        "FOO=1 git worktree add /tmp/w",
+        "for f in a; do git worktree add /tmp/w; done",
+        "if x; then git -C /r worktree add /tmp/w; fi",
+    ],
+)
+def test_statement_prefix_shapes_are_detected(command):
+    assert _detects(command), f"prefix shape must be detected: {command!r}"
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Issue #82's own class -- these must never come back.
+        'grep -rn "git commit" file.txt',
+        "echo 'remember to git commit later'",
+        'rg "git commit" -n',
+        'echo "TODO: git commit"',
+        'grep -rn "git worktree add" .',
+        'echo "sudo git commit"',
+        'echo "FOO=1 git commit"',
+        'git log --grep "git commit"',
+        "cat <<EOF\nremember to git commit\nEOF",
+        # `{` and `!` survive ONLY because a prefix token requires trailing
+        # whitespace: `{}`, `{a:`, `{print`, `!=` and `!!` all fail on that.
+        r'find . -name "*.py" -exec grep -l "git commit" {} \;',
+        "jq '{a: 1}' f.json; echo git commit",
+        "awk '{print $1}' f; echo 'git commit'",
+        "ls {src,test}; echo git commit",
+        'test "$a" != "git commit"',
+        "echo ${GIT_DIR} | wc -l; echo git commit",
+        # A wrapper-looking word that is not a wrapper invocation.
+        "timeout 5 echo git commit",
+        "echo hi! git commit",
+        'python3 -m pytest -k "git_commit"',
+        "git status # git commit later",
+        'docker run img sh -c "git commit"',
+    ],
+)
+def test_mere_mentions_stay_undetected_with_statement_prefixes(command):
+    assert not _detects(command), f"mention must stay silent: {command!r}"
+
+
+def test_prefix_depth_ceiling_is_six():
+    """Pins the documented {0,6} bound so a reader meets it as a decision.
+
+    Six covers the deepest realistic prefix; a seventh token is dropped.
+    """
+    assert dispatcher._GIT_COMMIT_RE.search("A=1 " * 6 + "git commit")
+    assert dispatcher._GIT_COMMIT_RE.search(
+        "x; do sudo GIT_A=1 GIT_B=2 GIT_C=3 git commit"
+    )
+    assert dispatcher._GIT_COMMIT_RE.search("A=1 " * 7 + "git commit") is None
+
+
+def test_prefix_run_does_not_backtrack_exponentially():
+    """The assignment-value branches must stay disjoint by first character.
+
+    A bare value branch that may begin with a quote makes `A="xy" ` parse two
+    ways over the identical span, doubling live paths per token: 0.0004s at
+    n=10, 0.023s at n=16, 0.38s at n=20, over 3s at n=24 before the fix.
+    n=30 sits well past the {0,6} ceiling so this fails if EITHER defence --
+    the disjoint branches or the bound -- is later removed.
+    """
+    import time
+
+    payload = 'A="xy" ' * 30 + "gi"
+    start = time.perf_counter()
+    for pattern in (
+        dispatcher._GIT_COMMIT_RE,
+        dispatcher._GIT_C_COMMIT_RE,
+        dispatcher._GIT_WORKTREE_ADD_RE,
+        dispatcher._GIT_C_WORKTREE_ADD_RE,
+    ):
+        assert pattern.search(payload) is None
+    elapsed = time.perf_counter() - start
+    assert elapsed < 0.5, f"prefix scan took {elapsed:.3f}s -- backtracking regression"
+
+
+def test_prefix_scan_is_linear_across_many_anchors():
+    """A large command with a prefix run at every anchor must stay cheap.
+
+    The short canary above cannot see a multiplicative term that only shows
+    up once many anchor positions each pay the prefix cost.
+    """
+    import time
+
+    payload = ("A=1 B=2 sudo do then gi;\n" * 1600) + "echo done"
+    assert len(payload) > 35_000
+    start = time.perf_counter()
+    for pattern in (
+        dispatcher._GIT_COMMIT_RE,
+        dispatcher._GIT_C_COMMIT_RE,
+        dispatcher._GIT_WORKTREE_ADD_RE,
+        dispatcher._GIT_C_WORKTREE_ADD_RE,
+    ):
+        assert pattern.search(payload) is None
+    elapsed = time.perf_counter() - start
+    assert elapsed < 1.0, f"many-anchor scan took {elapsed:.3f}s -- cost regression"
+
+
+def test_main_denies_env_prefixed_commit_on_protected_branch():
+    """End-to-end through main(), not just the regex: the flagship shape."""
+    out = _run_dispatcher("GIT_AUTHOR_DATE=2020-01-01 git commit -m x", branch="main")
+    assert out, "Expected deny -- env-prefixed commit must reach the guard"
+    data = json.loads(out[0])
+    assert data["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_main_denies_sudo_prefixed_commit_on_protected_branch():
+    out = _run_dispatcher("sudo git commit -m x", branch="main")
+    assert out, "Expected deny -- sudo-prefixed commit must reach the guard"
+    assert json.loads(out[0])["hookSpecificOutput"]["permissionDecision"] == "deny"


### PR DESCRIPTION
## Summary

PR #83 (v1.119.1) anchored the guard regexes to command-start position to fix issue #82 — a mere *mention* of the phrase inside a `grep`/`echo`/heredoc was denying the command. That worked, but it **regressed real detections**, and the regression is in the fail-open direction: the commit on the protected branch just happens, with no message at all.

`[^\S\n]*` after the anchor consumes whitespace only, so any token between the separator and `git` broke the match:

| command | v1.119.0 | v1.119.1 | this PR |
|---|---|---|---|
| `GIT_AUTHOR_DATE=2020-01-01 git commit -m x` | detects | **misses** | detects |
| `sudo git commit -m x` | detects | **misses** | detects |
| `for f in a b; do git commit -m $f; done` | detects | **misses** | detects |
| `if ok; then git commit; fi` | detects | **misses** | detects |
| `grep -rn "git commit" f.txt` (mention) | *false positive* | silent | silent |

The env-assignment prefix is an everyday git idiom — it was the most likely shape of all, and the one that escaped.

## The change

`_CMD_START` becomes `_CMD_ANCHOR` (unchanged from 1.119.1) + `_CMD_PREFIX`, a bounded run of the tokens a real invocation may legitimately carry: environment assignments, the four wrapper commands, and the keywords that open a body. The four guard regexes already concatenate `_CMD_START`, so **none of their own definitions changed and no call site moved** — the functional diff is one constant.

Two decisions carry the weight, and both were measured rather than argued:

**The assignment-value branches are disjoint by first character.** The bare branch may not begin with a quote, and empty is its own branch. Without that, `A="xy" ` parses two ways over the identical span and live paths double per token — 0.0004 s at 10 tokens, 0.023 s at 16, 0.38 s at 20, over 3 s at 24. This is the same class of defect as the quadratic `\s*` that shipped in 1.119.1, caught before merging this time.

**The `{0,6}` ceiling does *not* fix that on its own.** Worth stating plainly for whoever revisits this: a bounded run over an ambiguous value still scales roughly 5–7× per doubling, because the blowup lives *inside* one iteration rather than in the iteration count. The disjoint branches are what actually fix it; the bound is defence in depth, so that a future added alternative is safe by construction.

**Every token requires trailing whitespace.** That supplies the word boundary (`sudoedit`, `done`, `timeout` cannot match), guarantees no iteration matches empty, and is precisely what keeps `find … {} \;`, `jq '{a: 1}'`, `awk '{print $1}'`, brace expansion `{src,test}`, `${VAR}` and `!=` out of the guard.

Also normalises the leading `\b` on `_GIT_WORKTREE_ADD_RE` — a proven no-op that four separate reviewers had flagged as an unexplained asymmetry.

## Verification

- **Red-green proven.** The 33 new assertions were run against the shipped 1.119.1 regexes via in-memory injection and all 33 fail — a count matching the must-hit table exactly (25 parametrized shapes + the depth ceiling + 2 end-to-end + 3 deny-path + 2 worktree-budget). The must-stay-silent table passes against the old code by construction, so only the must-hit set carries signal.
- **Strict superset.** Differential over all 802 string literals in `hooks/tests/`: 28 detections gained, **zero lost**.
- **Cost pinned by two tests**, because without them a future edit reinstates an ambiguous branch and nobody notices until a session hangs: an exponential canary well past the `{0,6}` ceiling, and a ~40 KB many-anchor command that must finish under a second. Worst measured cost versus the shipped regexes is ~1.6× on adversarial payloads orders of magnitude larger than any real command, against a 60 s hook timeout.
- **285 tests pass** (229 before).

## Residual risk, documented in the code comment and CHANGELOG

Still undetected, deliberately: a wrapper outside the four covered (`timeout`, `xargs`, `command`, `exec`, `nice`) or one carrying its own option token (`sudo -u alice git commit`, `env -i git commit`); an assignment whose value holds a `$(...)` with whitespace; `VAR="a"b`; prefix runs deeper than six tokens; `case` arms and bodies opened by `(`. Plus the pre-existing `bash -c`, subshell, command substitution and single-`&` cases from 1.119.1.

One note for future readers, recorded in the comment block: `FOO=a&b git commit` not matching is **correct**, not a gap — bash parses it as `FOO=a &` followed by `b git commit`, so no commit runs. Excluding `&` from the value class is faithful shell semantics.

The 1.119.1 CHANGELOG entry's "Known limitation" bullet claimed this whole class was accepted risk; the new entry explicitly supersedes that clause so the two do not contradict each other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSzwwMhzmh38hZ9eL9gtuK
