### PR TITLE
fix: number computed waves from 1, so validate-waves agrees with the writer

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimi-engineering",
       "description": "Fully standalone autonomous task execution with aimi-native agents. Direct tasks.json generation, guided brainstorming, multi-agent review, iterative execution with parallel story support via dependency graphs and worktree+team orchestration.",
-      "version": "1.123.0",
+      "version": "1.123.1",
       "author": {
         "name": "Aimi — Autonomous Code Companion",
         "url": "https://github.com/aimi-so"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.123.1] - 2026-08-28
+
+One issue — #129 — closed by a one-character correction and the release that
+carries it. PATCH rather than MINOR: nothing is added, no syntax changes, and
+no field appears or disappears; a validator that disagreed with every other
+component in the plugin now agrees with them. The thing worth knowing before
+you upgrade is that `validate-waves` was not occasionally wrong — it was wrong
+about every story of every file it was ever given, so a verdict that flips
+from invalid to valid on this upgrade is the verb being repaired, not your
+data changing.
+
+### Fixed
+
+- **`validate-waves` computed waves from 0 while `story-merge` writes them from 1, so it reported a mismatch on every story of every tasks file for its entire existence.** `computed_waves` in `tasks.py` seeded a story with no dependencies at wave 0, while `compute_waves` in `story_merge.py` — the component that *writes* the field — seeds it at 1. The two never agreed, so every story in every file the planner produced came back off by exactly one. Concretely: the tasks file behind the previous release reported eight mismatches, `US-001 stored=1 computed=0` through `US-008 stored=2 computed=1`, every one off by one; it now reports `valid: true` with no errors. **If a file the verb used to call invalid now passes, nothing changed in your data** — the verb was previously wrong about every file it was handed, correct ones included.
+- **The validator is the side that was corrected, and that was not a coin flip.** Four components already stated the 1-based convention, against `tasks.py` alone: `story_merge.py`'s `compute_waves`, the writer; `commands/plan.md`'s schema, which defines the field as "computed from dependsOn: roots=1, others=max(dep waves)+1" and repeats "wave 1 for roots" in two further checklist lines; and `commands/execute.md`, which starts its displayed wave numbering at 1 and prints it as `--- Wave [n] ---`. Correcting the writer instead would have invalidated every `tasks.json` already on disk and left the stored field disagreeing with the number you read on screen. The change is one seed value — `current[story_id] = 0` becoming `= 1`. The n-pass reduce, the increment and the mismatch predicate are all untouched, so a story inside a dependency cycle is still assigned no wave at all and a dangling `dependsOn` still hides its own story's wave errors; reporting those remains `validate-deps`' job.
+- **Why this went unnoticed for the field's whole life: the failure was reported into a channel nothing branches on.** Nothing but `validate-waves` itself reads the stored `wave` field — `story-merge` writes it, `plan.md` documents it, and `execute.md` counts its own wave loop rather than reading it — so a wrong value corrupted no behavior anywhere. And `validate-waves` **always exits 0**, invalid verdict included: the verdict lives in `.valid` in its JSON output, so anything checking exit status saw success on every run. That exit status is unchanged here, deliberately, and a test still pins it against a wave-mismatch fixture. This release changes which verdict the verb computes, never how it reports one.
+- **`tests/golden_from_jq.json` moved, which it normally must not, and the reason is that the disagreement predates the Python port.** That corpus was captured from the jq implementations before they were deleted and is the evidence the port changed nothing, so it is frozen except for the single carve-out `CLAUDE.md` names — a genuine rule change, recorded in the same commit with the reason in the message. This is that case: both sides are faithful ports, the jq behind `tasks.py` already disagreed with the jq behind `story_merge.py`, so the 0-based answers recorded there were the jq's own and the port reproduced them correctly. Only the `tasks_validate_cases` block moved. Of its 82 recorded `validate-waves` cases, 63 were re-recorded, 6 came back byte-identical (every one a document in which no story is ever assigned a wave) and 13 are engine-abort recordings already excused by name, which never depended on the convention. Across all 82 only `stdout` differs — `input`, `exit`, `stderr` and `state_after` are byte-identical — and each of the 63 was re-recorded by replaying its own stored input through the CLI, never regenerated from the Python. Every other block in the file is untouched, and the block's own comment gained its reason as an append, keeping the existing text as a byte-for-byte prefix. Six new pytest cases pin the convention directly rather than through a recording, and all six fail against the 0-based seed. Issue #129.
+
 ## [1.123.0] - 2026-08-27
 
 Two issues — #126 and #127 — closed by six of the seven stories landed on one

--- a/plugins/aimi-engineering/.claude-plugin/plugin.json
+++ b/plugins/aimi-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimi-engineering",
-  "version": "1.123.0",
+  "version": "1.123.1",
   "description": "Autonomous task execution with standalone aimi-native agents. Direct tasks.json generation, research-driven planning, multi-agent review, iterative execution.",
   "author": {
     "name": "Aimi — Autonomous Code Companion"

--- a/plugins/aimi-engineering/scripts/tasks.py
+++ b/plugins/aimi-engineering/scripts/tasks.py
@@ -1211,16 +1211,35 @@ def validate_ids(docs):
 
 
 def computed_waves(stories):
-    """The wave assignment, exactly as the jq's nested reduce built it.
+    """Roots are wave 1; everyone else is max(dependency waves) + 1.
 
-    n outer passes over the stories still unassigned; a story with no
-    dependencies lands in wave 0, one whose dependencies are ALL already
-    assigned lands one above their max, and one whose dependencies are not
-    lands nowhere this pass. A story inside a cycle is therefore never assigned
-    at all -- which is why validate-waves reports nothing for a cyclic file
-    (wave-ciclo) and why a dangling dependsOn hides every wave error in its
-    story (dep-pendurada). Both are recorded passes, not oversights: reporting
-    them is validate-deps' job.
+    THE SEED USED TO BE 0, AND THAT WAS THE OUTLIER. Four components state the
+    1-based convention and only this one stated 0-based, so every tasks file
+    story-merge writes reported a mismatch on every story it contains:
+
+      * story_merge.py's compute_waves -- the WRITER, "Roots are wave 1";
+      * commands/plan.md's schema -- "computed from dependsOn: roots=1, others
+        = max(dep waves)+1", repeated as "wave 1 for roots";
+      * commands/execute.md -- starts its display at `wave = 1` and prints it
+        as "--- Wave [wave] ---", so the stored field now agrees with the
+        number the user actually reads on screen.
+
+    The off-by-one was inherited, not introduced by the port: the jq this is a
+    port of already disagreed with the jq story_merge.py is a port of. Which is
+    why correcting it moves recorded answers in tests/golden_from_jq.json's
+    tasks_validate_cases block -- a rule change, recorded as one.
+
+    The walk itself is untouched, and its structure is load-bearing. n outer
+    passes over the stories still unassigned; a story with no dependencies
+    lands in wave 1, one whose dependencies are ALL already assigned lands one
+    above their max, and one whose dependencies are not lands nowhere this
+    pass. A story inside a cycle is therefore never assigned at all -- which is
+    why validate-waves reports nothing for a cyclic file (wave-ciclo) and why a
+    dangling dependsOn hides every wave error in its story (dep-pendurada).
+    Both are recorded passes, not oversights: reporting them is validate-deps'
+    job. Assignment is still tracked by key PRESENCE in $assigned, never by the
+    wave value, so seeding roots at 1 shifts every assigned story by exactly
+    one and changes nothing about who gets assigned.
     """
     deps = {}
     for story in stories:
@@ -1243,7 +1262,7 @@ def computed_waves(stories):
             story_deps = jq_alternative(deps.get(story_id), [])
             if jq_length(story_deps, STORY + ".dependsOn") == 0:
                 current = dict(current)
-                current[story_id] = 0
+                current[story_id] = 1
             elif all(
                 jq_has(current, dep, "$assigned")
                 for dep in jq_iterate(story_deps, STORY + ".dependsOn")

--- a/plugins/aimi-engineering/scripts/test-aimi-cli-part1-core.sh
+++ b/plugins/aimi-engineering/scripts/test-aimi-cli-part1-core.sh
@@ -7499,7 +7499,7 @@ _setup_gate_fixture() {
       "status": "pending",
       "dependsOn": [],
       "notes": "",
-      "wave": 0,
+      "wave": 1,
       "gate": {
         "type": "decision",
         "status": "pending",
@@ -7516,7 +7516,7 @@ _setup_gate_fixture() {
       "status": "completed",
       "dependsOn": [],
       "notes": "",
-      "wave": 0,
+      "wave": 1,
       "gate": {
         "type": "action",
         "status": "pending",
@@ -7532,7 +7532,7 @@ _setup_gate_fixture() {
       "status": "pending",
       "dependsOn": [],
       "notes": "",
-      "wave": 0,
+      "wave": 1,
       "gate": {
         "type": "verify",
         "status": "pending",
@@ -7548,7 +7548,7 @@ _setup_gate_fixture() {
       "status": "pending",
       "dependsOn": ["US-002"],
       "notes": "",
-      "wave": 1
+      "wave": 2
     },
     {
       "id": "US-005",
@@ -7559,7 +7559,7 @@ _setup_gate_fixture() {
       "status": "pending",
       "dependsOn": [],
       "notes": "",
-      "wave": 0
+      "wave": 1
     }
   ]
 }
@@ -7809,7 +7809,7 @@ test_validate_waves_mismatch() {
     {
       "id": "US-002",
       "title": "Depends on US-001",
-      "description": "Should be wave 1 but stored as 0",
+      "description": "Should be wave 2 but stored as 0",
       "acceptanceCriteria": ["Passes"],
       "priority": 2,
       "status": "pending",
@@ -7829,6 +7829,10 @@ WAVEOF
   local output exit_code
   output=$("$CLI" validate-waves) && exit_code=0 || exit_code=$?
 
+  # Both stories mismatch under the 1-based convention: the root stores 0 where
+  # it computes 1, and its dependent stores 0 where it computes 2. US-002 is the
+  # one asserted because it is the one whose wave comes from the WALK rather
+  # than from the seed.
   assert_contains '"valid": false' "$output" "validate-waves: mismatched waves fail validation"
   assert_contains "Wave mismatch" "$output" "validate-waves: reports wave mismatch error"
   assert_contains "US-002" "$output" "validate-waves: identifies US-002 as mismatched"

--- a/plugins/aimi-engineering/scripts/tests/golden_from_jq.json
+++ b/plugins/aimi-engineering/scripts/tests/golden_from_jq.json
@@ -24268,7 +24268,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\",\n    \"Wave mismatch: US-002 stored=1 computed=2\",\n    \"Wave mismatch: US-003 stored=2 computed=3\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -24388,7 +24388,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\",\n    \"Wave mismatch: US-002 stored=1 computed=2\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -24448,7 +24448,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-002 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -24748,7 +24748,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\",\n    \"Wave mismatch: US-002 stored=1 computed=2\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -24808,7 +24808,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\",\n    \"Wave mismatch: US-002 stored=1 computed=2\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -24868,7 +24868,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\",\n    \"Wave mismatch: US-001a stored=0 computed=1\",\n    \"Wave mismatch: US-012a stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -24928,7 +24928,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\",\n    \"Wave mismatch: us-002 stored=0 computed=1\",\n    \"Wave mismatch: US-3 stored=0 computed=1\",\n    \"Wave mismatch: US-0001 stored=0 computed=1\",\n    \"Wave mismatch: US-001A stored=0 computed=1\",\n    \"Wave mismatch: US-001  stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -25048,7 +25048,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\",\n    \"Wave mismatch:  stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -25108,7 +25108,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001\\nUS-002 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -25288,7 +25288,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\",\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -25348,7 +25348,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -25408,7 +25408,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -25468,7 +25468,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -25528,7 +25528,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -25588,7 +25588,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -25648,7 +25648,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -25708,7 +25708,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -25768,7 +25768,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -25828,7 +25828,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -25888,7 +25888,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -25948,7 +25948,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -26008,7 +26008,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -26068,7 +26068,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -26128,7 +26128,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -26188,7 +26188,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -26248,7 +26248,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -26308,7 +26308,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -26368,7 +26368,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -26428,7 +26428,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -26488,7 +26488,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -26548,7 +26548,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -26608,7 +26608,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -26668,7 +26668,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -26728,7 +26728,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -26788,7 +26788,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -26848,7 +26848,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -26908,7 +26908,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -26968,7 +26968,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -27028,7 +27028,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -27088,7 +27088,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -27148,7 +27148,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -27208,7 +27208,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -27268,7 +27268,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -27328,7 +27328,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -27388,7 +27388,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -27448,7 +27448,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-002 stored=5 computed=1\"\n  ]\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\",\n    \"Wave mismatch: US-002 stored=5 computed=2\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -27508,7 +27508,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-002 stored=null computed=1\"\n  ]\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\",\n    \"Wave mismatch: US-002 stored=null computed=2\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -27568,7 +27568,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-002 stored=null computed=1\"\n  ]\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\",\n    \"Wave mismatch: US-002 stored=null computed=2\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -27628,7 +27628,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-002 stored=1 computed=1\"\n  ]\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\",\n    \"Wave mismatch: US-002 stored=1 computed=2\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -27688,7 +27688,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\",\n    \"Wave mismatch: US-002 stored=1 computed=2\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -27748,7 +27748,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=1 computed=0\"\n  ]\n}\n",
+      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -27868,7 +27868,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\",\n    \"Wave mismatch: US-002 stored=1 computed=2\",\n    \"Wave mismatch: US-003 stored=1 computed=2\",\n    \"Wave mismatch: US-004 stored=2 computed=3\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -27928,7 +27928,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-002 stored=1 computed=2\",\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -27988,7 +27988,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-002 stored=true computed=1\"\n  ]\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\",\n    \"Wave mismatch: US-002 stored=true computed=2\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -28048,7 +28048,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-002 stored=null computed=1\"\n  ]\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\",\n    \"Wave mismatch: US-002 stored=null computed=2\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -28108,7 +28108,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -28168,7 +28168,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -28228,7 +28228,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -28288,7 +28288,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -28348,7 +28348,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -28408,7 +28408,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -28588,7 +28588,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: us-002 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -28648,7 +28648,7 @@
         "state": {}
       },
       "exit": 0,
-      "stdout": "{\n  \"valid\": true,\n  \"errors\": []\n}\n{\n  \"valid\": true,\n  \"errors\": []\n}\n",
+      "stdout": "{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-001 stored=0 computed=1\"\n  ]\n}\n{\n  \"valid\": false,\n  \"errors\": [\n    \"Wave mismatch: US-002 stored=0 computed=1\"\n  ]\n}\n",
       "stderr": "",
       "state_after": {}
     },
@@ -29133,7 +29133,7 @@
       "state_after": {}
     }
   ],
-  "_comment_tasks_validate": "The four validator verbs -- validate-deps, validate-stories, validate-ids and validate-waves -- captured exactly the way the three blocks before them were, and before their jq was deleted: 328 cases, 82 adversarial documents run through all four verbs, at commit 8d5477e. Recorded per case: the argv, the tasks file the run was given and the .aimi/state/ files it started with (`input`, so the case is REPLAYABLE and not merely described), exit code, stdout, stderr, and every .aimi/ file left behind afterwards (`state_after`). All 328 `state_after` values are empty, and that is this block's own evidence rather than a formality: these four are pure readers, so they take no lock, write no temp file and leave the document untouched -- a port that started writing one would have nowhere to hide. Each case ran in its own throwaway project root; exactly one normalization rule fired, the temp root to /TMP, and nothing else in the recording is non-deterministic. 1234 of 1312 field comparisons identical after the port, and 289 of the 328 cases matched on all four fields -- every stdout and every state_after matched in all 328. The 78 fields that differ fall in 39 cases, are exit code and stderr ONLY, and are all of one kind: jq aborting mid-expression, so the exit status was the engine's (5 for a runtime error, 4 for a parse error) and the message the code would otherwise have printed did not exist. Every one of them was, and still is, a refusal that writes nothing to stdout; only the wording and the number moved, to `Error: <verb>: <file>: <expression>: <what went wrong>` at exit 1. Recorded rather than reproduced, same as the 37 in _comment_tasks_read: synthesizing an engine error would be the only way to match, and that is not a thing to write on purpose. VALIDATE_DIVERGENCES in test_tasks.py names all 39 individually, in the ten groups the engine's own messages fall into: a userStories that is absent, null or a string (12), an acceptanceCriteria that is absent or null (2), a dependsOn that is a number (2), a document that is an array (4), malformed JSON at jq's own exit 4 (4), a story that is a string (3), a `has` against a string (2), a `test` against a non-string (4), an id used as an OBJECT KEY (4) and a `has` against a non-string key (2). The object-key group is validate-waves' alone and is worth naming: it builds `{(.id): ...}` before anything else runs, so an absent, numeric or array id kills that verb where the other three answer -- id-ausente-ids records the answer validate-ids gives the same document, `Invalid story ID: null`. THE CORPUS IS ADVERSARIAL BY CONSTRUCTION, not by claim: every one of the four verbs has at least one PASS and at least one distinct failure of every error class it can emit. validate-deps: a dangling reference (dep-pendurada), a self-reference (auto-referencia, which is necessarily also a cycle) and a cycle that is not one (ciclo, ciclo-longo). validate-stories: all twenty-four of its strings, one document each -- the three length caps, the two suspicious-content screens plus the tasks[] one, all four project rules, all five skills rules, all six tasks rules, the plural-gates field, `gate` missing each of type, status and prompt in turn and all three at once, a bare-string verification, and a story with no status. validate-ids: the accepted US-NNNa suffix (id-sufixo) beside five rejected forms (id-malformado), plus the four shapes that are not strings at all. validate-waves: a stale wave (wave-lacuna), an absent one (wave-ausente), a null one, a string one, a boolean one and a float one that is NOT a mismatch because jq and Python agree that 1.0 == 1. THREE CONTRACT DETAILS ARE PINNED HERE BECAUSE EACH LOOKS LIKE A DEFECT AND EACH WOULD BE A REGRESSION TO 'CORRECT'. (1) validate-ids' regex is `^US-[0-9]{3}[a-z]?$` and its message says `(expected US-NNN)`: the regex is the contract -- task-format-v3.md documents the suffix with US-012a as its example -- and the message describes the common case. US-001a is ACCEPTED (id-sufixo) and the wording is what /aimi:plan matches on, so neither may move to agree with the other. (2) validate-ids' output shape is ASYMMETRIC: the pass branch is `{valid, count}` with no `errors` key, the failure branch `{valid, errors}` with no `count`. A uniform `{valid, errors}` would pass a naive shape test and break the caller that reads them apart. (3) validate-waves NEVER returns non-zero: its bash body ended at the jq call with no `return 1`, unlike all three of its siblings, so an invalid verdict still exits 0 and the verdict lives in `.valid`. wave-lacuna-waves records `{valid: false}` at exit 0. And one message that reads like a typo and is not ours to correct: the plural-gates error says `gates` and `gate` with NO quotes around either, because the jq program sat inside a bash SINGLE-quoted string and the quotes the author typed closed and reopened it. gates-plural records the string bash actually assembled, which is the string the caller sees. FIVE CLASSES NO VALIDATOR FLAGS are recorded as the passes they are, so a later 'improvement' that starts flagging one shows up as a golden diff rather than as a silent contract change: a duplicated story id passes ALL FOUR (id-duplicado -- validate-ids checks format alone and validate-deps checks references alone); a story inside a cycle is never assigned a computed wave, so validate-waves reports nothing about it (wave-ciclo); a dangling dependsOn does the same to its own story (dep-pendurada-waves); an explicitly empty `skills: []` is legal (skills-vazio); and a dependsOn holding an ARRAY is legal too, because jq's `index` searches for a contiguous SUBSEQUENCE when the needle is an array and finds `[\"US-001\"]` inside `[\"US-001\", \"US-002\"]` (deps-array-elemento). WHERE A NAIVE PYTHON WOULD HAVE DIVERGED, each with the recorded case that catches it: `unique` inside validate-deps' cycle reduce sorts a dependsOn holding null, a number and a string, which jq orders and Python's sorted() raises TypeError on (deps-heterogeneo, the one place in these four that needs roadmap.py's jq_sort_key); `==` says a boolean is not a number, so a hand-edited `wave: true` IS a mismatch against a computed 0 where Python's `1 == True` would have hidden it (wave-true); `jq -r` unquotes a string and pretty-prints everything else, so an id that is `[1, 2]` reaches bash's line-at-a-time loop as FOUR lines and yields four errors from one story (id-array), while an id containing a newline yields two well-formed ids from one story (id-newline) and an id that is the empty string is skipped entirely and not even counted (id-vazio). Two whole-file behaviours were preserved rather than tidied away. An EMPTY tasks file makes jq read zero values, and the three verbs that piped their output through `echo` therefore print a BLANK LINE and refuse (doc-vazio-deps and doc-vazio-stories at exit 1), while validate-ids answers `{valid: true, count: 0}` and validate-waves prints nothing at all, both at exit 0. And a file holding TWO concatenated documents runs each verb twice: validate-deps then exits 1 even when both documents are valid, because its status came from comparing two lines of `.valid` against the one word `true` (dois-documentos-validos-deps), while validate-stories' `jq -e` reported on the LAST document alone and validate-ids pooled both documents' ids into a single verdict.",
+  "_comment_tasks_validate": "The four validator verbs -- validate-deps, validate-stories, validate-ids and validate-waves -- captured exactly the way the three blocks before them were, and before their jq was deleted: 328 cases, 82 adversarial documents run through all four verbs, at commit 8d5477e. Recorded per case: the argv, the tasks file the run was given and the .aimi/state/ files it started with (`input`, so the case is REPLAYABLE and not merely described), exit code, stdout, stderr, and every .aimi/ file left behind afterwards (`state_after`). All 328 `state_after` values are empty, and that is this block's own evidence rather than a formality: these four are pure readers, so they take no lock, write no temp file and leave the document untouched -- a port that started writing one would have nowhere to hide. Each case ran in its own throwaway project root; exactly one normalization rule fired, the temp root to /TMP, and nothing else in the recording is non-deterministic. 1234 of 1312 field comparisons identical after the port, and 289 of the 328 cases matched on all four fields -- every stdout and every state_after matched in all 328. The 78 fields that differ fall in 39 cases, are exit code and stderr ONLY, and are all of one kind: jq aborting mid-expression, so the exit status was the engine's (5 for a runtime error, 4 for a parse error) and the message the code would otherwise have printed did not exist. Every one of them was, and still is, a refusal that writes nothing to stdout; only the wording and the number moved, to `Error: <verb>: <file>: <expression>: <what went wrong>` at exit 1. Recorded rather than reproduced, same as the 37 in _comment_tasks_read: synthesizing an engine error would be the only way to match, and that is not a thing to write on purpose. VALIDATE_DIVERGENCES in test_tasks.py names all 39 individually, in the ten groups the engine's own messages fall into: a userStories that is absent, null or a string (12), an acceptanceCriteria that is absent or null (2), a dependsOn that is a number (2), a document that is an array (4), malformed JSON at jq's own exit 4 (4), a story that is a string (3), a `has` against a string (2), a `test` against a non-string (4), an id used as an OBJECT KEY (4) and a `has` against a non-string key (2). The object-key group is validate-waves' alone and is worth naming: it builds `{(.id): ...}` before anything else runs, so an absent, numeric or array id kills that verb where the other three answer -- id-ausente-ids records the answer validate-ids gives the same document, `Invalid story ID: null`. THE CORPUS IS ADVERSARIAL BY CONSTRUCTION, not by claim: every one of the four verbs has at least one PASS and at least one distinct failure of every error class it can emit. validate-deps: a dangling reference (dep-pendurada), a self-reference (auto-referencia, which is necessarily also a cycle) and a cycle that is not one (ciclo, ciclo-longo). validate-stories: all twenty-four of its strings, one document each -- the three length caps, the two suspicious-content screens plus the tasks[] one, all four project rules, all five skills rules, all six tasks rules, the plural-gates field, `gate` missing each of type, status and prompt in turn and all three at once, a bare-string verification, and a story with no status. validate-ids: the accepted US-NNNa suffix (id-sufixo) beside five rejected forms (id-malformado), plus the four shapes that are not strings at all. validate-waves: a stale wave (wave-lacuna), an absent one (wave-ausente), a null one, a string one, a boolean one and a float one that is NOT a mismatch because jq and Python agree that 1.0 == 1. THREE CONTRACT DETAILS ARE PINNED HERE BECAUSE EACH LOOKS LIKE A DEFECT AND EACH WOULD BE A REGRESSION TO 'CORRECT'. (1) validate-ids' regex is `^US-[0-9]{3}[a-z]?$` and its message says `(expected US-NNN)`: the regex is the contract -- task-format-v3.md documents the suffix with US-012a as its example -- and the message describes the common case. US-001a is ACCEPTED (id-sufixo) and the wording is what /aimi:plan matches on, so neither may move to agree with the other. (2) validate-ids' output shape is ASYMMETRIC: the pass branch is `{valid, count}` with no `errors` key, the failure branch `{valid, errors}` with no `count`. A uniform `{valid, errors}` would pass a naive shape test and break the caller that reads them apart. (3) validate-waves NEVER returns non-zero: its bash body ended at the jq call with no `return 1`, unlike all three of its siblings, so an invalid verdict still exits 0 and the verdict lives in `.valid`. wave-lacuna-waves records `{valid: false}` at exit 0. And one message that reads like a typo and is not ours to correct: the plural-gates error says `gates` and `gate` with NO quotes around either, because the jq program sat inside a bash SINGLE-quoted string and the quotes the author typed closed and reopened it. gates-plural records the string bash actually assembled, which is the string the caller sees. FIVE CLASSES NO VALIDATOR FLAGS are recorded as the passes they are, so a later 'improvement' that starts flagging one shows up as a golden diff rather than as a silent contract change: a duplicated story id passes ALL FOUR (id-duplicado -- validate-ids checks format alone and validate-deps checks references alone); a story inside a cycle is never assigned a computed wave, so validate-waves reports nothing about it (wave-ciclo); a dangling dependsOn does the same to its own story (dep-pendurada-waves); an explicitly empty `skills: []` is legal (skills-vazio); and a dependsOn holding an ARRAY is legal too, because jq's `index` searches for a contiguous SUBSEQUENCE when the needle is an array and finds `[\"US-001\"]` inside `[\"US-001\", \"US-002\"]` (deps-array-elemento). WHERE A NAIVE PYTHON WOULD HAVE DIVERGED, each with the recorded case that catches it: `unique` inside validate-deps' cycle reduce sorts a dependsOn holding null, a number and a string, which jq orders and Python's sorted() raises TypeError on (deps-heterogeneo, the one place in these four that needs roadmap.py's jq_sort_key); `==` says a boolean is not a number, so a hand-edited `wave: true` IS a mismatch against a computed 0 where Python's `1 == True` would have hidden it (wave-true); `jq -r` unquotes a string and pretty-prints everything else, so an id that is `[1, 2]` reaches bash's line-at-a-time loop as FOUR lines and yields four errors from one story (id-array), while an id containing a newline yields two well-formed ids from one story (id-newline) and an id that is the empty string is skipped entirely and not even counted (id-vazio). Two whole-file behaviours were preserved rather than tidied away. An EMPTY tasks file makes jq read zero values, and the three verbs that piped their output through `echo` therefore print a BLANK LINE and refuse (doc-vazio-deps and doc-vazio-stories at exit 1), while validate-ids answers `{valid: true, count: 0}` and validate-waves prints nothing at all, both at exit 0. And a file holding TWO concatenated documents runs each verb twice: validate-deps then exits 1 even when both documents are valid, because its status came from comparing two lines of `.valid` against the one word `true` (dois-documentos-validos-deps), while validate-stories' `jq -e` reported on the LAST document alone and validate-ids pooled both documents' ids into a single verdict. THE WAVE CONVENTION CHANGED, AND 63 OF THIS BLOCK'S RECORDINGS MOVED WITH IT -- deliberately, in the commit that changed it, which is the one carve-out CLAUDE.md allows for this file: \"When a rule genuinely changes, the golden file changes in the same commit, with the reason in the message.\" Everything ABOVE this sentence describes the capture as it was taken and is left exactly as it was written; this paragraph is the amendment, not a rewrite of it. THE RULE: computed_waves used to seed a story with no dependencies at wave 0; it now seeds it at wave 1, so every assigned story's computed wave is exactly one higher than the number recorded at capture time. tasks.py was the OUTLIER and four components already said 1-based: story_merge.py's compute_waves (the writer -- \"Roots are wave 1\"), commands/plan.md's schema (\"roots=1, others = max(dep waves)+1\", and \"wave 1 for roots\") and commands/execute.md's display, which starts at `wave = 1` and prints \"--- Wave [wave] ---\". Because the writer was 1-based and the validator was 0-based, validate-waves reported a mismatch on EVERY story of EVERY tasks file story-merge produced. THE OFF-BY-ONE WAS INHERITED, NOT INTRODUCED BY THE PORT, which is the only reason this file may move at all: both sides are faithful ports of jq implementations that already disagreed with each other, so the 0-based answers recorded here were the JQ's answers and the port reproduced them correctly. Correcting them is a rule change, not a port repair. WHAT MOVED, MEASURED: of the 82 validate-waves cases, 63 changed, 6 came back byte-identical (vazio, auto-referencia, ciclo, ciclo-longo, wave-ciclo, doc-vazio -- every one of them a document in which no story is ever assigned a wave, or has none to compare) and 13 are the engine-abort recordings VALIDATE_DIVERGENCES already excuses, which never depended on the convention and were NOT re-recorded. Only `stdout` moved: all 82 keep their recorded `input` byte for byte, their `exit`, their `stderr` and their empty `state_after`. Each of the 63 was re-recorded by replaying its OWN stored input through the CLI -- the file was never regenerated from tasks.py, and no other block in it was touched. THREE READINGS ABOVE ARE NOW ONE HIGHER, and are left in place rather than edited so this stays an append: the `wave: true` note says a boolean \"IS a mismatch against a computed 0\" (wave-true-waves now records computed=1 -- the point it makes, that jq's `==` keeps a boolean and a number in different types, is untouched); wave-lacuna-waves and wave-ausente-waves now report computed=1 where the prose says the mismatch was against 0; and wave-um-em-vez-de-zero-waves -- the case named for storing 1 where the old convention wanted 0 -- is now a PASS, and limpo-waves, whose fixture stores the 0-based 0/1/2, is now the mismatch. That inversion is the clearest single statement in the diff that the convention, and not the walk, is what changed. WHAT DID NOT CHANGE: validate-waves still ALWAYS exits 0, verdict and all (contract detail (3) above still holds, and wave-lacuna-waves still records exit 0 alongside its `{valid: false}`); the n-pass reduce is untouched, so a story inside a cycle is still assigned no wave at all (wave-ciclo-waves is one of the 6 identical cases) and a dangling dependsOn still hides its OWN story's wave errors (dep-pendurada-waves moved only because its other story, a root storing the 0-based 0, is now reported -- US-001, the one with the dangling reference, is still absent from the list); and the mismatch predicate is unchanged, so an unreached story is still skipped entirely and a stored wave that is absent, null or false still reads as stored=null.",
   "validate_tasks_cases": [
     {
       "label": "limpo",

--- a/plugins/aimi-engineering/scripts/tests/test_tasks.py
+++ b/plugins/aimi-engineering/scripts/tests/test_tasks.py
@@ -862,9 +862,18 @@ def test_the_validate_corpus_exercises_every_error_class_each_verb_can_emit():
         "Invalid story ID: " + bad + " (expected US-NNN)"
         for bad in ("us-002", "US-3", "US-0001", "US-001A", "US-001 ")
     ]
-    # 3. validate-waves: a stale wave, and an absent one
-    assert _errors("wave-lacuna-waves") == ["Wave mismatch: US-002 stored=5 computed=1"]
-    assert _errors("wave-ausente-waves") == ["Wave mismatch: US-002 stored=null computed=1"]
+    # 3. validate-waves: a stale wave, and an absent one. Both fixtures store the
+    #    OLD 0-based waves throughout, so under the 1-based convention their root
+    #    is reported as well -- the SECOND line of each is the class this bucket
+    #    is for, and the first is the convention correction showing its work.
+    assert _errors("wave-lacuna-waves") == [
+        "Wave mismatch: US-001 stored=0 computed=1",
+        "Wave mismatch: US-002 stored=5 computed=2",
+    ]
+    assert _errors("wave-ausente-waves") == [
+        "Wave mismatch: US-001 stored=0 computed=1",
+        "Wave mismatch: US-002 stored=null computed=2",
+    ]
     # 4. a story missing a required field
     assert _errors("sem-status-stories") == [
         "US-001: missing required field: status — run normalize-status to fix"
@@ -919,10 +928,17 @@ def test_the_validate_corpus_exercises_every_error_class_each_verb_can_emit():
     assert _errors("tasks-elemento-nao-string-stories") == [
         "US-001: tasks[] element must be a string"
     ] * 2
-    # 11. and a PASS for each of the four, so none of them is merely a refuser
-    for verb in ("deps", "stories", "ids", "waves"):
+    # 11. and a PASS for each of the four, so none of them is merely a refuser.
+    #     `limpo` stores the OLD 0-based 0/1/2, so it is the three siblings that
+    #     still pass it; validate-waves' pass is now the case the capture named
+    #     for the disagreement itself -- wave-um-em-vez-de-zero stores 1 on a
+    #     root, which is exactly what the writer produces.
+    for verb in ("deps", "stories", "ids"):
         assert _verdict("limpo-" + verb)["valid"] is True
         assert VALIDATE["limpo-" + verb]["exit"] == 0
+    assert _verdict("wave-um-em-vez-de-zero-waves") == {"valid": True, "errors": []}
+    assert VALIDATE["wave-um-em-vez-de-zero-waves"]["exit"] == 0
+    assert _verdict("limpo-waves")["valid"] is False, "0/1/2 is the old convention"
 
 
 def _story(project=None, verify=None):
@@ -990,24 +1006,215 @@ def test_a_duplicated_story_id_is_flagged_by_none_of_the_four():
     opinion either. Pinning the pass means a later change that starts flagging
     it shows up as a golden diff rather than as a silent contract change.
     """
-    for verb in ("deps", "stories", "ids", "waves"):
+    for verb in ("deps", "stories", "ids"):
         assert _verdict("id-duplicado-" + verb)["valid"] is True, verb
         assert VALIDATE["id-duplicado-" + verb]["exit"] == 0, verb
     assert _verdict("id-duplicado-ids")["count"] == 2, "both copies are counted"
+    # validate-waves has no opinion on the duplication either. Its fixture stores
+    # the old 0-based wave, so what it reports is the SAME wave mismatch twice,
+    # once per copy -- not a word about the id being repeated, which is the
+    # property this test is about.
+    assert _errors("id-duplicado-waves") == ["Wave mismatch: US-001 stored=0 computed=1"] * 2
+    assert VALIDATE["id-duplicado-waves"]["exit"] == 0
 
 
 def test_a_cycle_and_a_dangling_id_hide_their_story_from_validate_waves():
     """Two more recorded passes that read like misses and are the contract.
 
     A story the wave walk never places has a computed wave of null, and both
-    arms of the select require a non-null one -- so a cyclic file and a file
-    with a dangling dependsOn are both `{valid: true}` here. Reporting them is
+    arms of the select require a non-null one -- so neither the cyclic story nor
+    the one with the dangling dependsOn is ever reported here. Reporting them is
     validate-deps' job, and it does.
+
+    The property is per-STORY, and the 1-based correction is what made that
+    visible: wave-ciclo places NO story, so its whole document still passes,
+    while dep-pendurada holds a second story -- a root storing the old 0-based
+    0 -- which is now reported. US-001, the one with the dangling reference, is
+    still absent from the list, and that absence is the assertion.
     """
     assert _verdict("wave-ciclo-waves") == {"valid": True, "errors": []}
-    assert _verdict("dep-pendurada-waves") == {"valid": True, "errors": []}
+    assert _errors("dep-pendurada-waves") == ["Wave mismatch: US-002 stored=0 computed=1"]
+    assert not any("US-001" in error for error in _errors("dep-pendurada-waves"))
     assert _verdict("wave-ciclo-deps")["valid"] is False
     assert _verdict("dep-pendurada-deps")["valid"] is False
+
+
+# ---------------------------------------------------------------------------
+# The wave convention itself: 1-based, and the same 1-based as the writer's
+# ---------------------------------------------------------------------------
+#
+# The recordings above pin the MESSAGES. These pin the RULE, against documents
+# written here rather than replayed, because the corpus was captured while the
+# validator still seeded roots at 0 and no recording in it can state what the
+# convention ought to be. They discriminate, and that is checked rather than
+# claimed: with the seed flipped back to 0 in a throwaway copy of scripts/, ALL
+# SIX of them fail. None of them passes by accident.
+
+
+def _waves_doc(stories):
+    return json.dumps(
+        {
+            "schemaVersion": "3.3",
+            "metadata": {
+                "title": "ref: waves",
+                "type": "ref",
+                "branchName": "ref/waves",
+                "createdAt": "2020-01-01",
+                "planPath": None,
+            },
+            "userStories": stories,
+        },
+        indent=2,
+    ) + "\n"
+
+
+def _wave_story(story_id, depends_on, wave="omit"):
+    story = {
+        "id": story_id,
+        "title": "Story " + story_id,
+        "description": "As a user, I want " + story_id + ".",
+        "acceptanceCriteria": ["Typecheck passes"],
+        "status": "pending",
+        "priority": 1,
+        "dependsOn": depends_on,
+    }
+    if wave != "omit":
+        story["wave"] = wave
+    return story
+
+
+def _run_validate_waves(tmp_path, stories):
+    """One live validate-waves over a document written for the occasion."""
+    root = os.path.realpath(str(tmp_path))
+    tasks_dir = os.path.join(root, ".aimi", "tasks")
+    os.makedirs(tasks_dir, exist_ok=True)
+    with open(os.path.join(tasks_dir, "2020-01-01-waves-tasks.json"), "w", encoding="utf-8") as fh:
+        fh.write(_waves_doc(stories))
+    proc = subprocess.run(
+        ["bash", CLI, "validate-waves"], cwd=root, capture_output=True, text=True, timeout=120
+    )
+    return proc, json.loads(proc.stdout)
+
+
+def test_computed_waves_numbers_roots_from_one_and_climbs_from_there():
+    """The rule this story corrected, stated three ways.
+
+    A story with no dependencies is wave 1, never 0; everyone else is one above
+    the max of its dependencies. tasks.py used to seed roots at 0 while
+    story_merge.py -- the WRITER -- seeded them at 1, so validate-waves reported
+    a mismatch on every story of every file the writer produced.
+    """
+    roots_only = [_wave_story("US-00" + str(n), []) for n in (1, 2, 3)]
+    assert T.computed_waves(roots_only) == {"US-001": 1, "US-002": 1, "US-003": 1}
+
+    chain = [
+        _wave_story("US-001", []),
+        _wave_story("US-002", ["US-001"]),
+        _wave_story("US-003", ["US-002"]),
+    ]
+    assert T.computed_waves(chain) == {"US-001": 1, "US-002": 2, "US-003": 3}
+
+    diamond = [
+        _wave_story("US-001", []),
+        _wave_story("US-002", ["US-001"]),
+        _wave_story("US-003", ["US-001"]),
+        _wave_story("US-004", ["US-002", "US-003"]),
+    ]
+    assert T.computed_waves(diamond) == {
+        "US-001": 1, "US-002": 2, "US-003": 2, "US-004": 3
+    }
+
+
+def test_the_validator_and_the_writer_now_number_the_same_document_alike():
+    """The defect was a disagreement between two components, so this is the
+    assertion that closes it: story_merge.compute_waves WRITES the field and
+    tasks.py's computed_waves CHECKS it, and they must agree on every shape --
+    a root, a chain, a diamond and a fan-out at once."""
+    import story_merge as SM
+
+    shapes = [
+        ("US-001", []), ("US-002", ["US-001"]), ("US-003", ["US-001"]),
+        ("US-004", ["US-002", "US-003"]), ("US-005", []), ("US-006", ["US-004"]),
+    ]
+    written = [{"id": sid, "dependsOn": deps} for sid, deps in shapes]
+    SM.compute_waves(written)
+    assert T.computed_waves([_wave_story(sid, deps) for sid, deps in shapes]) == {
+        story["id"]: story["wave"] for story in written
+    }
+
+
+def test_a_story_the_walk_never_reaches_is_still_skipped_entirely(tmp_path):
+    """The predicate's shape, unchanged by the reseeding.
+
+    Neither story in a cycle is ever assigned, so neither can be reported; the
+    story with the dangling dependsOn is not assigned either, while the root
+    beside it is. What survives the correction is that an UNREACHED story
+    contributes nothing at all -- not a `stored=X computed=null` line.
+    """
+    cycle = [_wave_story("US-001", ["US-002"]), _wave_story("US-002", ["US-001"])]
+    assert T.computed_waves(cycle) == {}
+    proc, verdict = _run_validate_waves(tmp_path, cycle)
+    assert verdict == {"valid": True, "errors": []} and proc.returncode == 0
+
+    dangling = [_wave_story("US-001", ["US-999"], 7), _wave_story("US-002", [], 1)]
+    assert T.computed_waves(dangling) == {"US-002": 1}
+    _, verdict = _run_validate_waves(tmp_path, dangling)
+    assert verdict == {"valid": True, "errors": []}, "US-001's stored 7 is not reported"
+
+
+def test_a_document_with_no_wave_field_at_all_is_reported_against_its_computed_one(tmp_path):
+    """An absent stored wave still reads as null and is still a mismatch.
+
+    This is the other half of the predicate the correction had to leave alone:
+    the story is skipped only when the WALK never reached it, never because the
+    document happens to carry no wave.
+    """
+    stories = [_wave_story("US-001", []), _wave_story("US-002", ["US-001"])]
+    assert all("wave" not in story for story in stories)
+    proc, verdict = _run_validate_waves(tmp_path, stories)
+    assert verdict == {
+        "valid": False,
+        "errors": [
+            "Wave mismatch: US-001 stored=null computed=1",
+            "Wave mismatch: US-002 stored=null computed=2",
+        ],
+    }
+    assert proc.returncode == 0
+
+
+def test_validate_waves_still_exits_zero_on_a_live_invalid_verdict(tmp_path):
+    """Pinned against a document written now, not only against the recordings.
+
+    op_validate_waves has no `return 1` and must not grow one: the verdict lives
+    in `.valid` and a caller branching on `$?` sees a pass today. A document
+    carrying the OLD 0-based waves is the sharpest fixture for it, because it is
+    exactly what this change made invalid.
+    """
+    old_convention = [_wave_story("US-001", [], 0), _wave_story("US-002", ["US-001"], 1)]
+    proc, verdict = _run_validate_waves(tmp_path, old_convention)
+    assert verdict["valid"] is False and verdict["errors"], "0/1 is the old convention"
+    assert proc.returncode == 0, "an invalid verdict still exits 0"
+    assert proc.stderr == ""
+
+    writer_convention = [_wave_story("US-001", [], 1), _wave_story("US-002", ["US-001"], 2)]
+    proc, verdict = _run_validate_waves(tmp_path, writer_convention)
+    assert verdict == {"valid": True, "errors": []} and proc.returncode == 0
+
+
+def test_a_boolean_wave_is_a_mismatch_against_a_computed_one(tmp_path):
+    """What wave-true-waves used to prove and cannot any more.
+
+    Its US-002 now computes 2, and Python's own `2 == True` is False, so the
+    recording stopped discriminating. Against a ROOT the computed wave is 1 and
+    Python's `1 == True` is True -- so only jq's type-aware `==` reports this,
+    and this is the fixture that catches a jq_equal replaced by `==`.
+    """
+    assert (1 == True) is True, "the trap this test exists for"
+    _, verdict = _run_validate_waves(tmp_path, [_wave_story("US-001", [], True)])
+    assert verdict == {
+        "valid": False,
+        "errors": ["Wave mismatch: US-001 stored=true computed=1"],
+    }
 
 
 def test_the_places_a_naive_python_would_have_diverged_from_jq():
@@ -1021,11 +1228,20 @@ def test_the_places_a_naive_python_would_have_diverged_from_jq():
         "Missing ID: US-002 depends on null which does not exist",
         "Missing ID: US-002 depends on 3 which does not exist",
     ]
-    # `==` puts a boolean and a number in different types, so `wave: true` IS a
+    # `==` puts a boolean and a number in different types, so `wave: true` is a
     # mismatch against a computed 1 where Python's `1 == True` would hide it.
+    # THE RECORDING NO LONGER PROVES THAT ON ITS OWN: US-002 computes 2 under the
+    # 1-based convention and Python's own `2 == True` is False too, so the case
+    # stopped discriminating when the convention moved. It still pins the
+    # message; test_a_boolean_wave_is_a_mismatch_against_a_computed_one below is
+    # what pins the rule against a live root, and the two unit assertions here
+    # pin jq_equal itself.
     assert (1 == True) is True and T.jq_equal(1, True) is False
     assert T.jq_equal(1, 1.0) is True and T.jq_equal([1], [True]) is False
-    assert _errors("wave-true-waves") == ["Wave mismatch: US-002 stored=true computed=1"]
+    assert _errors("wave-true-waves") == [
+        "Wave mismatch: US-001 stored=0 computed=1",
+        "Wave mismatch: US-002 stored=true computed=2",
+    ]
     # `index` searches for a contiguous SUBSEQUENCE when the needle is an array,
     # so a dependsOn holding ["US-001"] resolves rather than dangling.
     assert T.jq_index_in(["US-001", "US-002"], ["US-001"]) == 0


### PR DESCRIPTION
Closes #129.

`validate-waves` computed waves from 0 while `story-merge` writes them from 1, so
the verb reported a mismatch on **every story of every tasks file** for its entire
existence. The tasks file behind the previous release reported eight mismatches,
`US-001 stored=1 computed=0` through `US-008 stored=2 computed=1` — every one off by
exactly one. All three tasks files in this repo now validate clean.

**If a file the verb used to call invalid now passes, nothing changed in your data** —
the verb was previously wrong about every file it was handed, correct ones included.

## Why the validator is the side that changed

Not a coin flip between two conventions. Four components already stated 1-based,
against `tasks.py` alone:

- `story_merge.py`'s `compute_waves` — the component that *writes* the field
- `commands/plan.md`'s schema — "computed from dependsOn: roots=1, others=max(dep waves)+1", plus two checklist lines repeating "wave 1 for roots"
- `commands/execute.md` — starts its displayed numbering at 1 and prints `--- Wave [n] ---`

Every `tasks.json` already on disk is 1-based. Correcting the *writer* instead would
have invalidated all of them and left the stored field disagreeing with the number on
screen.

The change is **one seed value**: `current[story_id] = 0` becoming `= 1`. The n-pass
reduce, the increment and the mismatch predicate are untouched, so a story inside a
dependency cycle is still assigned no wave at all and a dangling `dependsOn` still
hides its own story's wave errors — reporting those remains `validate-deps`' job.
`validate-waves` still always exits 0; the verdict lives in `.valid`, and a test still
pins that exit status against a wave-mismatch fixture.

## Why it went unnoticed for the field's whole life

The failure was reported into a channel nothing branches on. Nothing but the validator
itself reads the stored `wave` field — `story-merge` writes it, `plan.md` documents it,
`execute.md` counts its own loop rather than reading it — so a wrong value corrupted no
behavior anywhere. And the verb exits 0 on an invalid verdict by design, so anything
checking `$?` saw success on every run.

## The frozen corpus moved, and why that is legitimate here

`tests/golden_from_jq.json` was captured from the jq implementations before they were
deleted and is the evidence the Python port changed nothing. It is frozen except for
the one carve-out `CLAUDE.md` names — a genuine rule change, recorded in the same commit
with the reason in the message.

This is that case: **the disagreement predates the port.** Both sides are faithful ports
of jq implementations that already disagreed with each other, so the 0-based answers
recorded there were the jq's own, reproduced correctly.

| | |
|---|---|
| blocks that moved | `tasks_validate_cases` and its own comment — **only** |
| `validate-waves` cases | 82 recorded: **63 re-recorded**, 6 byte-identical, 13 engine-abort recordings already excused by name |
| fields that moved | **`stdout` only** — `input`, `exit`, `stderr` and `state_after` byte-identical across all 82 |
| method | each of the 63 replayed through its own stored input; never regenerated from the Python |
| the block's comment | reason appended, existing text kept as a byte-for-byte prefix |

## Verification

| suite | result |
|---|---|
| `pytest scripts/tests` | 2912 passed, 155 skipped (baseline 2906 — the +6 are new convention tests) |
| `pytest hooks/tests` | 297 passed |
| `test-aimi-cli.sh` | 4889 assertions, invariant satisfied; `EXPECTED_ASSERTIONS` unmoved at 4891 |
| `test-worktree-manager.sh` | 59 passed |
| `test-command-blocks.sh` | 41 passed |
| `test-tasks-concurrency.sh` | 18 passed |

The new tests discriminate rather than merely pass: reverting the seed to 0-based makes
**67** wave tests fail — the six new convention cases and the 63 re-recorded replays.

One fixture outside the story's declared file list was also corrected:
`test-aimi-cli-part1-core.sh`'s `_setup_gate_fixture` stored 0-based waves, so
`validate-waves: correct waves pass` would have failed against the new convention. It
moves to 1-based with no assertion added or removed — which is why the assertion total
did not move.