### PR TITLE
fix(install): write opencode.json permission key in singular form (fixes #92)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and worktree+team orchestration.",
-      "version": "1.119.2",
+      "version": "1.119.3",
       "author": {
         "name": "Aimi — Autonomous Code Companion",
         "url": "https://github.com/aimi-so"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.119.3] - 2026-08-01
+
+### Fixed
+
+- **`install.sh` wrote OpenCode Bash auto-approval rules under `permissions` (plural), the opencode 0.x schema key; opencode 1.x rejects unknown top-level keys at startup with `Unrecognized key: permissions`, aborting launch before any session starts.** `install_permissions()` and `uninstall_permissions()` now use the singular `permission` key throughout: the heredoc JSON fragment, the `jq` merge (`.permission = ((.permission // {}) * $perms.permission)`), the `python3` fallback (`cfg.get('permission', …)`, `perms['permission']`, `cfg['permission']`), and the uninstall path (`grep '"permission"'`, `del(.permission)`, `cfg.pop('permission', None)`). Verified against the canonical schema at <https://opencode.ai/docs/permissions> and against opencode 1.18.10, where the singular key loads cleanly and the plural key is the rejection the user reproduced. Comments and human-readable log strings (`ok "Removed permissions from …"`) are unchanged — they are prose, not schema keys.
+- **Known limitation, accepted as residual risk:** a reinstall over an `opencode.json` that already carries the stale plural `permissions` key from a prior buggy install does **not** self-heal. The installer's idempotency guard greps for the `"git *"` rule, finds it under the old plural key, and returns early without ever writing the singular key or removing the plural one — so the startup crash persists across reinstalls. Affected users must delete the `permissions` (plural) block from `~/.config/opencode/opencode.json` by hand once; a migration step in `install_permissions()` was deliberately deferred. Fresh installs are correct.
+
 ## [1.119.2] - 2026-07-30
 
 ### Fixed

--- a/install.sh
+++ b/install.sh
@@ -863,7 +863,7 @@ install_permissions() {
   local perms_json
   perms_json=$(cat <<PERMS
 {
-  "permissions": {
+  "permission": {
     "bash": {
       "git *": "allow",
       "$aimi_cli": "allow",
@@ -890,7 +890,7 @@ PERMS
     if command -v jq >/dev/null 2>&1; then
       local tmp
       tmp=$(mktemp)
-      jq --argjson perms "$perms_json" '.permissions = ((.permissions // {}) * $perms.permissions)' "$config_file" > "$tmp" && mv "$tmp" "$config_file"
+      jq --argjson perms "$perms_json" '.permission = ((.permission // {}) * $perms.permission)' "$config_file" > "$tmp" && mv "$tmp" "$config_file"
     elif command -v python3 >/dev/null 2>&1; then
       python3 -c "
 import json, sys
@@ -901,10 +901,10 @@ with open('$config_file') as f:
     try: cfg = json.load(f)
     except: cfg = {}
 
-existing = cfg.get('permissions', {})
-for section, rules in perms['permissions'].items():
+existing = cfg.get('permission', {})
+for section, rules in perms['permission'].items():
     existing.setdefault(section, {}).update(rules)
-cfg['permissions'] = existing
+cfg['permission'] = existing
 
 with open('$config_file', 'w') as f:
     json.dump(cfg, f, indent=2)
@@ -1157,18 +1157,18 @@ with open('$config_file', 'w') as f:
   fi
 
   # Remove permissions from opencode.json
-  if [ -f "$config_file" ] && grep -q '"permissions"' "$config_file" 2>/dev/null; then
+  if [ -f "$config_file" ] && grep -q '"permission"' "$config_file" 2>/dev/null; then
     if command -v jq >/dev/null 2>&1; then
       local tmp
       tmp=$(mktemp)
-      jq 'del(.permissions)' "$config_file" > "$tmp" && mv "$tmp" "$config_file"
+      jq 'del(.permission)' "$config_file" > "$tmp" && mv "$tmp" "$config_file"
       ok "Removed permissions from $config_file"
     elif command -v python3 >/dev/null 2>&1; then
       python3 -c "
 import json
 with open('$config_file') as f:
     cfg = json.load(f)
-cfg.pop('permissions', None)
+cfg.pop('permission', None)
 with open('$config_file', 'w') as f:
     json.dump(cfg, f, indent=2)
     f.write('\n')

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.119.2",
+  "version": "1.119.3",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi — Autonomous Code Companion"


### PR DESCRIPTION
Fixes #92.

## Summary

`install_permissions()` and `uninstall_permissions()` wrote OpenCode Bash auto-approval rules under `permissions` (**plural**) — the opencode 0.x schema key. opencode 1.x rejects unknown top-level keys at startup with `Unrecognized key: permissions`, aborting launch before any session starts. Reproduced on opencode 1.18.10.

The installer now uses the singular `permission` key everywhere, matching the canonical schema at https://opencode.ai/docs/permissions.

## Root cause

The installer was written against the opencode 0.x schema. The 1.x loader rejects the plural key, so every `./install.sh --to opencode` (or reinstall) produced an `opencode.json` that crashed opencode on startup.

## What changed — `install.sh`

8 substitutions across the install and uninstall paths, no logic changes:

| Line | From | To |
|---|---|---|
| 866 | `"permissions":` | `"permission":` |
| 893 | `.permissions = ((.permissions // {}) * $perms.permissions)` | `.permission = ((.permission // {}) * $perms.permission)` |
| 904 | `cfg.get('permissions', {})` | `cfg.get('permission', {})` |
| 905 | `perms['permissions'].items()` | `perms['permission'].items()` |
| 907 | `cfg['permissions'] = existing` | `cfg['permission'] = existing` |
| 1160 | `grep -q '"permissions"'` | `grep -q '"permission"'` |
| 1164 | `del(.permissions)` | `del(.permission)` |
| 1171 | `cfg.pop('permissions', None)` | `cfg.pop('permission', None)` |

Comments and human-readable log strings (`ok "Removed permissions from …"`) are unchanged — they are prose, not schema keys.

Version bumped 1.119.2 → 1.119.3 (patch) across `plugin.json`, `marketplace.json`, and `CHANGELOG.md`, matching the PR #83 / #84 release pattern.

## Verification

No `install.sh` test harness exists, so verified manually into isolated temp `HOME` dirs:

- **`jq` install path** — real `./install.sh --to opencode` writes top-level keys `["mcp", "permission"]`; the `permission.bash` rules are correct; no stale `permissions` key.
- **`python3` fallback** — merges `permission` while preserving sibling keys; `cfg.pop('permission', None)` removes it.
- **`jq` uninstall path** — `del(.permission)` fires (log: `Removed permissions from …`); post-uninstall keys are `["mcp"]`, `permission` is `null`.
- `bash -n install.sh` clean.

## Known limitation (documented, deliberately not fixed here)

A reinstall over an `opencode.json` that already carries the stale plural `permissions` key from a prior buggy install **does not self-heal**: the idempotency guard (`install.sh:883`) greps for `"git *"`, finds it under the old plural key, and returns early — so the singular key is never written and the plural one is never removed, leaving the startup crash in place. Affected users must delete the `permissions` (plural) block from `~/.config/opencode/opencode.json` by hand once. A migration step in `install_permissions()` was deliberately deferred from this PR (tracked in issue #92's follow-up). Fresh installs are correct.